### PR TITLE
Lazy-broker lifecycle contract + conformance (0.2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +594,15 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys",
 ]
 
@@ -693,6 +720,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -747,6 +791,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -891,6 +936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1050,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1107,6 +1170,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1132,6 +1225,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,13 @@ required-features = ["macros", "memory", "asyncapi"]
 name = "metrics_http"
 required-features = ["macros", "memory", "metrics"]
 
+[[example]]
+name = "logging"
+required-features = ["macros", "memory", "json", "logging"]
+
 [package]
 name = "ruststream"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -50,6 +54,7 @@ cbor = ["dep:ciborium"]
 macros = ["dep:ruststream-macros"]
 asyncapi = ["json", "dep:schemars", "dep:serde_norway"]
 metrics = ["dep:prometheus"]
+logging = ["dep:tracing-subscriber"]
 cli = ["dep:clap", "dep:anyhow"]
 
 [dependencies]
@@ -63,6 +68,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
 ruststream-macros = { version = "0.2.1", path = "crates/ruststream-macros", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }
 ciborium = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ the framework.
 - **Zero-boilerplate binaries.** `#[ruststream::app]` generates `main`; the `ruststream` CLI
   scaffolds projects, runs them, and generates the AsyncAPI document.
 - **AsyncAPI 3.0 and Prometheus metrics,** served from your own HTTP stack.
+- **Colored console logging** behind the `logging` feature; the generated CLI installs it on `run`,
+  with verbosity driven by `RUST_LOG`.
 - **Capability traits** for optional features (batch subscribe, transactions, request-reply,
   partitioning); a broker implements only what it supports.
 

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -32,12 +32,65 @@ Core NATS subjects and JetStream durable consumers.
 ```toml
 ruststream = { version = "0.2", features = ["macros"] }
 ruststream-nats = "0.2"
+serde = { version = "1", features = ["derive"] }
 ```
 
-```rust
-use ruststream_nats::NatsBroker;
+`NatsBroker::new` is synchronous and does no I/O, so a NATS service is assembled with the same
+`#[ruststream::app]` macro as any other broker. The runtime connects the broker once at startup,
+before opening subscriptions.
 
-let broker = NatsBroker::new("nats://localhost:4222");
+### Core subscription
+
+A `#[subscriber("subject")]` handler binds straight to a NATS subject:
+
+```rust
+use ruststream::codec::JsonCodec;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use ruststream_nats::NatsBroker;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders.created")]
+async fn handle(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+```
+
+Wire it onto the broker; the `with_broker` / `include` part is identical to the in-memory broker.
+
+```rust
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(NatsBroker::new("nats://localhost:4222"), |b| {
+            b.include(handle, JsonCodec)
+        })
+}
+```
+
+### JetStream durable consumer
+
+To consume from JetStream instead, override the handler's by-name source with `SubscribeOptions`,
+naming the stream and a durable consumer so progress survives restarts. The handler's
+`HandlerResult::Ack` acks back to JetStream.
+
+```rust
+use ruststream_nats::SubscribeOptions;
+
+// inside with_broker(broker, |b| { ... }):
+b.include_on(
+    SubscribeOptions::new("orders.*")
+        .jetstream("ORDERS")
+        .durable("orders-worker"),
+    handle,
+    JsonCodec,
+);
 ```
 
 See the crate's documentation for connection options, authentication, and JetStream configuration.
@@ -46,7 +99,8 @@ For how a NATS broker implements the contract from the inside, read the
 
 ## Switching brokers
 
-The same service runs on either broker; only the construction differs.
+The same handlers and routers run on either broker, and both build synchronously, so only the
+broker construction differs by one line inside `with_broker`.
 
 === "Memory"
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,33 @@
+//! Colored console logging with zero boilerplate.
+//!
+//! ```text
+//! RUST_LOG=ruststream=debug,info cargo run --example logging \
+//!     --features macros,memory,json,logging -- run
+//! ```
+//!
+//! The `#[ruststream::app]` CLI installs the logger automatically on `run`, so the events RustStream
+//! emits during dispatch (and the one below) show up with colored levels. Set `RUST_LOG` to tune
+//! verbosity; without it the default `info` filter applies.
+
+use ruststream::codec::JsonCodec;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders")]
+async fn handle(order: &Order) -> HandlerResult {
+    tracing::info!(order.id, "processing order");
+    HandlerResult::Ack
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle, JsonCodec))
+}

--- a/src/bin/ruststream/templates/memory/Cargo.toml.in
+++ b/src/bin/ruststream/templates/memory/Cargo.toml.in
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "memory", "json", "asyncapi"] }
+ruststream = { version = "0.2", features = ["macros", "memory", "json", "asyncapi", "logging"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -14,6 +14,18 @@ use std::{error::Error as StdError, future::Future};
 ///
 /// `Send + Sync` is required so the router can share the broker handle across tasks.
 ///
+/// # Lazy startup contract
+///
+/// Implementations MUST be constructible **synchronously**, without performing I/O: expose a plain
+/// `new(..)` constructor that only captures configuration (addresses, credentials). All network
+/// setup happens in [`connect`], which the runtime calls once at startup, after the synchronous
+/// `#[ruststream::app]` builder has run. This is what lets a service be assembled with the app
+/// macro regardless of broker. A broker that can only be built by connecting (an `async` "connect
+/// and return the handle" constructor) does not satisfy this contract. Each broker also ships a
+/// [`SubscriptionSource`](crate::SubscriptionSource) for its subjects, resolved after `connect`.
+/// [`conformance::harness::lifecycle`](crate::conformance::harness::lifecycle) checks the whole
+/// path: synchronous construction, `connect`, subscribe through the source, deliver, ack, shutdown.
+///
 /// # Examples
 ///
 /// ```

--- a/src/conformance/harness.rs
+++ b/src/conformance/harness.rs
@@ -21,7 +21,8 @@
 use std::{future::Future, time::Duration};
 
 use crate::{
-    Headers, IncomingMessage, OutgoingMessage, Publisher, Subscriber, testing::TestClient,
+    Broker, Headers, IncomingMessage, OutgoingMessage, Publisher, Subscriber, SubscriptionSource,
+    testing::TestClient,
 };
 use bytes::Bytes;
 use futures::StreamExt;
@@ -53,6 +54,88 @@ where
     nack_without_requeue_drops(fresh().await).await;
     headers_propagate(fresh().await).await;
     expect_published_observes_publishes(fresh().await).await;
+}
+
+/// Verifies a broker honours the lazy-startup contract end to end.
+///
+/// The steps are: synchronous construction (no I/O in the constructor), then `connect`, a
+/// subscription opened through the broker's own [`SubscriptionSource`], a publish the subscription
+/// receives and acks, and finally `shutdown`.
+///
+/// The three factories keep the check broker-agnostic:
+/// * `make_broker` is **synchronous** (`Fn() -> B`). A broker that can only be built asynchronously
+///   cannot satisfy it, which is exactly the contract: construct cheaply, connect lazily in
+///   [`Broker::connect`].
+/// * `make_source` builds the broker's subscription descriptor for a subject (the macro-subscriber
+///   path).
+/// * `make_publisher` produces a publisher from the connected broker.
+///
+/// Run it from the broker crate, against a real server where one is needed (NATS, Kafka, ...) or
+/// in-process for the in-memory broker.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() {
+/// use ruststream::{conformance::harness, memory::{MemoryBroker, MemorySource}};
+///
+/// harness::lifecycle(
+///     || MemoryBroker::new(),
+///     |name| MemorySource::new(name),
+///     |broker| broker.publisher(),
+/// )
+/// .await;
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics with a descriptive message if construction, connection, subscription, delivery, ack, or
+/// shutdown does not behave as the contract requires.
+pub async fn lifecycle<B, MkBroker, Src, MkSrc, Pub, MkPub>(
+    make_broker: MkBroker,
+    make_source: MkSrc,
+    make_publisher: MkPub,
+) where
+    B: Broker,
+    MkBroker: Fn() -> B,
+    Src: SubscriptionSource<B> + Send,
+    Src::Subscriber: Send,
+    MkSrc: Fn(&str) -> Src,
+    Pub: Publisher,
+    MkPub: Fn(&B) -> Pub,
+{
+    const SUBJECT: &str = "conformance.lifecycle";
+
+    let broker = make_broker();
+    Broker::connect(&broker)
+        .await
+        .expect("broker must connect after synchronous construction");
+
+    let mut subscriber = make_source(SUBJECT)
+        .subscribe(&broker)
+        .await
+        .expect("subscription source must open after connect");
+    let publisher = make_publisher(&broker);
+
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"lifecycle".as_slice()))
+        .await
+        .expect("publish after connect failed");
+
+    let mut stream = std::pin::pin!(subscriber.stream());
+    let msg = expect_next(&mut stream, "lifecycle").await;
+    assert_eq!(
+        msg.payload(),
+        b"lifecycle",
+        "subscription opened through SubscriptionSource must receive the publish",
+    );
+    msg.ack().await.expect("ack failed");
+
+    Broker::shutdown(&broker)
+        .await
+        .expect("broker must shut down cleanly");
 }
 
 async fn ordering<T: TestClient>(client: T) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //!   [`#[derive(Message)]`](macro@Message) macros.
 //! * `asyncapi`: `AsyncAPI` document generation and the HTML viewer.
 //! * `metrics`: Prometheus metrics middleware and exporter.
+//! * `logging`: colored, `RUST_LOG`-driven console logging via `tracing-subscriber`
+//!   ([`logging::init`]). The generated `cli` `run` command installs it automatically.
 //! * `conformance`: the [`conformance::harness`] contract suite and broker-agnostic
 //!   [`conformance::helpers`] for application tests. Generic over any broker's `TestClient`, so it
 //!   pulls in no concrete broker (enable `memory` too to run it against [`memory::MemoryBroker`]).
@@ -95,6 +97,9 @@ pub use schemars;
 
 #[cfg(feature = "metrics")]
 pub mod metrics;
+
+#[cfg(feature = "logging")]
+pub mod logging;
 
 /// Implementation detail used by the `#[subscriber]` macro to capture a payload's JSON Schema.
 ///

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,310 @@
+//! Colorful, environment-driven console logging built on [`tracing-subscriber`].
+//!
+//! RustStream emits structured [`tracing`] events throughout dispatch, publishing and the service
+//! lifecycle, but - like any well-behaved library - installs no subscriber on its own. That choice
+//! belongs to the application. This module is the batteries-included answer: one call wires up a
+//! human-friendly, colored formatter whose verbosity is read from the `RUST_LOG` environment
+//! variable, so `RUST_LOG=debug cargo run -- run` just works.
+//!
+//! Output goes to **stderr** (keeping stdout clean for machine-readable command output such as
+//! `asyncapi gen`), and ANSI colors are enabled automatically when stderr is a terminal.
+//!
+//! The generated [`#[ruststream::app]`](macro@crate::app) CLI calls [`init`] for you on the `run`
+//! command when the `logging` feature is enabled; reach for [`Logging`] directly only when you want
+//! to override the defaults.
+//!
+//! Available with the `logging` feature.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! ruststream::logging::init()?;
+//! tracing::info!("service starting");
+//! # Ok::<(), ruststream::logging::LoggingInitError>(())
+//! ```
+//!
+//! Tuning the defaults through the builder:
+//!
+//! ```no_run
+//! use ruststream::logging::Logging;
+//!
+//! Logging::new()
+//!     .with_default_filter("ruststream=debug,info")
+//!     .with_target(false)
+//!     .try_init()?;
+//! # Ok::<(), ruststream::logging::LoggingInitError>(())
+//! ```
+
+use std::fmt;
+use std::io::IsTerminal as _;
+
+use thiserror::Error;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::{Directive, ParseError};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::{FormatTime as _, SystemTime};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// Errors returned while installing the logger.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LoggingInitError {
+    /// The default filter directive could not be parsed.
+    #[error("invalid log filter directive: {0}")]
+    Filter(#[from] ParseError),
+    /// A global [`tracing`] subscriber was already installed by this or another crate.
+    #[error("a tracing subscriber is already installed")]
+    AlreadyInitialized(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+/// Builder for RustStream's colored console logger.
+///
+/// The defaults match [`init`]: filter `info` (overridable per-target via `RUST_LOG`), colors auto-
+/// detected from the terminal, and event targets shown. Every setter returns `self`, so calls
+/// chain into a final [`try_init`](Self::try_init).
+///
+/// # Examples
+///
+/// ```no_run
+/// use ruststream::logging::Logging;
+///
+/// Logging::new().with_ansi(true).try_init()?;
+/// # Ok::<(), ruststream::logging::LoggingInitError>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct Logging {
+    default_filter: String,
+    ansi: Option<bool>,
+    target: bool,
+}
+
+impl Default for Logging {
+    fn default() -> Self {
+        Self {
+            default_filter: "info".to_owned(),
+            ansi: None,
+            target: true,
+        }
+    }
+}
+
+impl Logging {
+    /// Creates a logger configuration with the default settings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the fallback filter used when `RUST_LOG` is unset or empty.
+    ///
+    /// Accepts the [`tracing_subscriber` directive syntax](EnvFilter), e.g. `"info"`,
+    /// `"warn,ruststream=debug"`. Parsing is deferred to [`try_init`](Self::try_init), so an invalid
+    /// directive surfaces there as [`LoggingInitError::Filter`].
+    #[must_use]
+    pub fn with_default_filter(mut self, filter: impl Into<String>) -> Self {
+        self.default_filter = filter.into();
+        self
+    }
+
+    /// Forces ANSI colors on or off.
+    ///
+    /// By default colors are enabled only when stderr is a terminal; set this to override that
+    /// detection (e.g. force colors when piping into a pager that understands them).
+    #[must_use]
+    pub const fn with_ansi(mut self, ansi: bool) -> Self {
+        self.ansi = Some(ansi);
+        self
+    }
+
+    /// Controls whether each event's target (its module path) is printed. Defaults to `true`.
+    #[must_use]
+    pub const fn with_target(mut self, target: bool) -> Self {
+        self.target = target;
+        self
+    }
+
+    /// Installs the configured logger as the global [`tracing`] subscriber.
+    ///
+    /// Reads the filter from `RUST_LOG`, falling back to the configured default filter. Logs are
+    /// written to stderr with colored levels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoggingInitError::Filter`] if the default filter directive is invalid, or
+    /// [`LoggingInitError::AlreadyInitialized`] if a global subscriber is already in place (this
+    /// function never replaces an existing one).
+    pub fn try_init(self) -> Result<(), LoggingInitError> {
+        let directive: Directive = self.default_filter.parse()?;
+        let filter = EnvFilter::builder()
+            .with_default_directive(directive)
+            .with_env_var("RUST_LOG")
+            .from_env_lossy();
+        let ansi = self.ansi.unwrap_or_else(|| std::io::stderr().is_terminal());
+
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .event_format(ColorFormatter {
+                ansi,
+                target: self.target,
+            })
+            .finish()
+            .try_init()
+            .map_err(|err| LoggingInitError::AlreadyInitialized(err.into()))
+    }
+}
+
+/// Installs the default colored console logger.
+///
+/// Convenience for [`Logging::new().try_init()`](Logging::try_init): filter `info` (overridable via
+/// `RUST_LOG`), terminal-detected colors, targets shown. Call this once, early in `main`.
+///
+/// # Errors
+///
+/// See [`Logging::try_init`].
+///
+/// # Examples
+///
+/// ```no_run
+/// ruststream::logging::init()?;
+/// tracing::warn!(retries = 3, "broker reconnecting");
+/// # Ok::<(), ruststream::logging::LoggingInitError>(())
+/// ```
+pub fn init() -> Result<(), LoggingInitError> {
+    Logging::new().try_init()
+}
+
+/// A compact, colorful event formatter: dim timestamp, a bold colored level badge, a dim cyan
+/// target, and the message (tinted for warnings and errors so they stand out). Hand-rolled ANSI
+/// keeps the dependency surface to `tracing-subscriber` alone.
+#[derive(Debug, Clone, Copy)]
+struct ColorFormatter {
+    ansi: bool,
+    target: bool,
+}
+
+impl ColorFormatter {
+    fn paint(self, w: &mut Writer<'_>, codes: &str, text: &str) -> fmt::Result {
+        if self.ansi {
+            write!(w, "\x1b[{codes}m{text}\x1b[0m")
+        } else {
+            write!(w, "{text}")
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for ColorFormatter
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let meta = event.metadata();
+        let level = *meta.level();
+
+        if self.ansi {
+            write!(writer, "\x1b[2m")?;
+            SystemTime.format_time(&mut writer)?;
+            write!(writer, "\x1b[0m ")?;
+        } else {
+            SystemTime.format_time(&mut writer)?;
+            write!(writer, " ")?;
+        }
+
+        let color = level_color(level);
+        self.paint(
+            &mut writer,
+            &format!("1;{color}"),
+            &format!("{:>5}", meta.level()),
+        )?;
+        write!(writer, " ")?;
+
+        if self.target {
+            self.paint(&mut writer, "2;36", meta.target())?;
+            write!(writer, " ")?;
+        }
+
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+
+        if matches!(level, Level::WARN | Level::ERROR) {
+            self.paint(&mut writer, color, visitor.message.trim_end())?;
+        } else {
+            write!(writer, "{}", visitor.message.trim_end())?;
+        }
+        if !visitor.fields.is_empty() {
+            self.paint(&mut writer, "2", &visitor.fields)?;
+        }
+        writeln!(writer)
+    }
+}
+
+const fn level_color(level: Level) -> &'static str {
+    match level {
+        Level::ERROR => "31",
+        Level::WARN => "33",
+        Level::INFO => "32",
+        Level::DEBUG => "34",
+        Level::TRACE => "35",
+    }
+}
+
+/// Splits an event's fields into the `message` (rendered first) and the remaining `key=value`
+/// pairs (rendered dimmed after it).
+#[derive(Debug, Default)]
+struct EventVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for EventVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        use std::fmt::Write as _;
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={value:?}", field.name());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Logging;
+
+    #[test]
+    fn defaults_are_info_auto_color_with_targets() {
+        let cfg = Logging::new();
+        assert_eq!(cfg.default_filter, "info");
+        assert!(cfg.ansi.is_none());
+        assert!(cfg.target);
+    }
+
+    #[test]
+    fn setters_override_defaults() {
+        let cfg = Logging::new()
+            .with_default_filter("ruststream=debug,warn")
+            .with_ansi(false)
+            .with_target(false);
+        assert_eq!(cfg.default_filter, "ruststream=debug,warn");
+        assert_eq!(cfg.ansi, Some(false));
+        assert!(!cfg.target);
+    }
+
+    #[test]
+    fn invalid_default_filter_is_rejected_at_init() {
+        let err = Logging::new()
+            .with_default_filter("=:not a directive:=")
+            .try_init();
+        assert!(err.is_err());
+    }
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -19,7 +19,7 @@ use std::{
 
 use crate::{
     AckError, Broker, Headers, IncomingMessage, OutgoingMessage, Publisher, RawMessage, Subscribe,
-    Subscriber, testing::TestClient,
+    Subscriber, SubscriptionSource, testing::TestClient,
 };
 use bytes::Bytes;
 use futures::Stream;
@@ -142,6 +142,38 @@ impl Subscribe for MemoryBroker {
 
     async fn subscribe(&self, name: &str) -> Result<Self::Subscriber, Self::Error> {
         Ok(MemoryBroker::subscribe(self, name))
+    }
+}
+
+/// A subscription descriptor for [`MemoryBroker`], naming the subject to receive on.
+///
+/// The broker-owned counterpart to the generic [`Name`](crate::Name) source: it carries no extra
+/// configuration (the in-memory broker has none), but giving every broker its own
+/// [`SubscriptionSource`] keeps the macro-subscriber and lazy-startup paths uniform across brokers.
+/// Pass it to the descriptor form of the macro, `#[subscriber(MemorySource::new("orders"))]`, the
+/// way a NATS service passes `SubscribeOptions`.
+#[derive(Debug, Clone)]
+pub struct MemorySource {
+    name: String,
+}
+
+impl MemorySource {
+    /// Creates a source bound to `name`.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl SubscriptionSource<MemoryBroker> for MemorySource {
+    type Subscriber = MemorySubscriber;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn subscribe(self, broker: &MemoryBroker) -> Result<Self::Subscriber, Infallible> {
+        Ok(broker.subscribe(self.name))
     }
 }
 

--- a/src/runtime/app.rs
+++ b/src/runtime/app.rs
@@ -12,7 +12,7 @@ use std::{
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -489,8 +489,10 @@ impl<L> RustStream<L> {
         F: Future<Output = ()> + Send,
     {
         let Self {
+            info,
             brokers,
             starters,
+            handlers,
             mut state,
             on_startup,
             after_startup,
@@ -500,6 +502,18 @@ impl<L> RustStream<L> {
             ..
         } = self;
 
+        info!(
+            target: "ruststream::lifecycle",
+            service = %info.title,
+            version = %info.version,
+            brokers = brokers.len(),
+            subscribers = starters.len(),
+            "starting service",
+        );
+
+        if !on_startup.is_empty() {
+            debug!(target: "ruststream::lifecycle", count = on_startup.len(), "running on_startup hooks");
+        }
         for hook in on_startup {
             state = hook(state).await.map_err(RustStreamError::Startup)?;
         }
@@ -507,24 +521,37 @@ impl<L> RustStream<L> {
 
         for broker in &brokers {
             broker.connect().await.map_err(RustStreamError::Connect)?;
+            info!(target: "ruststream::lifecycle", broker = broker.name(), "broker connected");
         }
 
         let token = CancellationToken::new();
         let mut handles = Vec::with_capacity(starters.len());
-        for starter in starters {
+        for (starter, meta) in starters.into_iter().zip(handlers) {
             let handle = starter(state.clone(), token.clone())
                 .await
                 .map_err(RustStreamError::Subscribe)?;
+            info!(
+                target: "ruststream::dispatch",
+                subscriber = %meta.name,
+                input = meta.input_type,
+                "subscriber started",
+            );
             handles.push(handle);
         }
 
+        if !after_startup.is_empty() {
+            debug!(target: "ruststream::lifecycle", count = after_startup.len(), "running after_startup hooks");
+        }
         for hook in after_startup {
             hook(Arc::clone(&state))
                 .await
                 .map_err(RustStreamError::Startup)?;
         }
 
+        info!(target: "ruststream::lifecycle", subscribers = handles.len(), "service running");
+
         shutdown.await;
+        info!(target: "ruststream::lifecycle", "shutdown signal received");
 
         for hook in on_shutdown {
             if let Err(err) = hook(Arc::clone(&state)).await {
@@ -533,10 +560,12 @@ impl<L> RustStream<L> {
         }
 
         token.cancel();
+        debug!(target: "ruststream::lifecycle", "draining in-flight handlers");
         drain_handles(handles, shutdown_timeout).await?;
 
         for broker in brokers.iter().rev() {
             broker.shutdown().await.map_err(RustStreamError::Shutdown)?;
+            debug!(target: "ruststream::lifecycle", broker = broker.name(), "broker shut down");
         }
 
         for hook in after_shutdown {
@@ -544,6 +573,7 @@ impl<L> RustStream<L> {
                 warn!(target: "ruststream::lifecycle", error = %err, "after_shutdown hook failed");
             }
         }
+        info!(target: "ruststream::lifecycle", "service stopped");
         Ok(())
     }
 }

--- a/src/runtime/cli.rs
+++ b/src/runtime/cli.rs
@@ -5,7 +5,9 @@
 //! binary which understands two commands:
 //!
 //! - `run` (the default) builds a multi-thread Tokio runtime and runs the service until an
-//!   interrupt, mirroring [`RustStream::run`].
+//!   interrupt, mirroring [`RustStream::run`]. With the `logging` feature enabled it first installs
+//!   the colored console logger ([`crate::logging`]), so a scaffolded service prints logs without
+//!   any setup; an app that installs its own subscriber keeps it.
 //! - `asyncapi gen [-o <file>] [--yaml]` builds the [`AsyncAPI`](crate::asyncapi) document for the
 //!   service and writes it to stdout or a file. Requires the crate to enable the `asyncapi` feature.
 //!
@@ -116,6 +118,11 @@ where
     let args: Vec<String> = std::env::args().skip(1).collect();
     match parse(&args)? {
         Command::Run => {
+            // Install the colored console logger so a freshly scaffolded service prints logs out
+            // of the box. Ignore the error: it only fails if the app already installed its own
+            // subscriber, which we must not replace.
+            #[cfg(feature = "logging")]
+            let _ = crate::logging::init();
             let app = build();
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::{IncomingMessage, Subscriber};
 
@@ -77,7 +77,14 @@ where
                             "subscriber stream error",
                         );
                     }
-                    None => break,
+                    None => {
+                        debug!(
+                            target: "ruststream::dispatch",
+                            subscriber = %name,
+                            "subscriber stream ended",
+                        );
+                        break;
+                    }
                 }
             }
         }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -5,7 +5,7 @@
 //! never on the message hot path, so the boxing cost is negligible. Subscribers and publishers
 //! stay fully typed elsewhere.
 
-use std::{error::Error as StdError, future::Future, pin::Pin};
+use std::{any::type_name, error::Error as StdError, future::Future, pin::Pin};
 
 use crate::Broker;
 
@@ -16,9 +16,15 @@ pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub(crate) trait BrokerLifecycle: Send + Sync {
     fn connect(&self) -> BoxFuture<'_, Result<(), BoxError>>;
     fn shutdown(&self) -> BoxFuture<'_, Result<(), BoxError>>;
+    /// The concrete broker type's name, for diagnostics and logging.
+    fn name(&self) -> &'static str;
 }
 
 impl<B: Broker> BrokerLifecycle for B {
+    fn name(&self) -> &'static str {
+        type_name::<B>()
+    }
+
     fn connect(&self) -> BoxFuture<'_, Result<(), BoxError>> {
         Box::pin(async move {
             Broker::connect(self)

--- a/tests/conformance_self.rs
+++ b/tests/conformance_self.rs
@@ -5,9 +5,26 @@
 
 use std::convert::Infallible;
 
-use ruststream::{conformance::harness, memory::MemoryBroker};
+use ruststream::{
+    conformance::harness,
+    memory::{MemoryBroker, MemorySource},
+};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn memory_broker_passes_conformance_suite() {
     harness::run_suite(|| async { Ok::<_, Infallible>(MemoryBroker::new()) }).await;
+}
+
+// `make_source` / `make_publisher` must stay closures: their bounds are higher-ranked
+// (`Fn(&str) -> _` / `Fn(&B) -> _`), so a bare method path - which binds one concrete lifetime -
+// would not type-check.
+#[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_lifecycle() {
+    harness::lifecycle(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
 }


### PR DESCRIPTION
## What

Makes **"construct synchronously, connect lazily"** the broker contract, so any broker works with the synchronous `#[ruststream::app]` builder, not just the in-memory one. The runtime already calls `Broker::connect()` once at startup (`src/runtime/app.rs`); this codifies that brokers must be buildable without I/O and connect there.

## Changes

- **broker**: document the lazy-startup contract on the `Broker` trait (sync `new`, async `connect` does the I/O, each broker ships its own `SubscriptionSource`). `connect`/`shutdown` stay async, signatures unchanged.
- **conformance**: add `harness::lifecycle`, exercising the full path `new -> connect -> subscribe via SubscriptionSource -> publish/ack -> shutdown`. Broker-agnostic via three factories; the synchronous `Fn() -> B` factory is the type-level proof of lazy construction.
- **memory**: add `MemorySource` (`SubscriptionSource<MemoryBroker>`), the broker-owned descriptor alongside the generic `Name` source. `Subscribe`/`Name` (string-literal `#[subscriber("x")]`) unchanged.
- **tests**: cover the lifecycle path against `MemoryBroker`.
- **docs**: NATS section uses `NatsBroker::new` + `#[ruststream::app]`.
- Also lands the in-progress **`logging`** feature (colored RUST_LOG console logging, installed by the CLI `run`).
- Bump **0.2.1 -> 0.2.2** (additive).

## Checks

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo check --no-default-features` all green.

## Follow-ups

- Publishing `ruststream 0.2.2` to crates.io is left to the maintainer (GitHub Release -> trusted publishing).
- After 0.2.2 is live, `ruststream-nats` gets a sync `NatsBroker::new()` (lazy connect) to satisfy `harness::lifecycle` and bumps to 0.2.1 (separate PR).
- NATS examples were temporarily removed from this repo (they depend on the unreleased `ruststream-nats 0.2.1`); they can be restored afterwards.