### PR TITLE
docs: credit FastStream as inspiration in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,5 @@ just test     # the test suite
 ## License
 
 Licensed under the [Apache-2.0](./LICENSE) license.
+
+<sub>Inspired by [FastStream](https://github.com/airtai/faststream).</sub>


### PR DESCRIPTION
Add an unobtrusive line at the bottom of the README crediting FastStream as the inspiration.