### PR TITLE
docs: add Cursor rules for agents

### DIFF
--- a/.cursor/rules/broker-authors.mdc
+++ b/.cursor/rules/broker-authors.mdc
@@ -1,0 +1,33 @@
+---
+description: How to author a new RustStream broker crate (the Broker contract, capabilities, conformance)
+globs:
+alwaysApply: false
+---
+
+- A broker is its own crate that depends on `ruststream` (broker clients never go into core).
+  Implement `Broker`: associated `Error`, async `connect`, async `shutdown`.
+- Follow the lazy-startup contract so the broker works with the synchronous `#[ruststream::app]`
+  builder: a synchronous, I/O-free `new(addrs)` constructor that only records configuration; all
+  network work happens in `connect`, which must be idempotent and is called once at startup before
+  any subscription opens.
+- Hold the live connection behind interior mutability (e.g. `Arc<tokio::sync::OnceCell<Client>>`) so a
+  publisher handed out at build time (before `connect`) resolves the connection on first use.
+  Operations that need the connection before `connect` return a `NotConnected`-style error.
+- Implement `Subscribe` (subscribe by name) so the string-literal `#[subscriber("topic")]` form works.
+  Ship a `SubscriptionSource<YourBroker>` descriptor type for broker-specific options (consumer
+  groups, durable names, delivery policy); the macro's descriptor form mounts it via `include_on`.
+- Implement capability traits only for what the broker natively supports: `RequestReply`,
+  `BatchSubscriber`, `TransactionalPublisher`, `Partitioned`, `DescribeServer`. Do not fold optional
+  behaviour into the required interface.
+- `ack` consumes `self` (double-ack is a compile error). For transports without acknowledgement,
+  return `AckError::Unsupported` from `ack`/`nack`.
+- Verify against `ruststream::conformance::harness`:
+  - `run_suite` - the Core routing contract, driven through your `TestClient`.
+  - `lifecycle` - sync `new` -> `connect` -> subscribe via `SubscriptionSource` -> publish -> receive
+    -> ack (or `AckError::Unsupported`) -> `shutdown`. Run it against a real server in an env-gated
+    integration test (e.g. `NATS_TEST_URL`), not just in-process.
+- Ship a `TestClient` under a `testing` feature: handler-stub, Core routing only. Do not simulate
+  broker-specific semantics (durable cursors, consumer-group offsets, exchanges/DLX, redelivery
+  timers) - those are tested only against a real server.
+- Version the broker crate independently and depend on `ruststream` by a semver range. Run the
+  conformance suite against the real broker before releasing.

--- a/.cursor/rules/broker-authors.mdc
+++ b/.cursor/rules/broker-authors.mdc
@@ -6,28 +6,134 @@ alwaysApply: false
 
 - A broker is its own crate that depends on `ruststream` (broker clients never go into core).
   Implement `Broker`: associated `Error`, async `connect`, async `shutdown`.
-- Follow the lazy-startup contract so the broker works with the synchronous `#[ruststream::app]`
-  builder: a synchronous, I/O-free `new(addrs)` constructor that only records configuration; all
-  network work happens in `connect`, which must be idempotent and is called once at startup before
-  any subscription opens.
-- Hold the live connection behind interior mutability (e.g. `Arc<tokio::sync::OnceCell<Client>>`) so a
-  publisher handed out at build time (before `connect`) resolves the connection on first use.
-  Operations that need the connection before `connect` return a `NotConnected`-style error.
-- Implement `Subscribe` (subscribe by name) so the string-literal `#[subscriber("topic")]` form works.
-  Ship a `SubscriptionSource<YourBroker>` descriptor type for broker-specific options (consumer
-  groups, durable names, delivery policy); the macro's descriptor form mounts it via `include_on`.
-- Implement capability traits only for what the broker natively supports: `RequestReply`,
-  `BatchSubscriber`, `TransactionalPublisher`, `Partitioned`, `DescribeServer`. Do not fold optional
-  behaviour into the required interface.
-- `ack` consumes `self` (double-ack is a compile error). For transports without acknowledgement,
-  return `AckError::Unsupported` from `ack`/`nack`.
-- Verify against `ruststream::conformance::harness`:
-  - `run_suite` - the Core routing contract, driven through your `TestClient`.
-  - `lifecycle` - sync `new` -> `connect` -> subscribe via `SubscriptionSource` -> publish -> receive
-    -> ack (or `AckError::Unsupported`) -> `shutdown`. Run it against a real server in an env-gated
-    integration test (e.g. `NATS_TEST_URL`), not just in-process.
-- Ship a `TestClient` under a `testing` feature: handler-stub, Core routing only. Do not simulate
-  broker-specific semantics (durable cursors, consumer-group offsets, exchanges/DLX, redelivery
-  timers) - those are tested only against a real server.
-- Version the broker crate independently and depend on `ruststream` by a semver range. Run the
-  conformance suite against the real broker before releasing.
+- Lazy-startup contract (so the broker works with `#[ruststream::app]`): a synchronous, I/O-free
+  `new(addrs)` that only records config; all network work happens in `connect`, which is idempotent
+  and runs once at startup. Keep the connection behind interior mutability so publishers handed out
+  before `connect` resolve on first use.
+- Implement `Subscribe` for the by-name `#[subscriber("topic")]` form, and ship a
+  `SubscriptionSource<YourBroker>` descriptor for broker-specific options. Implement capability traits
+  (`RequestReply`, `BatchSubscriber`, `TransactionalPublisher`, `Partitioned`, `DescribeServer`) only
+  for what the broker natively supports.
+- `ack` consumes `self`; for transports without acks return `AckError::Unsupported`.
+- Ship a `TestClient` (handler-stub, Core routing only) under a `testing` feature. Verify with the
+  conformance harness; run `lifecycle` against a real server (env-gated). No simulation of
+  broker-specific semantics (durable cursors, offsets, DLX) - those are tested only against a server.
+
+## Lazy broker
+
+`new` is synchronous; the connection is opened lazily in `Broker::connect`.
+
+```rust
+use std::sync::Arc;
+use ruststream::Broker;
+use tokio::sync::OnceCell;
+
+#[derive(Clone)]
+pub struct MyBroker {
+    client: Arc<OnceCell<Client>>,
+    addrs: Option<String>,
+}
+
+impl MyBroker {
+    /// Records the address; opens the connection later in `Broker::connect`.
+    #[must_use]
+    pub fn new(addrs: impl Into<String>) -> Self {
+        Self { client: Arc::new(OnceCell::new()), addrs: Some(addrs.into()) }
+    }
+
+    fn connected(&self) -> Result<Client, MyError> {
+        self.client.get().cloned().ok_or(MyError::NotConnected)
+    }
+}
+
+impl Broker for MyBroker {
+    type Error = MyError;
+
+    async fn connect(&self) -> Result<(), MyError> {
+        self.client
+            .get_or_try_init(|| async {
+                let addrs = self.addrs.as_deref().ok_or(MyError::NotConnected)?;
+                Client::connect(addrs).await.map_err(MyError::connect)
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> Result<(), MyError> {
+        if let Some(client) = self.client.get() {
+            client.drain().await;
+        }
+        Ok(())
+    }
+}
+```
+
+## Deferred publisher
+
+The publisher shares the broker's connection cell, so it works even when created before `connect`.
+
+```rust
+use ruststream::{OutgoingMessage, Publisher};
+
+#[derive(Clone)]
+pub struct MyPublisher {
+    client: Arc<OnceCell<Client>>,
+}
+
+impl Publisher for MyPublisher {
+    type Error = MyError;
+
+    async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), MyError> {
+        let client = self.client.get().ok_or(MyError::NotConnected)?;
+        client.send(msg.name(), msg.payload()).await.map_err(MyError::publish)
+    }
+}
+```
+
+## Subscription source
+
+The by-name `Subscribe` impl covers `#[subscriber("topic")]`; a descriptor carries richer options.
+
+```rust
+use ruststream::{Subscribe, SubscriptionSource};
+
+impl Subscribe for MyBroker {
+    type Subscriber = MySubscriber;
+    async fn subscribe(&self, name: &str) -> Result<MySubscriber, MyError> {
+        self.open(MySubscribeOptions::new(name)).await
+    }
+}
+
+impl SubscriptionSource<MyBroker> for MySubscribeOptions {
+    type Subscriber = MySubscriber;
+    fn name(&self) -> &str {
+        &self.subject
+    }
+    async fn subscribe(self, broker: &MyBroker) -> Result<MySubscriber, MyError> {
+        broker.open(self).await
+    }
+}
+```
+
+## Conformance
+
+Run both, the lifecycle against a real server behind an env gate.
+
+```rust
+use ruststream::conformance::harness;
+
+// routing, via your TestClient (testing feature)
+harness::run_suite(|| async { MyTestClient::start().await }).await;
+
+// full lazy lifecycle against a real broker
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lazy_lifecycle_conformance() {
+    let Ok(url) = std::env::var("MY_BROKER_TEST_URL") else { return };
+    harness::lifecycle(
+        || MyBroker::new(url.clone()),
+        |name| MySubscribeOptions::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+```

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -5,33 +5,106 @@ alwaysApply: false
 ---
 
 - Core is broker-agnostic: traits and message types with zero broker dependencies. Keep
-  broker-specific config and defaults out of core. If a field has no sane default, do not implement
-  `Default` - force the caller to be explicit.
-- Core is fully generic (associated types, native `async fn in trait`); no object-safety in core.
-  Type erasure for dynamic dispatch or language bindings lives in `runtime`, not core.
-- Default visibility is `pub(crate)`; make `pub` only what `lib.rs` re-exports. The crate root denies
-  `missing_docs`: every `pub` item needs a one-line summary plus a compiling `# Examples` doctest that
-  uses `?`, not `unwrap()`. Document `# Errors`, `# Panics`, `# Cancel safety` where they apply.
-- Library code uses `thiserror`; `anyhow` is banned in the library surface (bins/examples only).
-  Public error enums are `#[non_exhaustive]`, variants by source. Never panic on user/network/FFI
-  input - return `Result`. `panic!`/`unwrap` only on invariant violations.
-- Use native `async fn in trait` (RPITIT); add `+ Send` at the call site, not in the trait.
-  Destructors never panic or block - cleanup is an explicit `async shutdown() -> Result`.
-- Features are strictly additive and never mutually exclusive; optional deps are named like their
-  feature (`json = ["dep:serde_json"]`). Gate code that needs a default codec with
-  `#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]`.
-- The only sanctioned "mock" is the in-memory broker (`memory`) plus the conformance harness - no
-  `mockall`. Spawning tests use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`; never
-  `sleep` to synchronize - use notify primitives or `tokio::time::pause()`. `proptest`, not
-  `quickcheck`, for codec/routing properties.
-- When a contract-level change touches the broker lifecycle, verify against a real broker (sibling
-  `ruststream-nats` with `NATS_TEST_URL`) before committing or releasing - an in-process pass is not
-  enough.
-- Gates: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
-  `cargo test --all-features`, `cargo check --no-default-features` (or `just check` + `just test`).
-  Narrow `#[allow(...)]` only for genuine false positives, with a one-line reason.
-- SemVer pre-1.0: minor bump = breaking, patch = additive (MSRV 1.85, edition 2024). `ruststream` and
-  `ruststream-macros` move in lockstep via `[workspace.package].version`.
-- English only in files; no emoji; no em-dashes (use hyphens). Comments explain "why", not "what".
-  Files under ~500 lines. One logical unit per commit; no `Co-Authored-By` trailer. Do not publish,
-  tag, or release - prepare branches/PRs; the maintainer releases via GitHub Release.
+  broker-specific config and defaults out of core; if a field has no sane default, do not implement
+  `Default`. Core is fully generic (no object-safety); erasure lives in `runtime`.
+- Default visibility `pub(crate)`; make `pub` only what `lib.rs` re-exports. The crate root denies
+  `missing_docs`: every `pub` item gets a summary plus a compiling `# Examples` doctest using `?`.
+- Library code uses `thiserror` (`anyhow` is bins/examples only); public error enums are
+  `#[non_exhaustive]`. Never panic on user/network input - return `Result`.
+- Native `async fn in trait`; `+ Send` at the call site, not the trait. Destructors never panic or
+  block. Features are strictly additive, never mutually exclusive.
+- Gates: `just check` (`cargo fmt --check`, `clippy --all-targets --all-features -- -D warnings`,
+  `cargo check` all-features and `--no-default-features`) + `just test`. SemVer pre-1.0: minor =
+  breaking, patch = additive; `ruststream` and `ruststream-macros` versions are lockstep via
+  `[workspace.package].version`.
+- English only, no emoji, no em-dashes. One logical unit per commit; no `Co-Authored-By`. Do not
+  publish/tag/release - prepare branches/PRs; the maintainer releases.
+
+## Error type
+
+One `#[non_exhaustive]` enum per crate, variants by source, with `thiserror`.
+
+```rust
+use std::error::Error as StdError;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PublishError {
+    /// The broker rejected the publish.
+    #[error("publish rejected: {0}")]
+    Rejected(#[source] Box<dyn StdError + Send + Sync>),
+}
+```
+
+## Trait with async methods
+
+Use RPITIT; keep `+ Send` on the returned future. Do not force object-safety in core.
+
+```rust
+use std::future::Future;
+
+pub trait Publisher: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Publishes `msg`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] when the broker rejects the message.
+    fn publish(
+        &self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+```
+
+## Public item with a doctest
+
+Every `pub` item carries a compiling example using `?`, not `unwrap()`.
+
+```rust
+/// Creates a name source bound to `name`.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::Name;
+/// let source = Name::new("orders");
+/// # let _ = source;
+/// ```
+#[must_use]
+pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
+    Self(name.into())
+}
+```
+
+## Feature-gated default-codec API
+
+The default-codec convenience methods only exist when a codec feature is on.
+
+```rust
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+pub fn include<D>(&mut self, def: D)
+where
+    D: SubscriberDef,
+    // ...
+{
+    self.mount(def, crate::codec::DefaultCodec::default());
+}
+```
+
+## Conformance self-test
+
+The reference `MemoryBroker` runs the harness in `tests/`.
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_lifecycle() {
+    harness::lifecycle(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+```

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -1,0 +1,37 @@
+---
+description: Conventions for developing the RustStream core crate (src/, crates/ruststream-macros)
+globs: src/**/*.rs,crates/**/*.rs,tests/**/*.rs
+alwaysApply: false
+---
+
+- Core is broker-agnostic: traits and message types with zero broker dependencies. Keep
+  broker-specific config and defaults out of core. If a field has no sane default, do not implement
+  `Default` - force the caller to be explicit.
+- Core is fully generic (associated types, native `async fn in trait`); no object-safety in core.
+  Type erasure for dynamic dispatch or language bindings lives in `runtime`, not core.
+- Default visibility is `pub(crate)`; make `pub` only what `lib.rs` re-exports. The crate root denies
+  `missing_docs`: every `pub` item needs a one-line summary plus a compiling `# Examples` doctest that
+  uses `?`, not `unwrap()`. Document `# Errors`, `# Panics`, `# Cancel safety` where they apply.
+- Library code uses `thiserror`; `anyhow` is banned in the library surface (bins/examples only).
+  Public error enums are `#[non_exhaustive]`, variants by source. Never panic on user/network/FFI
+  input - return `Result`. `panic!`/`unwrap` only on invariant violations.
+- Use native `async fn in trait` (RPITIT); add `+ Send` at the call site, not in the trait.
+  Destructors never panic or block - cleanup is an explicit `async shutdown() -> Result`.
+- Features are strictly additive and never mutually exclusive; optional deps are named like their
+  feature (`json = ["dep:serde_json"]`). Gate code that needs a default codec with
+  `#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]`.
+- The only sanctioned "mock" is the in-memory broker (`memory`) plus the conformance harness - no
+  `mockall`. Spawning tests use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`; never
+  `sleep` to synchronize - use notify primitives or `tokio::time::pause()`. `proptest`, not
+  `quickcheck`, for codec/routing properties.
+- When a contract-level change touches the broker lifecycle, verify against a real broker (sibling
+  `ruststream-nats` with `NATS_TEST_URL`) before committing or releasing - an in-process pass is not
+  enough.
+- Gates: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo test --all-features`, `cargo check --no-default-features` (or `just check` + `just test`).
+  Narrow `#[allow(...)]` only for genuine false positives, with a one-line reason.
+- SemVer pre-1.0: minor bump = breaking, patch = additive (MSRV 1.85, edition 2024). `ruststream` and
+  `ruststream-macros` move in lockstep via `[workspace.package].version`.
+- English only in files; no emoji; no em-dashes (use hyphens). Comments explain "why", not "what".
+  Files under ~500 lines. One logical unit per commit; no `Co-Authored-By` trailer. Do not publish,
+  tag, or release - prepare branches/PRs; the maintainer releases via GitHub Release.

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -27,7 +27,9 @@ One `#[non_exhaustive]` enum per crate, variants by source, with `thiserror`.
 ```rust
 use std::error::Error as StdError;
 
-#[derive(Debug, thiserror::Error)]
+use thiserror::Error;
+
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PublishError {
     /// The broker rejected the publish.

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -190,10 +190,12 @@ JSON Schema language (as in OpenAPI), independent of how bytes are encoded on th
 attach a codec to a type.
 
 ```rust
+use ruststream::Message;
+use ruststream::schemars::JsonSchema;
 use serde::Deserialize;
 
 /// An order placed on the orders channel.
-#[derive(Debug, Deserialize, ruststream::Message, ruststream::schemars::JsonSchema)]
+#[derive(Debug, Deserialize, Message, JsonSchema)]
 struct Order {
     id: u64,
 }

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -1,0 +1,32 @@
+---
+description: How to build a service with RustStream (handlers, app, brokers, codecs)
+globs: examples/**/*.rs
+alwaysApply: false
+---
+
+- A handler is an `async fn` annotated with `#[subscriber("subject")]`. Its first parameter is the
+  decoded payload by reference (`&T`, where `T: serde::Deserialize`). An optional second parameter is
+  `ctx: &mut ruststream::runtime::Context`.
+- The return type drives acknowledgement: `HandlerResult` (`HandlerResult::Ack`, or
+  `HandlerResult::Nack { requeue }`), `()` (always acks), or `Result<_, E>` (an `Err` nacks).
+- For a reply handler, return the reply value (`R: serde::Serialize`) and add a `publish("subject")`
+  clause: `#[subscriber("orders", publish("confirmations"))]`.
+- Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream`. It generates
+  `main` understanding `run` and `asyncapi gen`. Do not write your own `main` or `#[tokio::main]`.
+- Construct the broker synchronously and pass it to `with_broker`; the runtime connects it at startup.
+  Memory: `MemoryBroker::new()`. NATS: `NatsBroker::new("nats://localhost:4222")`. Never connect in
+  the builder.
+- Mount inside `with_broker(broker, |b| { ... })`: `b.include(handle)` for a plain handler;
+  `b.include_publishing(handle, TypedPublisher::new(b.broker().publisher()))` for a reply handler.
+- The codec defaults to `codec::DefaultCodec` (feature priority `json` > `cbor` > `msgpack`), so
+  `include` takes no codec argument. Override per scope with `with_broker_codec(broker, codec, |b|
+  ...)`, or per call on a `Router` with `router.with_codec(codec).include(def)`.
+- Use a `Router` to collect handlers in their own module, then `b.include_router(router)`. Bind a
+  broker-specific source (NATS JetStream, ...) with `b.include_on(source, handle, codec)`.
+- Message types derive `serde::Deserialize` (incoming) / `Serialize` (replies). Add
+  `#[derive(ruststream::Message)]` to name them in the generated AsyncAPI, and
+  `#[derive(ruststream::schemars::JsonSchema)]` (feature `asyncapi`) for payload schemas.
+- Log with `tracing` events, never `println!` in handlers. Enable the `logging` feature so the CLI
+  `run` installs a console subscriber.
+- In tests use `MemoryBroker` (feature `memory`) or a broker's `TestClient` (feature `testing`); do
+  not stand up a real server in unit tests.

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -5,28 +5,183 @@ alwaysApply: false
 ---
 
 - A handler is an `async fn` annotated with `#[subscriber("subject")]`. Its first parameter is the
-  decoded payload by reference (`&T`, where `T: serde::Deserialize`). An optional second parameter is
+  decoded payload by reference (`&T`, where `T: serde::Deserialize`); an optional second parameter is
   `ctx: &mut ruststream::runtime::Context`.
-- The return type drives acknowledgement: `HandlerResult` (`HandlerResult::Ack`, or
-  `HandlerResult::Nack { requeue }`), `()` (always acks), or `Result<_, E>` (an `Err` nacks).
-- For a reply handler, return the reply value (`R: serde::Serialize`) and add a `publish("subject")`
-  clause: `#[subscriber("orders", publish("confirmations"))]`.
-- Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream`. It generates
-  `main` understanding `run` and `asyncapi gen`. Do not write your own `main` or `#[tokio::main]`.
-- Construct the broker synchronously and pass it to `with_broker`; the runtime connects it at startup.
-  Memory: `MemoryBroker::new()`. NATS: `NatsBroker::new("nats://localhost:4222")`. Never connect in
-  the builder.
-- Mount inside `with_broker(broker, |b| { ... })`: `b.include(handle)` for a plain handler;
-  `b.include_publishing(handle, TypedPublisher::new(b.broker().publisher()))` for a reply handler.
-- The codec defaults to `codec::DefaultCodec` (feature priority `json` > `cbor` > `msgpack`), so
-  `include` takes no codec argument. Override per scope with `with_broker_codec(broker, codec, |b|
-  ...)`, or per call on a `Router` with `router.with_codec(codec).include(def)`.
-- Use a `Router` to collect handlers in their own module, then `b.include_router(router)`. Bind a
-  broker-specific source (NATS JetStream, ...) with `b.include_on(source, handle, codec)`.
-- Message types derive `serde::Deserialize` (incoming) / `Serialize` (replies). Add
-  `#[derive(ruststream::Message)]` to name them in the generated AsyncAPI, and
-  `#[derive(ruststream::schemars::JsonSchema)]` (feature `asyncapi`) for payload schemas.
-- Log with `tracing` events, never `println!` in handlers. Enable the `logging` feature so the CLI
-  `run` installs a console subscriber.
-- In tests use `MemoryBroker` (feature `memory`) or a broker's `TestClient` (feature `testing`); do
-  not stand up a real server in unit tests.
+- The return type drives acknowledgement: `HandlerResult`, `()` (always acks), or `Result<_, E>` (an
+  `Err` nacks). For a reply handler, return the reply value and add a `publish("subject")` clause.
+- Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream`. Do not write
+  your own `main` or `#[tokio::main]`.
+- Construct brokers synchronously (`MemoryBroker::new()`, `NatsBroker::new(url)`); the runtime
+  connects them at startup. Never connect inside the builder.
+- The codec defaults to `codec::DefaultCodec` (`json` > `cbor` > `msgpack`), so `include` needs no
+  codec argument. Log with `tracing`, never `println!`. In tests use `MemoryBroker` or a `TestClient`.
+
+## Subscriber and app
+
+The macro turns `handle` into a value named after the function; mount it with `include`.
+
+```rust
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders.created")]
+async fn handle(order: &Order) -> HandlerResult {
+    tracing::info!(order.id, "processing order");
+    HandlerResult::Ack
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include(handle);
+        })
+}
+```
+
+Swap the broker without touching the handlers (NATS connects lazily at startup):
+
+```rust
+use ruststream_nats::NatsBroker;
+
+.with_broker(NatsBroker::new("nats://localhost:4222"), |b| b.include(handle))
+```
+
+## Handler results
+
+```rust
+// explicit ack / nack
+HandlerResult::Ack
+HandlerResult::Nack { requeue: true }
+
+// `()` always acks; `Result<(), E>` acks on Ok, nacks on Err
+async fn handle(order: &Order) -> Result<(), MyError> { Ok(()) }
+```
+
+## Replying (request/response)
+
+Return the reply value and add `publish("subject")`; hand `include_publishing` a `TypedPublisher`.
+
+```rust
+use ruststream::runtime::TypedPublisher;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Confirmation {
+    id: u64,
+    accepted: bool,
+}
+
+#[subscriber("orders", publish("confirmations"))]
+async fn confirm(order: &Order) -> Confirmation {
+    Confirmation { id: order.id, accepted: true }
+}
+
+// inside with_broker(broker, |b| { ... }):
+let replies = TypedPublisher::new(b.broker().publisher()); // default codec
+b.include_publishing(confirm, replies);
+```
+
+## Choosing a codec
+
+`include` uses `DefaultCodec`. Name one per scope, or per call on a `Router`.
+
+```rust
+use ruststream::codec::CborCodec;
+
+// every handler in this scope decodes with CborCodec
+RustStream::new(info).with_broker_codec(broker, CborCodec, |b| {
+    b.include(handle);
+});
+
+// one handler, on a Router
+router.with_codec(CborCodec).include(handle);
+```
+
+## Routers
+
+Collect handlers in their own module, then mount the group.
+
+```rust
+use ruststream::runtime::Router;
+
+fn orders() -> Router<MemoryBroker> {
+    let mut router = Router::new();
+    router.include(handle);
+    router.include_publishing(confirm, replies);
+    router
+}
+
+// in main
+.with_broker(MemoryBroker::new(), |b| b.include_router(orders()))
+```
+
+## Broker-specific subscriptions
+
+For options the by-name form can't express (NATS JetStream, consumer groups), override the source
+with `include_on`. It is the source-override form, so it takes the codec explicitly.
+
+```rust
+use ruststream::codec::JsonCodec;
+use ruststream_nats::SubscribeOptions;
+
+b.include_on(
+    SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("worker"),
+    handle,
+    JsonCodec,
+);
+```
+
+## Context
+
+Add `ctx: &mut Context` as the second parameter to read the topic, headers, or app state.
+
+```rust
+use ruststream::runtime::{Context, HandlerResult};
+
+#[subscriber("orders")]
+async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
+    let topic = ctx.topic();
+    let db = ctx.get::<Database>(); // state inserted with RustStream::insert_state
+    HandlerResult::Ack
+}
+```
+
+## AsyncAPI metadata
+
+Derive `Message` to name a type in the generated AsyncAPI document, and `JsonSchema` (feature
+`asyncapi`) for its payload schema.
+
+```rust
+use serde::Deserialize;
+
+/// An order placed on the orders channel.
+#[derive(Debug, Deserialize, ruststream::Message, ruststream::schemars::JsonSchema)]
+struct Order {
+    id: u64,
+}
+```
+
+## Testing
+
+Use the in-memory broker (or a broker's `TestClient` under the `testing` feature); no real server.
+
+```rust
+use std::time::Duration;
+use ruststream::memory::MemoryBroker;
+use ruststream::testing::TestClient;
+
+let client = MemoryBroker::start().await?;
+client.publish("orders", br#"{"id":1}"#).await?;
+let published = client
+    .expect_published("confirmations", 1, Duration::from_secs(1))
+    .await?;
+client.shutdown().await?;
+```

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -139,19 +139,43 @@ b.include_on(
 );
 ```
 
-## Context
+## Context (optional handler argument)
 
-Add `ctx: &mut Context` as the second parameter to read the topic, headers, or app state.
+`ctx: &mut Context` is an **optional** second handler parameter. Omit it when you do not use it - do
+not add it just in case. When present it exposes the delivery's runtime objects:
+
+- `ctx.name()` - the subject/channel the message arrived on.
+- `ctx.headers()` / `ctx.headers_mut()` - the working copy of the message headers.
+- `ctx.get::<T>()` - shared application state registered with `RustStream::insert_state`.
+- `ctx.publisher(name)` - a named publisher (registered with `RustStream::publisher`) for a manual
+  publish through the same middleware pipeline as a macro reply.
 
 ```rust
-use ruststream::runtime::{Context, HandlerResult};
+use ruststream::runtime::{Context, HandlerResult, Outgoing};
+
+struct Database; // connection pool, etc.
 
 #[subscriber("orders")]
 async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let topic = ctx.topic();
-    let db = ctx.get::<Database>(); // state inserted with RustStream::insert_state
+    let subject = ctx.name();                  // "orders"
+    if let Some(db) = ctx.get::<Database>() {   // application state
+        // db.store(order).await;
+        let _ = db;
+    }
+    if let Some(audit) = ctx.publisher("audit") {
+        let _ = audit.publish(Outgoing::new("audit", b"stored".to_vec())).await;
+    }
     HandlerResult::Ack
 }
+```
+
+Register state and named publishers on the app builder:
+
+```rust
+RustStream::new(AppInfo::new("orders", "0.1.0"))
+    .insert_state(Database)
+    .publisher("audit", broker.publisher())
+    .with_broker(broker, |b| b.include(handle))
 ```
 
 ## AsyncAPI metadata

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -180,8 +180,14 @@ RustStream::new(AppInfo::new("orders", "0.1.0"))
 
 ## AsyncAPI metadata
 
-Derive `Message` to name a type in the generated AsyncAPI document, and `JsonSchema` (feature
-`asyncapi`) for its payload schema.
+Decoding only needs `serde::Deserialize`. The extra derives are **documentation only** for the
+generated AsyncAPI spec and are optional: `ruststream::Message` names/describes the type, and
+`JsonSchema` (feature `asyncapi`) emits its payload schema.
+
+Neither selects a wire codec - that stays the default (`json` > `cbor` > `msgpack`) or whatever
+`with_codec` / `with_broker_codec` names. `JsonSchema` describes the payload's logical shape in the
+JSON Schema language (as in OpenAPI), independent of how bytes are encoded on the wire; you cannot
+attach a codec to a type.
 
 ```rust
 use serde::Deserialize;


### PR DESCRIPTION
Adds `.cursor/rules/*.mdc` (FastStream-style agent rules) for three audiences, scoped by globs:

- **usage.mdc** (`examples/**/*.rs`) - building a service: `#[subscriber]` handlers, `#[ruststream::app]`, `with_broker` / `include` / `include_publishing`, `MemoryBroker::new` / `NatsBroker::new`, the default codec and overrides, message derives, logging, testing.
- **core.mdc** (`src/**`, `crates/**`, `tests/**`) - developing the core: broker-agnostic design, visibility/docs, thiserror, async-fn-in-trait, additive features, conformance, gates, pre-1.0 semver + workspace-lockstep, style.
- **broker-authors.mdc** (agent-requested) - authoring a broker: the lazy `new` + async `connect` contract, interior-mutability connection, `Subscribe` + `SubscriptionSource`, capability traits, `AckError::Unsupported`, `conformance::harness::{run_suite, lifecycle}`, the handler-stub `TestClient`.

Concise, mirroring `CLAUDE.md`. Frontmatter validated.