### PR TITLE
ci: fix crates.io trusted publishing (use crates-io-auth-action)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,16 @@ jobs:
             echo "$pkg $VERSION verified"
           done
 
-      - name: Exchange OIDC token for crates.io token
-        run: |
-          RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=crates-io")
-          TOKEN=$(echo "$RESPONSE" | jq -r '.token')
-          echo "CARGO_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Authenticate to crates.io via trusted publishing
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: cargo publish (dependency order)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           # ruststream-macros is a proc-macro crate and a dependency of ruststream,
           # so it must be on crates.io first. cargo waits for the index before returning.


### PR DESCRIPTION
The release failed with `401 Unauthorized: The given API token does not match the format used by crates.io`.

The hand-rolled OIDC step read `.token` from GitHub's OIDC endpoint, but that endpoint returns the JWT in `.value` and it still has to be exchanged with crates.io's trusted-publishing token endpoint. So `CARGO_REGISTRY_TOKEN` was empty/garbage.

This switches to the official `rust-lang/crates-io-auth-action`, which does the OIDC-to-crates.io exchange and outputs a valid temporary token used for both publishes.