### PR TITLE
ci: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a problem with RustStream
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please fill in the sections below so the problem can be
+        reproduced and fixed.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal steps or a self-contained code snippet that triggers the issue.
+      render: rust
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: RustStream version
+      description: The `ruststream` version, plus any broker crate and its version.
+      placeholder: "ruststream 0.2.3, ruststream-nats 0.2.1"
+    validations:
+      required: true
+  - type: input
+    id: rustc
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version`.
+      placeholder: "1.85.0"
+    validations:
+      required: true
+  - type: input
+    id: features
+    attributes:
+      label: Enabled cargo features
+      placeholder: "macros, json, memory"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / backtrace
+      description: Relevant logs, the panic message, or a backtrace (`RUST_BACKTRACE=1`).
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://powersemmi.github.io/ruststream/
+    about: Guides and API reference - check here before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an idea or enhancement for RustStream
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what is missing or awkward today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you would like to happen. API sketches are welcome.
+      render: rust
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have thought about and why they fall short.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps explain the request (use cases, related brokers, links).
+    validations:
+      required: false


### PR DESCRIPTION
Adds GitHub issue forms under `.github/ISSUE_TEMPLATE/`, complementing the pull request template:

- **Bug report** (`bug_report.yml`) - structured fields: what happened, reproduction (Rust code), RustStream version + broker, `rustc` version, enabled features, logs/backtrace.
- **Feature request** (`feature_request.yml`) - problem, proposed solution, alternatives, context.
- **config.yml** - disables blank issues and links to the docs site (Discussions is not enabled on this repo, so no discussions link).

YAML validated locally; GitHub renders these as issue forms.