### PR TITLE
runtime: Router-level middleware via Router::layer (0.2.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ruststream-macros"]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -43,6 +43,10 @@ required-features = ["macros", "memory", "metrics"]
 
 [[example]]
 name = "logging"
+required-features = ["macros", "memory", "json", "logging"]
+
+[[example]]
+name = "logging_middleware"
 required-features = ["macros", "memory", "json", "logging"]
 
 [[example]]

--- a/examples/logging_middleware.rs
+++ b/examples/logging_middleware.rs
@@ -1,0 +1,61 @@
+//! Logging every message with the built-in `TracingLayer` middleware, on a `Router`.
+//!
+//! ```text
+//! RUST_LOG=ruststream=debug,info cargo run --example logging_middleware \
+//!     --features macros,memory,json,logging -- run
+//! ```
+//!
+//! `TracingLayer` is the ready-made middleware for this: it wraps every handler and emits a
+//! `tracing` event on each delivery (DEBUG on arrival, INFO on ack, WARN on nack), so the handlers
+//! stay free of logging calls. The `logging` feature installs the console subscriber that renders
+//! those events; the generated `#[ruststream::app]` CLI calls it on `run`.
+//!
+//! The app's global `.layer(..)` does NOT reach handlers mounted through `include_router` - a
+//! `Router` is built independently. So the middleware goes on the router itself with
+//! `Router::layer(..)`, which wraps every handler registered after it. This mirrors how the
+//! scaffolded projects (`ruststream new --broker nats`) group their handlers in a `routes` module.
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::layers::TracingLayer;
+use ruststream::runtime::{AppInfo, HandlerResult, Identity, Router, RustStream, Stack};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+    quantity: u32,
+}
+
+/// Accepts an order. The middleware logs the arrival and the resulting ack; no logging here.
+#[subscriber("orders")]
+async fn confirm(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    HandlerResult::Ack
+}
+
+/// Rejects empty orders by requeueing. The middleware logs the nack at WARN with `requeue=true`.
+#[subscriber("returns")]
+async fn reject(order: &Order) -> HandlerResult {
+    if order.quantity == 0 {
+        return HandlerResult::retry();
+    }
+    HandlerResult::Ack
+}
+
+/// Builds the orders router with `TracingLayer` in front of every handler.
+///
+/// The layer is added first, so both `confirm` and `reject` registered after it are wrapped.
+/// `TracingLayer::with_target("orders")` would route the events under a custom tracing target.
+fn routes() -> Router<MemoryBroker, Stack<TracingLayer, Identity>> {
+    let mut router = Router::new().layer(TracingLayer::default());
+    router.include(confirm);
+    router.include(reject);
+    router
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include_router(routes()))
+}

--- a/src/runtime/app.rs
+++ b/src/runtime/app.rs
@@ -637,9 +637,10 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
 
     /// Mounts every registration from `router` onto this broker.
     ///
-    /// The global middleware stack does **not** apply to these handlers: a [`Router`] is built
-    /// independently and its handlers are already finalized. Wrap them in the router if needed.
-    pub fn include_router(&mut self, router: Router<B>) {
+    /// The app's global middleware stack does **not** apply to these handlers: a [`Router`] is built
+    /// independently and its handlers are already finalized with the router's own middleware. Give
+    /// the router its own stack with [`Router::layer`] to wrap them.
+    pub fn include_router<L2>(&mut self, router: Router<B, L2>) {
         self.router.merge(router);
     }
 }

--- a/src/runtime/router.rs
+++ b/src/runtime/router.rs
@@ -24,10 +24,11 @@ use super::dispatch::{Delivery, spawn_dispatch};
 use super::handler::Handler;
 use super::lifecycle::{BoxError, BoxFuture};
 use super::metadata::HandlerMetadata;
+use super::middleware::{Identity, Layer, Stack};
 use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
 use super::publishing::{PublishingDef, PublishingHandler};
 use super::subscriber_def::SubscriberDef;
-use super::typed::typed;
+use super::typed::{Typed, typed};
 
 /// A deferred registration: given the broker (after connect), shared state, the per-scope publish
 /// [`Delivery`] context, and the shutdown token, it opens the subscription and spawns the dispatch
@@ -44,6 +45,13 @@ pub(crate) type BoundStarter<B> = Box<
 
 /// A lazily-bound group of handler registrations, not yet attached to any broker.
 ///
+/// The `L` type parameter is the router's middleware stack, applied to every handler registered
+/// after a [`layer`](Self::layer) call, exactly like [`RustStream::layer`](super::RustStream::layer).
+/// It defaults to [`Identity`] (no middleware). Because the global stack on
+/// [`RustStream`](super::RustStream) does **not** reach handlers mounted through
+/// [`include_router`](super::BrokerScope::include_router), this is how a standalone router gets
+/// middleware such as [`TracingLayer`](super::layers::TracingLayer).
+///
 /// # Examples
 ///
 /// ```no_run
@@ -51,9 +59,10 @@ pub(crate) type BoundStarter<B> = Box<
 /// # fn build() {
 /// use ruststream::memory::MemoryBroker;
 /// use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, Router};
+/// use ruststream::runtime::layers::TracingLayer;
 /// use ruststream::Name;
 ///
-/// let mut router = Router::<MemoryBroker>::new();
+/// let mut router = Router::<MemoryBroker>::new().layer(TracingLayer::default());
 /// router.subscribe(
 ///     Name::new("events"),
 ///     |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
@@ -62,21 +71,23 @@ pub(crate) type BoundStarter<B> = Box<
 /// // later: app.with_broker(broker, |b| b.include_router(router));
 /// # }
 /// ```
-pub struct Router<B> {
+pub struct Router<B, L = Identity> {
     starters: Vec<BoundStarter<B>>,
     handlers: Vec<HandlerMetadata>,
+    layer: L,
 }
 
-impl<B> Default for Router<B> {
+impl<B> Default for Router<B, Identity> {
     fn default() -> Self {
         Self {
             starters: Vec::new(),
             handlers: Vec::new(),
+            layer: Identity,
         }
     }
 }
 
-impl<B> std::fmt::Debug for Router<B> {
+impl<B, L> std::fmt::Debug for Router<B, L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Router")
             .field("handlers", &self.handlers.len())
@@ -84,14 +95,31 @@ impl<B> std::fmt::Debug for Router<B> {
     }
 }
 
-impl<B: Broker + 'static> Router<B> {
-    /// Creates an empty router.
+impl<B: Broker + 'static> Router<B, Identity> {
+    /// Creates an empty router with no middleware.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
+}
 
-    /// Attaches `handler` to an already-created `subscriber`.
+impl<B: Broker + 'static, L> Router<B, L> {
+    /// Adds a middleware layer, applied to every handler registered after it.
+    ///
+    /// The first layer added runs outermost, matching
+    /// [`RustStream::layer`](super::RustStream::layer). Call before the `include`/`subscribe` calls
+    /// whose handlers it should wrap; handlers registered earlier keep the previous stack.
+    #[must_use]
+    pub fn layer<N>(self, layer: N) -> Router<B, Stack<N, L>> {
+        Router {
+            starters: self.starters,
+            handlers: self.handlers,
+            layer: Stack::new(layer, self.layer),
+        }
+    }
+
+    /// Attaches `handler` (wrapped with this router's middleware) to an already-created
+    /// `subscriber`.
     ///
     /// The subscriber is created up front (before connect). Use this for brokers whose
     /// subscription does not need a live connection, or when you already hold a subscriber.
@@ -99,8 +127,10 @@ impl<B: Broker + 'static> Router<B> {
     where
         S: Subscriber + Send + 'static,
         H: Handler<S::Message> + 'static,
+        L: Layer<H>,
+        L::Handler: Handler<S::Message> + 'static,
     {
-        let handler = Arc::new(handler);
+        let handler = Arc::new(self.layer.layer(handler));
         let name: Arc<str> = Arc::from(meta.name.as_ref());
         self.starters
             .push(Box::new(move |_broker, state, delivery, token| {
@@ -113,7 +143,8 @@ impl<B: Broker + 'static> Router<B> {
         self.handlers.push(meta);
     }
 
-    /// Attaches `handler` to a subscription described by `source`.
+    /// Attaches `handler` (wrapped with this router's middleware) to a subscription described by
+    /// `source`.
     ///
     /// The subscription is opened when the application runs, after the broker is connected, so this
     /// is the path that works for brokers requiring a live connection to subscribe.
@@ -122,8 +153,10 @@ impl<B: Broker + 'static> Router<B> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         H: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
+        L: Layer<H>,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
     {
-        let handler = Arc::new(handler);
+        let handler = Arc::new(self.layer.layer(handler));
         let name: Arc<str> = Arc::from(meta.name.as_ref());
         self.starters
             .push(Box::new(move |broker: Arc<B>, state, delivery, token| {
@@ -156,6 +189,16 @@ impl<B: Broker + 'static> Router<B> {
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        L: Layer<
+            Typed<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+                D::Input,
+                crate::codec::DefaultCodec,
+                D::Handler,
+            >,
+        >,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         self.mount(def, crate::codec::DefaultCodec::default());
     }
@@ -169,6 +212,16 @@ impl<B: Broker + 'static> Router<B> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         C: Codec + 'static,
+        L: Layer<
+            Typed<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+                D::Input,
+                C,
+                D::Handler,
+            >,
+        >,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         let source = def.source();
         let mut meta = HandlerMetadata::typed::<D::Input>(source.name().to_owned());
@@ -201,6 +254,9 @@ impl<B: Broker + 'static> Router<B> {
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishLayer + 'static,
+        L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         let codec = publisher.codec().clone();
         self.mount_publishing(def, codec, publisher);
@@ -222,6 +278,9 @@ impl<B: Broker + 'static> Router<B> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishLayer + 'static,
+        L: Layer<PublishingHandler<D, C, P, PC, PL>>,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         let source = def.source();
         let description = def.description().map(str::to_owned);
@@ -251,7 +310,7 @@ impl<B: Broker + 'static> Router<B> {
     /// [`include`](Self::include). The view's
     /// [`include_publishing`](RouterCodec::include_publishing) overrides the decode codec; the reply
     /// still uses the publisher's own.
-    pub fn with_codec<C>(&mut self, codec: C) -> RouterCodec<'_, B, C>
+    pub fn with_codec<C>(&mut self, codec: C) -> RouterCodec<'_, B, L, C>
     where
         C: Codec + Clone + 'static,
     {
@@ -262,7 +321,10 @@ impl<B: Broker + 'static> Router<B> {
     }
 
     /// Merges another router's registrations into this one, preserving order.
-    pub fn merge(&mut self, other: Self) {
+    ///
+    /// The other router's middleware was already baked into its handlers at registration, so its
+    /// stack type does not need to match this one's.
+    pub fn merge<L2>(&mut self, other: Router<B, L2>) {
         self.starters.extend(other.starters);
         self.handlers.extend(other.handlers);
     }
@@ -282,18 +344,18 @@ impl<B: Broker + 'static> Router<B> {
 ///
 /// Its [`include`](Self::include) / [`include_publishing`](Self::include_publishing) decode handler
 /// input with the chosen codec instead of the [`DefaultCodec`](crate::codec::DefaultCodec).
-pub struct RouterCodec<'a, B, C> {
-    router: &'a mut Router<B>,
+pub struct RouterCodec<'a, B, L, C> {
+    router: &'a mut Router<B, L>,
     codec: C,
 }
 
-impl<B, C> std::fmt::Debug for RouterCodec<'_, B, C> {
+impl<B, L, C> std::fmt::Debug for RouterCodec<'_, B, L, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RouterCodec").finish_non_exhaustive()
     }
 }
 
-impl<B: Broker + 'static, C: Codec + Clone + 'static> RouterCodec<'_, B, C> {
+impl<B: Broker + 'static, L, C: Codec + Clone + 'static> RouterCodec<'_, B, L, C> {
     /// Mounts `def` on its own source, decoding its input with this view's codec.
     pub fn include<D>(&mut self, def: D)
     where
@@ -303,6 +365,16 @@ impl<B: Broker + 'static, C: Codec + Clone + 'static> RouterCodec<'_, B, C> {
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        L: Layer<
+            Typed<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+                D::Input,
+                C,
+                D::Handler,
+            >,
+        >,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         self.router.mount(def, self.codec.clone());
     }
@@ -320,6 +392,9 @@ impl<B: Broker + 'static, C: Codec + Clone + 'static> RouterCodec<'_, B, C> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishLayer + 'static,
+        L: Layer<PublishingHandler<D, C, P, PC, PL>>,
+        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
+            + 'static,
     {
         self.router
             .mount_publishing(def, self.codec.clone(), publisher);

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -183,6 +183,47 @@ async fn included_router_handlers_dispatch() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn router_layer_wraps_handlers() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let layer_hits = Arc::new(AtomicU32::new(0));
+    let handler_hits = Arc::new(AtomicU32::new(0));
+    let handler_hits_clone = Arc::clone(&handler_hits);
+
+    // The app's global stack does not reach router handlers, so the router carries its own layer.
+    let mut router = Router::<MemoryBroker>::new().layer(CountLayer(Arc::clone(&layer_hits)));
+    router.subscribe(
+        Name::new("events"),
+        move |_msg: &_, _ctx: &mut Context| {
+            let handler_hits = Arc::clone(&handler_hits_clone);
+            async move {
+                handler_hits.fetch_add(1, Ordering::SeqCst);
+                HandlerResult::Ack
+            }
+        },
+        HandlerMetadata::raw("events"),
+    );
+
+    let app = RustStream::new(AppInfo::new("events", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(router));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    wait_for_published(&publisher, &handler_hits, Duration::from_secs(1)).await;
+
+    assert!(
+        layer_hits.load(Ordering::SeqCst) >= 1,
+        "router layer did not wrap the handler"
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn global_layer_wraps_handlers() {
     let broker = MemoryBroker::new();
     let publisher = broker.publisher();


### PR DESCRIPTION
Additive change for 0.2.5.

## Problem

The app-global `RustStream::layer` stack does not reach handlers mounted through `include_router`: a `Router` is built independently and its handlers are type-erased at registration, before the app's global layer is known. So a standalone router (the pattern the `nats`/`nats-js` scaffolds use via a `routes` module) had no way to attach middleware such as `TracingLayer`.

## Change

- `Router` carries its own middleware stack: a defaulted type parameter `Router<B, L = Identity>` plus `Router::layer`, applied to every handler registered after it, mirroring `RustStream::layer`.
- `include_router` now accepts a router with any layer stack; the layer was already baked into its handlers at registration.
- Add a `logging_middleware` example (`TracingLayer` on a router) and a test proving the router layer wraps handlers.

Adding a defaulted type parameter and a method is additive: patch bump `0.2.4 -> 0.2.5`.

## Follow-up (not in this PR)

Making the app-global `.layer()` reach router handlers requires routers to be static (generic over their handler list) and is a breaking change. That work is tracked on a `0.3` branch and will ship under 0.3 with other breaking changes.