### PR TITLE
ci: make crates.io publish idempotent (skip already-published versions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,22 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
-          # ruststream-macros is a proc-macro crate and a dependency of ruststream,
-          # so it must be on crates.io first. cargo waits for the index before returning.
-          cargo publish -p ruststream-macros
-          cargo publish -p ruststream --all-features
+          # Publish a crate only if its current version is not already on crates.io,
+          # so re-running a release after a partial failure is safe. ruststream-macros
+          # is a proc-macro crate and a dependency of ruststream, so it goes first.
+          publish() {
+            name="$1"; shift
+            version=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r --arg n "$name" '.packages[] | select(.name == $n) | .version')
+            index="https://index.crates.io/${name:0:2}/${name:2:2}/${name}"
+            if curl -fsSL "$index" 2>/dev/null | grep -qF "\"vers\":\"${version}\""; then
+              echo "$name $version already on crates.io, skipping"
+            else
+              cargo publish -p "$name" "$@"
+            fi
+          }
+          publish ruststream-macros
+          publish ruststream --all-features
 
       - name: Generate release notes
         if: github.event_name == 'release'


### PR DESCRIPTION
After a partial release failure, `ruststream-macros 0.2.1` was published but `ruststream 0.2.1` was not. Re-running the release would fail on the macros step because that version already exists.

The publish step now checks the sparse index for each crate's current version and skips it if already present, so releases are safely re-runnable. Verified locally: macros 0.2.1 is detected as published (skipped), ruststream 0.2.1 is not (would publish).