### PR TITLE
0.3: static routers, app-global layers reach router handlers (breaking)

### DIFF
--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -102,25 +102,30 @@ RustStream::new(info).with_broker_codec(broker, CborCodec, |b| {
 });
 
 // one handler, on a Router
-router.with_codec(CborCodec).include(handle);
+Router::<MemoryBroker>::new().include_with(handle, CborCodec);
 ```
 
 ## Routers
 
-Collect handlers in their own module, then mount the group.
+Collect handlers in their own module, then mount the group. A `Router` is a consuming builder
+(each call returns a new type), so the calls chain and the function returns `impl RouterDef<B>`.
+The app's global `.layer(..)` reaches router handlers, so cross-cutting middleware (logging,
+metrics) goes on the app and applies everywhere; that global layer must be a `BlanketLayer`
+(every bundled layer is).
 
 ```rust
-use ruststream::runtime::Router;
+use ruststream::runtime::{Router, RouterDef};
 
-fn orders() -> Router<MemoryBroker> {
-    let mut router = Router::new();
-    router.include(handle);
-    router.include_publishing(confirm, replies);
-    router
+// `use<>` opts out of borrowing the broker (the router owns its Arc-backed publisher).
+fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
+    let replies = TypedPublisher::new(broker.publisher());
+    Router::new()
+        .include(handle)
+        .include_publishing(confirm, replies)
 }
 
 // in main
-.with_broker(MemoryBroker::new(), |b| b.include_router(orders()))
+.with_broker(MemoryBroker::new(), |b| b.include_router(orders(b.broker())))
 ```
 
 ## Broker-specific subscriptions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ruststream-macros"]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -138,7 +138,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
-ruststream-macros = { version = "0.2.3", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "0.3.0", path = "crates/ruststream-macros", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }

--- a/examples/logging_middleware.rs
+++ b/examples/logging_middleware.rs
@@ -1,23 +1,22 @@
-//! Logging every message with the built-in `TracingLayer` middleware, on a `Router`.
+//! Logging every message with the app-global `TracingLayer`, reaching handlers behind a `Router`.
 //!
 //! ```text
 //! RUST_LOG=ruststream=debug,info cargo run --example logging_middleware \
 //!     --features macros,memory,json,logging -- run
 //! ```
 //!
-//! `TracingLayer` is the ready-made middleware for this: it wraps every handler and emits a
-//! `tracing` event on each delivery (DEBUG on arrival, INFO on ack, WARN on nack), so the handlers
-//! stay free of logging calls. The `logging` feature installs the console subscriber that renders
-//! those events; the generated `#[ruststream::app]` CLI calls it on `run`.
+//! `TracingLayer` wraps every handler and emits a `tracing` event on each delivery (DEBUG on
+//! arrival, INFO on ack, WARN on nack), so the handlers stay free of logging calls. The `logging`
+//! feature installs the console subscriber that renders those events; the generated
+//! `#[ruststream::app]` CLI calls it on `run`.
 //!
-//! The app's global `.layer(..)` does NOT reach handlers mounted through `include_router` - a
-//! `Router` is built independently. So the middleware goes on the router itself with
-//! `Router::layer(..)`, which wraps every handler registered after it. This mirrors how the
-//! scaffolded projects (`ruststream new --broker nats`) group their handlers in a `routes` module.
+//! The app-global `.layer(..)` reaches router handlers: `include_router` wraps each with the app's
+//! stack, which must be a `BlanketLayer` (every bundled layer is). `TracingLayer` here applies to
+//! both `confirm` and `reject`, mounted through the `routes` module.
 
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::layers::TracingLayer;
-use ruststream::runtime::{AppInfo, HandlerResult, Identity, Router, RustStream, Stack};
+use ruststream::runtime::{AppInfo, HandlerResult, Identity, Router, RouterDef, RustStream, Stack};
 use ruststream::subscriber;
 use serde::Deserialize;
 
@@ -43,21 +42,18 @@ async fn reject(order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
-/// Builds the orders router with `TracingLayer` in front of every handler.
-///
-/// The layer is added first, so both `confirm` and `reject` registered after it are wrapped.
-/// `TracingLayer::with_target("orders")` would route the events under a custom tracing target.
+/// Builds the orders router. Broker-agnostic and middleware-agnostic: the app's global layer wraps
+/// these handlers when the router is mounted.
 // --8<-- [start:layered_router]
-fn routes() -> Router<MemoryBroker, Stack<TracingLayer, Identity>> {
-    let mut router = Router::new().layer(TracingLayer::default());
-    router.include(confirm);
-    router.include(reject);
-    router
+fn routes() -> impl RouterDef<MemoryBroker> {
+    Router::new().include(confirm).include(reject)
 }
 // --8<-- [end:layered_router]
 
 #[ruststream::app]
-fn app() -> RustStream {
+fn app() -> RustStream<Stack<TracingLayer, Identity>> {
+    // The global layer is added before with_broker; include_router applies it to the router handlers.
     RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .layer(TracingLayer::default())
         .with_broker(MemoryBroker::new(), |b| b.include_router(routes()))
 }

--- a/examples/routed_service/routes.rs
+++ b/examples/routed_service/routes.rs
@@ -4,7 +4,7 @@
 //! to a concrete broker only when [`main`](crate::main) mounts it with `include_router`.
 
 use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{Router, TypedPublisher};
+use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 
 use crate::orders;
 
@@ -12,12 +12,15 @@ use crate::orders;
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
 /// with the default codec, and `include_publishing` reuses that codec to decode the order.
-/// `on_cancel` has no reply, so it is mounted with `include` (also the default codec).
-pub(crate) fn orders(broker: &MemoryBroker) -> Router<MemoryBroker> {
+/// `on_cancel` has no reply, so it is mounted with `include` (also the default codec). The router is
+/// a consuming builder, so the calls chain; the registration list is opaque, hence `impl RouterDef`.
+///
+/// `use<>` opts out of capturing the `broker` borrow: the router owns its publisher (Arc-backed), so
+/// it does not borrow the broker, and the caller can still mutate the scope to mount it.
+pub(crate) fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher());
 
-    let mut router = Router::new();
-    router.include_publishing(orders::confirm, confirmations);
-    router.include(orders::on_cancel);
-    router
+    Router::new()
+        .include_publishing(orders::confirm, confirmations)
+        .include(orders::on_cancel)
 }

--- a/src/bin/ruststream/scaffold.rs
+++ b/src/bin/ruststream/scaffold.rs
@@ -146,7 +146,7 @@ mod tests {
         assert!(cargo.contains("ruststream-nats = "));
         assert!(main.contains("NatsBroker::new("));
         assert!(main.contains("include_router"));
-        assert!(routes.contains("Router<NatsBroker>"));
+        assert!(routes.contains("impl RouterDef<NatsBroker>"));
         assert!(orders.contains("JsonSchema"));
         assert!(!dir.join("src/stream.rs").exists());
         for file in [&cargo, &main, &orders, &routes] {
@@ -166,7 +166,7 @@ mod tests {
         assert!(orders.contains("jetstream(\"ORDERS\")"));
         assert!(orders.contains("durable(\"svc-worker\")"));
         assert!(main.contains("include_router"));
-        assert!(routes.contains("Router<NatsBroker>"));
+        assert!(routes.contains("impl RouterDef<NatsBroker>"));
         assert!(!dir.join("src/stream.rs").exists());
         for file in [&main, &orders, &routes] {
             assert!(!file.contains("{{name}}"));

--- a/src/bin/ruststream/templates/memory/Cargo.toml.in
+++ b/src/bin/ruststream/templates/memory/Cargo.toml.in
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "memory", "json", "asyncapi", "logging"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json", "asyncapi", "logging"] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/src/bin/ruststream/templates/memory/routes.rs.in
+++ b/src/bin/ruststream/templates/memory/routes.rs.in
@@ -4,7 +4,7 @@
 //! to a concrete broker only when `main` mounts it.
 
 use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{Router, TypedPublisher};
+use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 
 use crate::orders;
 
@@ -12,12 +12,13 @@ use crate::orders;
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
 /// with the default codec, reused to decode the order. `on_cancel` has no reply, so it is mounted
-/// with `include` (also the default codec).
-pub fn orders(broker: &MemoryBroker) -> Router<MemoryBroker> {
+/// with `include` (also the default codec). The router is a consuming builder, so the calls chain;
+/// the registration list is opaque, hence `impl RouterDef`. `use<>` opts out of borrowing `broker`
+/// (the router owns its Arc-backed publisher), so `main` can still mutate the scope to mount it.
+pub fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher());
 
-    let mut router = Router::new();
-    router.include_publishing(orders::confirm, confirmations);
-    router.include(orders::on_cancel);
-    router
+    Router::new()
+        .include_publishing(orders::confirm, confirmations)
+        .include(orders::on_cancel)
 }

--- a/src/bin/ruststream/templates/nats-js/Cargo.toml.in
+++ b/src/bin/ruststream/templates/nats-js/Cargo.toml.in
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "json", "asyncapi", "logging"] }
-ruststream-nats = "0.2"
+ruststream = { version = "0.3", features = ["macros", "json", "asyncapi", "logging"] }
+ruststream-nats = "0.3"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/src/bin/ruststream/templates/nats-js/routes.rs.in
+++ b/src/bin/ruststream/templates/nats-js/routes.rs.in
@@ -4,7 +4,7 @@
 //! to a concrete broker only when `main` mounts it. `confirm` carries its JetStream
 //! `SubscribeOptions` source from the decorator; `include_publishing` reuses that source as is.
 
-use ruststream::runtime::{Router, TypedPublisher};
+use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 use ruststream_nats::NatsBroker;
 
 use crate::orders;
@@ -14,12 +14,13 @@ use crate::orders;
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
 /// with the default codec, reused to decode the order. `on_cancel` has no reply, so it is mounted
-/// with `include` (also the default codec).
-pub fn orders(broker: &NatsBroker) -> Router<NatsBroker> {
+/// with `include` (also the default codec). The router is a consuming builder, so the calls chain;
+/// the registration list is opaque, hence `impl RouterDef`. `use<>` opts out of borrowing `broker`
+/// (the router owns its Arc-backed publisher), so `main` can still mutate the scope to mount it.
+pub fn orders(broker: &NatsBroker) -> impl RouterDef<NatsBroker> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher());
 
-    let mut router = Router::new();
-    router.include_publishing(orders::confirm, confirmations);
-    router.include(orders::on_cancel);
-    router
+    Router::new()
+        .include_publishing(orders::confirm, confirmations)
+        .include(orders::on_cancel)
 }

--- a/src/bin/ruststream/templates/nats/Cargo.toml.in
+++ b/src/bin/ruststream/templates/nats/Cargo.toml.in
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "json", "asyncapi", "logging"] }
-ruststream-nats = "0.2"
+ruststream = { version = "0.3", features = ["macros", "json", "asyncapi", "logging"] }
+ruststream-nats = "0.3"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/src/bin/ruststream/templates/nats/routes.rs.in
+++ b/src/bin/ruststream/templates/nats/routes.rs.in
@@ -3,7 +3,7 @@
 //! Keeping registration in its own module lets the handlers stay broker-agnostic - the router binds
 //! to a concrete broker only when `main` mounts it.
 
-use ruststream::runtime::{Router, TypedPublisher};
+use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 use ruststream_nats::NatsBroker;
 
 use crate::orders;
@@ -12,12 +12,13 @@ use crate::orders;
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
 /// with the default codec, reused to decode the order. `on_cancel` has no reply, so it is mounted
-/// with `include` (also the default codec).
-pub fn orders(broker: &NatsBroker) -> Router<NatsBroker> {
+/// with `include` (also the default codec). The router is a consuming builder, so the calls chain;
+/// the registration list is opaque, hence `impl RouterDef`. `use<>` opts out of borrowing `broker`
+/// (the router owns its Arc-backed publisher), so `main` can still mutate the scope to mount it.
+pub fn orders(broker: &NatsBroker) -> impl RouterDef<NatsBroker> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher());
 
-    let mut router = Router::new();
-    router.include_publishing(orders::confirm, confirmations);
-    router.include(orders::on_cancel);
-    router
+    Router::new()
+        .include_publishing(orders::confirm, confirmations)
+        .include(orders::on_cancel)
 }

--- a/src/runtime/app.rs
+++ b/src/runtime/app.rs
@@ -25,11 +25,11 @@ use super::dispatch::{Delivery, Publishers};
 use super::handler::Handler;
 use super::lifecycle::{BoxError, BoxFuture, BrokerLifecycle};
 use super::metadata::HandlerMetadata;
-use super::middleware::{Identity, Layer, Stack};
+use super::middleware::{BlanketLayer, Identity, Layer, Stack};
 use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
 use super::publisher_registry::ErasedPublisher;
 use super::publishing::{PublishingDef, PublishingHandler};
-use super::router::Router;
+use super::router::{RouterDef, RouterSink};
 use super::subscriber_def::SubscriberDef;
 use super::typed::{Typed, typed};
 
@@ -415,7 +415,7 @@ impl<L> RustStream<L> {
     {
         BrokerScope {
             broker: broker.clone(),
-            router: Router::new(),
+            sink: RouterSink::new(),
             publishers: self.publishers.clone(),
             pipeline: self.publish_layers.iter().cloned().collect(),
             global: self.global.clone(),
@@ -433,7 +433,7 @@ impl<L> RustStream<L> {
             publishers: self.publishers.clone(),
             pipeline: scope.pipeline.clone(),
         });
-        let (starters, handlers) = scope.router.into_parts();
+        let (starters, handlers) = scope.sink.into_parts();
         for (bound, meta) in starters.into_iter().zip(handlers) {
             let broker = broker.clone();
             let delivery = delivery.clone();
@@ -585,7 +585,7 @@ impl<L> RustStream<L> {
 /// [`RustStream::run`]. Each handler registered here is wrapped with `L` before it is stored.
 pub struct BrokerScope<B, L = Identity, C = ()> {
     broker: Arc<B>,
-    router: Router<B>,
+    sink: RouterSink<B>,
     publishers: Publishers,
     pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
     global: L,
@@ -617,7 +617,7 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
         L::Handler: Handler<S::Message> + 'static,
     {
         let handler = self.global.layer(handler);
-        self.router.handle(subscriber, handler, meta);
+        self.sink.push_handle(subscriber, handler, meta);
     }
 
     /// Attaches `handler` (wrapped with the global stack) to a subscription described by `source`.
@@ -632,16 +632,22 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
         L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
     {
         let handler = self.global.layer(handler);
-        self.router.subscribe(source, handler, meta);
+        self.sink.push_subscribe(source, handler, meta);
     }
 
-    /// Mounts every registration from `router` onto this broker.
+    /// Mounts every registration from `router` onto this broker, wrapping each handler with the
+    /// app's global middleware stack.
     ///
-    /// The app's global middleware stack does **not** apply to these handlers: a [`Router`] is built
-    /// independently and its handlers are already finalized with the router's own middleware. Give
-    /// the router its own stack with [`Router::layer`] to wrap them.
-    pub fn include_router<L2>(&mut self, router: Router<B, L2>) {
-        self.router.merge(router);
+    /// Unlike a hand-rolled handler group, a [`Router`] composes with the app's
+    /// [`layer`](RustStream::layer): the global stack must be a [`BlanketLayer`] (it applies to
+    /// handlers whose concrete types the router hides), which every bundled layer and any
+    /// [`Stack`](super::Stack) of them satisfies.
+    pub fn include_router<R>(&mut self, router: R)
+    where
+        R: RouterDef<B>,
+        L: BlanketLayer,
+    {
+        router.mount(&self.global, &mut self.sink);
     }
 }
 
@@ -828,7 +834,7 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
 impl<B, L, C> std::fmt::Debug for BrokerScope<B, L, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BrokerScope")
-            .field("router", &self.router)
+            .field("sink", &self.sink)
             .finish_non_exhaustive()
     }
 }

--- a/src/runtime/middleware.rs
+++ b/src/runtime/middleware.rs
@@ -30,6 +30,25 @@ pub trait Layer<H> {
     fn layer(&self, inner: H) -> Self::Handler;
 }
 
+/// A [`Layer`] that wraps a handler on *any* message type, not one fixed `H`.
+///
+/// [`Layer`] is checked per concrete handler (`L: Layer<H>`). That bound cannot be discharged when
+/// the handler types are hidden, which is exactly the case for a [`Router`](super::Router) mounted
+/// through [`include_router`](super::BrokerScope::include_router): its handlers are erased behind
+/// [`RouterDef`](super::RouterDef). `BlanketLayer` carries the wrapping as a generic method, so a
+/// layer that applies uniformly (logging, metrics) can wrap every router handler from one bound.
+///
+/// Implemented for [`Identity`], a [`Stack`] of blanket layers, and the bundled
+/// [`TracingLayer`](layers::TracingLayer). Implement it for a custom layer to let the app's global
+/// stack reach router handlers; a layer that only wraps specific handler types cannot be blanket.
+pub trait BlanketLayer: Send + Sync {
+    /// Wraps `handler`, returning the layered handler.
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static;
+}
+
 /// Convenience extension trait for fluent layer stacking on any [`Handler`].
 pub trait HandlerExt<M>: Handler<M> + Sized {
     /// Wrap this handler with the given layer.
@@ -53,6 +72,16 @@ impl<H> Layer<H> for Identity {
 
     fn layer(&self, inner: H) -> H {
         inner
+    }
+}
+
+impl BlanketLayer for Identity {
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static,
+    {
+        handler
     }
 }
 
@@ -85,11 +114,26 @@ where
     }
 }
 
+impl<Inner, Outer> BlanketLayer for Stack<Inner, Outer>
+where
+    Inner: BlanketLayer,
+    Outer: BlanketLayer,
+{
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static,
+    {
+        // Same order as the static `Layer` impl: inner wraps first (innermost), outer outside.
+        self.outer.apply::<M, _>(self.inner.apply::<M, _>(handler))
+    }
+}
+
 /// Bundled, opinionated middleware layers ready to drop into a handler stack.
 pub mod layers {
     use tracing::{debug, info, instrument, warn};
 
-    use super::{Context, Future, Handler, HandlerResult, Layer};
+    use super::{BlanketLayer, Context, Future, Handler, HandlerResult, Layer};
 
     /// Logs every delivery and its outcome via [`tracing`]. Default level is `INFO` for the
     /// outcome and `DEBUG` for arrival.
@@ -116,6 +160,16 @@ pub mod layers {
                 inner,
                 target: self.target,
             }
+        }
+    }
+
+    impl BlanketLayer for TracingLayer {
+        fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+        where
+            M: Send + Sync + 'static,
+            H: Handler<M> + 'static,
+        {
+            self.layer(handler)
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,13 +21,13 @@ pub use context::{Context, State};
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
 pub use handler::{Handler, HandlerResult, IntoHandlerResult};
 pub use metadata::HandlerMetadata;
-pub use middleware::{HandlerExt, Identity, Layer, Stack, layers};
+pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
     Outgoing, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext, PublishStack,
     ScopedPublisher, TypedPublisher,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingDef, PublishingHandler};
-pub use router::{Router, RouterCodec};
+pub use router::{Router, RouterDef, RouterSink};
 pub use subscriber_def::SubscriberDef;
 pub use typed::{DecodeFailure, Typed, typed};

--- a/src/runtime/router.rs
+++ b/src/runtime/router.rs
@@ -1,14 +1,18 @@
-//! [`Router`]: a broker-agnostic, lazily-bound group of handler registrations.
+//! [`Router`]: a broker-agnostic, statically-typed group of handler registrations.
 //!
 //! A `Router` collects subscriber registrations without a live broker, so a set of handlers can be
-//! defined in its own module and mounted later. Bind it to a broker by passing it to
-//! [`BrokerScope::include_router`](super::BrokerScope::include_router) inside
-//! [`RustStream::with_broker`](super::RustStream::with_broker). Nothing connects or subscribes
-//! until the application runs.
+//! defined in its own module and mounted later. It is a consuming builder: each `include`/
+//! `subscribe`/`handle` call takes the router by value and returns a new type carrying the added
+//! registration, so the full registration list lives in the type. A builder function therefore
+//! returns an opaque [`RouterDef`] rather than naming that type.
 //!
-//! It is also the shared registration collector: a [`BrokerScope`](super::BrokerScope) is a
-//! `Router` plus the broker it is bound to.
+//! Bind it to a broker by passing it to [`BrokerScope::include_router`](super::BrokerScope::include_router)
+//! inside [`RustStream::with_broker`](super::RustStream::with_broker). Nothing connects or
+//! subscribes until the application runs. Unlike a hand-rolled callback group, the app's global
+//! [`layer`](super::RustStream::layer) stack DOES reach router handlers: each is wrapped with the
+//! app's [`BlanketLayer`] global when the router is mounted.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -24,7 +28,7 @@ use super::dispatch::{Delivery, spawn_dispatch};
 use super::handler::Handler;
 use super::lifecycle::{BoxError, BoxFuture};
 use super::metadata::HandlerMetadata;
-use super::middleware::{Identity, Layer, Stack};
+use super::middleware::BlanketLayer;
 use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
 use super::publishing::{PublishingDef, PublishingHandler};
 use super::subscriber_def::SubscriberDef;
@@ -43,94 +47,70 @@ pub(crate) type BoundStarter<B> = Box<
         + Send,
 >;
 
-/// A lazily-bound group of handler registrations, not yet attached to any broker.
+/// The message a source's subscriber yields, for broker `B`. Tames the long projection in bounds
+/// and return types.
+type SourceMessage<B, S> = <<S as SubscriptionSource<B>>::Subscriber as Subscriber>::Message;
+
+/// The router that mounting a [`SubscriberDef`] `D` (decoded with `C`) onto `R` produces. Names the
+/// otherwise unwieldy builder return type.
+type IncludedRouter<B, D, C, R> = Router<
+    B,
+    (
+        SubscribeRoute<
+            <D as SubscriberDef>::Source,
+            Typed<
+                SourceMessage<B, <D as SubscriberDef>::Source>,
+                <D as SubscriberDef>::Input,
+                C,
+                <D as SubscriberDef>::Handler,
+            >,
+        >,
+        R,
+    ),
+>;
+
+/// The router that mounting a publishing [`PublishingDef`] `D` (replying through a `P`/`PC`/`PL`
+/// publisher) onto `R` produces.
+type PublishingRouter<B, D, P, PC, PL, R> = Router<
+    B,
+    (
+        SubscribeRoute<<D as PublishingDef>::Source, PublishingHandler<D, PC, P, PC, PL>>,
+        R,
+    ),
+>;
+
+/// The runtime collector a router mounts into: type-erased starters plus handler metadata.
 ///
-/// The `L` type parameter is the router's middleware stack, applied to every handler registered
-/// after a [`layer`](Self::layer) call, exactly like [`RustStream::layer`](super::RustStream::layer).
-/// It defaults to [`Identity`] (no middleware). Because the global stack on
-/// [`RustStream`](super::RustStream) does **not** reach handlers mounted through
-/// [`include_router`](super::BrokerScope::include_router), this is how a standalone router gets
-/// middleware such as [`TracingLayer`](super::layers::TracingLayer).
-///
-/// # Examples
-///
-/// ```no_run
-/// # #[cfg(feature = "memory")]
-/// # fn build() {
-/// use ruststream::memory::MemoryBroker;
-/// use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, Router};
-/// use ruststream::runtime::layers::TracingLayer;
-/// use ruststream::Name;
-///
-/// let mut router = Router::<MemoryBroker>::new().layer(TracingLayer::default());
-/// router.subscribe(
-///     Name::new("events"),
-///     |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
-///     HandlerMetadata::raw("events"),
-/// );
-/// // later: app.with_broker(broker, |b| b.include_router(router));
-/// # }
-/// ```
-pub struct Router<B, L = Identity> {
+/// Created and drained inside the application; a [`RouterDef`] pushes into it during
+/// [`include_router`](super::BrokerScope::include_router). You do not construct one directly.
+pub struct RouterSink<B> {
     starters: Vec<BoundStarter<B>>,
     handlers: Vec<HandlerMetadata>,
-    layer: L,
 }
 
-impl<B> Default for Router<B, Identity> {
-    fn default() -> Self {
-        Self {
-            starters: Vec::new(),
-            handlers: Vec::new(),
-            layer: Identity,
-        }
-    }
-}
-
-impl<B, L> std::fmt::Debug for Router<B, L> {
+impl<B> std::fmt::Debug for RouterSink<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Router")
+        f.debug_struct("RouterSink")
             .field("handlers", &self.handlers.len())
             .finish_non_exhaustive()
     }
 }
 
-impl<B: Broker + 'static> Router<B, Identity> {
-    /// Creates an empty router with no middleware.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl<B: Broker + 'static, L> Router<B, L> {
-    /// Adds a middleware layer, applied to every handler registered after it.
-    ///
-    /// The first layer added runs outermost, matching
-    /// [`RustStream::layer`](super::RustStream::layer). Call before the `include`/`subscribe` calls
-    /// whose handlers it should wrap; handlers registered earlier keep the previous stack.
-    #[must_use]
-    pub fn layer<N>(self, layer: N) -> Router<B, Stack<N, L>> {
-        Router {
-            starters: self.starters,
-            handlers: self.handlers,
-            layer: Stack::new(layer, self.layer),
+impl<B: Broker + 'static> RouterSink<B> {
+    pub(crate) fn new() -> Self {
+        Self {
+            starters: Vec::new(),
+            handlers: Vec::new(),
         }
     }
 
-    /// Attaches `handler` (wrapped with this router's middleware) to an already-created
-    /// `subscriber`.
-    ///
-    /// The subscriber is created up front (before connect). Use this for brokers whose
-    /// subscription does not need a live connection, or when you already hold a subscriber.
-    pub fn handle<S, H>(&mut self, subscriber: S, handler: H, meta: HandlerMetadata)
+    /// Erases an already-created subscriber and its handler into a starter.
+    pub(crate) fn push_handle<S, H>(&mut self, subscriber: S, handler: H, meta: HandlerMetadata)
     where
         S: Subscriber + Send + 'static,
         H: Handler<S::Message> + 'static,
-        L: Layer<H>,
-        L::Handler: Handler<S::Message> + 'static,
     {
-        let handler = Arc::new(self.layer.layer(handler));
+        let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
         self.starters
             .push(Box::new(move |_broker, state, delivery, token| {
@@ -143,20 +123,14 @@ impl<B: Broker + 'static, L> Router<B, L> {
         self.handlers.push(meta);
     }
 
-    /// Attaches `handler` (wrapped with this router's middleware) to a subscription described by
-    /// `source`.
-    ///
-    /// The subscription is opened when the application runs, after the broker is connected, so this
-    /// is the path that works for brokers requiring a live connection to subscribe.
-    pub fn subscribe<S, H>(&mut self, source: S, handler: H, meta: HandlerMetadata)
+    /// Erases a source and its handler into a starter; the subscription opens after connect.
+    pub(crate) fn push_subscribe<S, H>(&mut self, source: S, handler: H, meta: HandlerMetadata)
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
-        H: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
-        L: Layer<H>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
+        H: Handler<SourceMessage<B, S>> + 'static,
     {
-        let handler = Arc::new(self.layer.layer(handler));
+        let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
         self.starters
             .push(Box::new(move |broker: Arc<B>, state, delivery, token| {
@@ -173,55 +147,248 @@ impl<B: Broker + 'static, L> Router<B, L> {
         self.handlers.push(meta);
     }
 
+    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B>>, Vec<HandlerMetadata>) {
+        (self.starters, self.handlers)
+    }
+}
+
+/// One subscription registration: a source plus the handler it dispatches to. An implementation
+/// detail of [`Router`]'s registration list.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct SubscribeRoute<S, H> {
+    source: S,
+    handler: H,
+    meta: HandlerMetadata,
+}
+
+/// One registration bound to an already-created subscriber. An implementation detail of [`Router`].
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct HandleRoute<S, H> {
+    subscriber: S,
+    handler: H,
+    meta: HandlerMetadata,
+}
+
+/// One mountable registration: applies the global blanket layer to its handler and registers it.
+trait MountRoute<B> {
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>);
+    fn collect(&self, out: &mut Vec<HandlerMetadata>);
+}
+
+impl<B, S, H> MountRoute<B> for SubscribeRoute<S, H>
+where
+    B: Broker + 'static,
+    S: SubscriptionSource<B> + Send + 'static,
+    S::Subscriber: Send + 'static,
+    SourceMessage<B, S>: Send + Sync + 'static,
+    H: Handler<SourceMessage<B, S>> + 'static,
+{
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+        let handler = global.apply::<SourceMessage<B, S>, H>(self.handler);
+        sink.push_subscribe(self.source, handler, self.meta);
+    }
+
+    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
+        out.push(self.meta.clone());
+    }
+}
+
+impl<B, S, H> MountRoute<B> for HandleRoute<S, H>
+where
+    B: Broker + 'static,
+    S: Subscriber + Send + 'static,
+    S::Message: Send + Sync + 'static,
+    H: Handler<S::Message> + 'static,
+{
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+        let handler = global.apply::<S::Message, H>(self.handler);
+        sink.push_handle(self.subscriber, handler, self.meta);
+    }
+
+    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
+        out.push(self.meta.clone());
+    }
+}
+
+/// A mountable group of handler registrations.
+///
+/// Mounting applies the app's global [`BlanketLayer`] to each handler and registers it, so the
+/// app-wide [`layer`](super::RustStream::layer) stack reaches router handlers. Implemented by
+/// [`Router`] and its internal registration list; you obtain one from a builder and pass it to
+/// [`include_router`](super::BrokerScope::include_router). You do not implement it.
+pub trait RouterDef<B> {
+    /// Applies `global` to every registration and pushes it into `sink`. Called by `include_router`.
+    #[doc(hidden)]
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>);
+
+    /// Appends each registration's metadata, in registration order.
+    #[doc(hidden)]
+    fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>);
+}
+
+impl<B: Broker + 'static> RouterDef<B> for () {
+    fn mount<G: BlanketLayer>(self, _global: &G, _sink: &mut RouterSink<B>) {}
+    fn collect_handlers(&self, _out: &mut Vec<HandlerMetadata>) {}
+}
+
+impl<B, Head, Tail> RouterDef<B> for (Head, Tail)
+where
+    B: Broker + 'static,
+    Head: MountRoute<B>,
+    Tail: RouterDef<B>,
+{
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+        // Registrations are prepended, so the tail holds the earlier ones; mount it first to keep
+        // registration order.
+        self.1.mount(global, sink);
+        self.0.mount_one(global, sink);
+    }
+
+    fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>) {
+        self.1.collect_handlers(out);
+        self.0.collect(out);
+    }
+}
+
+/// A statically-typed, lazily-bound group of handler registrations, not attached to any broker.
+///
+/// Build it by chaining (each call consumes the router and returns a new type that carries the
+/// added registration), then mount it with
+/// [`include_router`](super::BrokerScope::include_router). The registration list `R` is an opaque
+/// nested tuple, so a builder function returns `impl RouterDef<B>` instead of naming the type.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(all(feature = "memory", feature = "json"))]
+/// # fn build() {
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, Router, RouterDef};
+/// use ruststream::Name;
+///
+/// fn routes() -> impl RouterDef<MemoryBroker> {
+///     Router::<MemoryBroker>::new().subscribe(
+///         Name::new("events"),
+///         |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
+///         HandlerMetadata::raw("events"),
+///     )
+/// }
+/// // later: app.with_broker(broker, |b| b.include_router(routes()));
+/// # }
+/// ```
+pub struct Router<B, R = ()> {
+    routes: R,
+    _broker: PhantomData<fn() -> B>,
+}
+
+impl<B: Broker + 'static> Default for Router<B, ()> {
+    fn default() -> Self {
+        Self {
+            routes: (),
+            _broker: PhantomData,
+        }
+    }
+}
+
+impl<B, R> std::fmt::Debug for Router<B, R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Router").finish_non_exhaustive()
+    }
+}
+
+impl<B: Broker + 'static> Router<B, ()> {
+    /// Creates an empty router.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<B: Broker + 'static, R> Router<B, R> {
+    /// Attaches `handler` to an already-created `subscriber`.
+    ///
+    /// The subscriber is created up front (before connect). Use this for brokers whose subscription
+    /// does not need a live connection, or when you already hold a subscriber.
+    pub fn handle<S, H>(
+        self,
+        subscriber: S,
+        handler: H,
+        meta: HandlerMetadata,
+    ) -> Router<B, (HandleRoute<S, H>, R)>
+    where
+        S: Subscriber + Send + 'static,
+        H: Handler<S::Message> + 'static,
+    {
+        Router {
+            routes: (
+                HandleRoute {
+                    subscriber,
+                    handler,
+                    meta,
+                },
+                self.routes,
+            ),
+            _broker: PhantomData,
+        }
+    }
+
+    /// Attaches `handler` to a subscription described by `source`.
+    ///
+    /// The subscription is opened when the application runs, after the broker is connected, so this
+    /// is the path that works for brokers requiring a live connection to subscribe.
+    pub fn subscribe<S, H>(
+        self,
+        source: S,
+        handler: H,
+        meta: HandlerMetadata,
+    ) -> Router<B, (SubscribeRoute<S, H>, R)>
+    where
+        S: SubscriptionSource<B> + Send + 'static,
+        S::Subscriber: Send + 'static,
+        H: Handler<SourceMessage<B, S>> + 'static,
+    {
+        Router {
+            routes: (
+                SubscribeRoute {
+                    source,
+                    handler,
+                    meta,
+                },
+                self.routes,
+            ),
+            _broker: PhantomData,
+        }
+    }
+
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
     /// [`DefaultCodec`](crate::codec::DefaultCodec).
     ///
-    /// Name a codec explicitly with [`with_codec`](Self::with_codec). The router-level counterpart
-    /// of [`BrokerScope::include`](super::BrokerScope::include): collect macro handlers in a
-    /// standalone module, then mount the whole group with
-    /// [`include_router`](super::BrokerScope::include_router).
+    /// Name a codec explicitly with [`include_with`](Self::include_with). The router-level
+    /// counterpart of [`BrokerScope::include`](super::BrokerScope::include).
     #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
-    pub fn include<D>(&mut self, def: D)
+    pub fn include<D>(self, def: D) -> IncludedRouter<B, D, crate::codec::DefaultCodec, R>
     where
         D: SubscriberDef,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
-        L: Layer<
-            Typed<
-                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
-                D::Input,
-                crate::codec::DefaultCodec,
-                D::Handler,
-            >,
-        >,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
     {
-        self.mount(def, crate::codec::DefaultCodec::default());
+        self.include_with(def, crate::codec::DefaultCodec::default())
     }
 
-    fn mount<D, C>(&mut self, def: D, codec: C)
+    /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
+    /// explicit `codec`.
+    pub fn include_with<D, C>(self, def: D, codec: C) -> IncludedRouter<B, D, C, R>
     where
         D: SubscriberDef,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         C: Codec + 'static,
-        L: Layer<
-            Typed<
-                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
-                D::Input,
-                C,
-                D::Handler,
-            >,
-        >,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
     {
         let source = def.source();
         let mut meta = HandlerMetadata::typed::<D::Input>(source.name().to_owned());
@@ -232,55 +399,29 @@ impl<B: Broker + 'static, L> Router<B, L> {
             meta = meta.with_payload_schema(schema);
         }
         let handler = typed(codec, def.into_handler());
-        self.subscribe(source, handler, meta);
+        self.subscribe(source, handler, meta)
     }
 
     /// Mounts a `#[subscriber(.., publish("name"))]`-generated definition on its own source,
     /// decoding its input with the `publisher`'s own codec and sending the reply through it.
     ///
-    /// The common case where input and reply share a format: name the codec once, on the
-    /// `publisher`. Override the decode codec with [`with_codec`](Self::with_codec). Router handlers
-    /// run with an empty dynamic publish pipeline - the app's
+    /// Router handlers run with an empty dynamic publish pipeline - the app's
     /// [`publish_layer`](super::RustStream::publish_layer)s do not apply; the publisher's own static
     /// [`PublishLayer`] stack still does.
-    pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
+    pub fn include_publishing<D, P, PC, PL>(
+        self,
+        def: D,
+        publisher: TypedPublisher<P, PC, PL>,
+    ) -> PublishingRouter<B, D, P, PC, PL, R>
     where
         D: PublishingDef + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishLayer + 'static,
-        L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
-    {
-        let codec = publisher.codec().clone();
-        self.mount_publishing(def, codec, publisher);
-    }
-
-    fn mount_publishing<D, C, P, PC, PL>(
-        &mut self,
-        def: D,
-        codec: C,
-        publisher: TypedPublisher<P, PC, PL>,
-    ) where
-        D: PublishingDef + 'static,
-        D::Source: SubscriptionSource<B> + Send + 'static,
-        <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
-        D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Reply: Serialize + Send + Sync + 'static,
-        C: Codec + 'static,
-        P: Publisher + 'static,
-        PC: Codec + 'static,
-        PL: PublishLayer + 'static,
-        L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
     {
         let source = def.source();
         let description = def.description().map(str::to_owned);
@@ -293,6 +434,7 @@ impl<B: Broker + 'static, L> Router<B, L> {
         if let Some(schema) = schema {
             meta = meta.with_payload_schema(schema);
         }
+        let codec = publisher.codec().clone();
         let pipeline: Arc<[Arc<dyn PublishMiddleware>]> = Arc::from([]);
         let handler = PublishingHandler {
             def,
@@ -300,103 +442,26 @@ impl<B: Broker + 'static, L> Router<B, L> {
             publisher,
             pipeline,
         };
-        self.subscribe(source, handler, meta);
+        self.subscribe(source, handler, meta)
     }
+}
 
-    /// Returns a view of this router that decodes with `codec` instead of the
-    /// [`DefaultCodec`](crate::codec::DefaultCodec).
-    ///
-    /// `router.with_codec(CborCodec).include(def)` is the explicit-codec form of
-    /// [`include`](Self::include). The view's
-    /// [`include_publishing`](RouterCodec::include_publishing) overrides the decode codec; the reply
-    /// still uses the publisher's own.
-    pub fn with_codec<C>(&mut self, codec: C) -> RouterCodec<'_, B, L, C>
-    where
-        C: Codec + Clone + 'static,
-    {
-        RouterCodec {
-            router: self,
-            codec,
-        }
-    }
-
-    /// Merges another router's registrations into this one, preserving order.
-    ///
-    /// The other router's middleware was already baked into its handlers at registration, so its
-    /// stack type does not need to match this one's.
-    pub fn merge<L2>(&mut self, other: Router<B, L2>) {
-        self.starters.extend(other.starters);
-        self.handlers.extend(other.handlers);
-    }
-
+impl<B: Broker + 'static, R: RouterDef<B>> Router<B, R> {
     /// Returns metadata for every registered handler, in registration order.
     #[must_use]
-    pub fn handlers(&self) -> &[HandlerMetadata] {
-        &self.handlers
-    }
-
-    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B>>, Vec<HandlerMetadata>) {
-        (self.starters, self.handlers)
+    pub fn handlers(&self) -> Vec<HandlerMetadata> {
+        let mut out = Vec::new();
+        self.routes.collect_handlers(&mut out);
+        out
     }
 }
 
-/// A codec-bound view of a [`Router`], returned by [`Router::with_codec`].
-///
-/// Its [`include`](Self::include) / [`include_publishing`](Self::include_publishing) decode handler
-/// input with the chosen codec instead of the [`DefaultCodec`](crate::codec::DefaultCodec).
-pub struct RouterCodec<'a, B, L, C> {
-    router: &'a mut Router<B, L>,
-    codec: C,
-}
-
-impl<B, L, C> std::fmt::Debug for RouterCodec<'_, B, L, C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RouterCodec").finish_non_exhaustive()
-    }
-}
-
-impl<B: Broker + 'static, L, C: Codec + Clone + 'static> RouterCodec<'_, B, L, C> {
-    /// Mounts `def` on its own source, decoding its input with this view's codec.
-    pub fn include<D>(&mut self, def: D)
-    where
-        D: SubscriberDef,
-        D::Source: SubscriptionSource<B> + Send + 'static,
-        <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
-        D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: 'static,
-        L: Layer<
-            Typed<
-                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
-                D::Input,
-                C,
-                D::Handler,
-            >,
-        >,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
-    {
-        self.router.mount(def, self.codec.clone());
+impl<B: Broker + 'static, R: RouterDef<B>> RouterDef<B> for Router<B, R> {
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+        self.routes.mount(global, sink);
     }
 
-    /// Mounts a publishing `def` on its own source, decoding its input with this view's codec; the
-    /// reply uses the `publisher`'s own codec.
-    pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
-    where
-        D: PublishingDef + 'static,
-        D::Source: SubscriptionSource<B> + Send + 'static,
-        <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
-        <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
-        D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Reply: Serialize + Send + Sync + 'static,
-        P: Publisher + 'static,
-        PC: Codec + 'static,
-        PL: PublishLayer + 'static,
-        L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
-    {
-        self.router
-            .mount_publishing(def, self.codec.clone(), publisher);
+    fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>) {
+        self.routes.collect_handlers(out);
     }
 }

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -11,8 +11,8 @@ use std::{
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
-    AppInfo, Context, Handler, HandlerMetadata, HandlerResult, Layer, Outgoing, PublishMiddleware,
-    PublishNext, Router, RustStream, State,
+    AppInfo, BlanketLayer, Context, Handler, HandlerMetadata, HandlerResult, Layer, Outgoing,
+    PublishMiddleware, PublishNext, Router, RustStream, State,
 };
 use ruststream::{Name, OutgoingMessage, Publisher};
 use serde::{Deserialize, Serialize};
@@ -58,6 +58,20 @@ where
     async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
         self.count.fetch_add(1, Ordering::SeqCst);
         self.inner.handle(msg, ctx).await
+    }
+}
+
+// Lets CountLayer be an app-global layer that reaches router handlers via include_router.
+impl BlanketLayer for CountLayer {
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static,
+    {
+        CountHandler {
+            inner: handler,
+            count: Arc::clone(&self.0),
+        }
     }
 }
 
@@ -155,9 +169,8 @@ async fn included_router_handlers_dispatch() {
     let seen = Arc::new(AtomicU32::new(0));
     let seen_clone = Arc::clone(&seen);
 
-    // Router defined independently of any live broker, then mounted.
-    let mut router = Router::<MemoryBroker>::new();
-    router.subscribe(
+    // Router defined independently of any live broker, then mounted. Consuming builder.
+    let router = Router::<MemoryBroker>::new().subscribe(
         Name::new("events"),
         move |_msg: &_, _ctx: &mut Context| {
             let seen = Arc::clone(&seen_clone);
@@ -183,7 +196,7 @@ async fn included_router_handlers_dispatch() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn router_layer_wraps_handlers() {
+async fn global_layer_reaches_router_handlers() {
     let broker = MemoryBroker::new();
     let publisher = broker.publisher();
 
@@ -191,9 +204,8 @@ async fn router_layer_wraps_handlers() {
     let handler_hits = Arc::new(AtomicU32::new(0));
     let handler_hits_clone = Arc::clone(&handler_hits);
 
-    // The app's global stack does not reach router handlers, so the router carries its own layer.
-    let mut router = Router::<MemoryBroker>::new().layer(CountLayer(Arc::clone(&layer_hits)));
-    router.subscribe(
+    // The app-global stack must reach handlers mounted through include_router.
+    let router = Router::<MemoryBroker>::new().subscribe(
         Name::new("events"),
         move |_msg: &_, _ctx: &mut Context| {
             let handler_hits = Arc::clone(&handler_hits_clone);
@@ -206,6 +218,7 @@ async fn router_layer_wraps_handlers() {
     );
 
     let app = RustStream::new(AppInfo::new("events", "0.1.0"))
+        .layer(CountLayer(Arc::clone(&layer_hits)))
         .with_broker(broker, |b| b.include_router(router));
 
     let shutdown = Arc::new(Notify::new());
@@ -216,7 +229,7 @@ async fn router_layer_wraps_handlers() {
 
     assert!(
         layer_hits.load(Ordering::SeqCst) >= 1,
-        "router layer did not wrap the handler"
+        "global layer did not reach the router handler"
     );
 
     shutdown.notify_one();


### PR DESCRIPTION
Draft accumulator for 0.3 breaking changes. Holds them until enough land to cut a 0.3 release. Based on top of #15 (Router::layer, 0.2.5); once #15 merges to main this PR's diff narrows to the breaking commit.

## Problem

The app-global `RustStream::layer` stack did not reach handlers mounted through `include_router`. A `Router` erased its handlers at registration, before the app's global layer was known, and a static `Layer<H>` cannot be applied once `H` is hidden. Applying it generically would need a higher-ranked `for<H> L: Layer<H>` bound, which Rust cannot express.

## Change

- **`BlanketLayer`**: a layer that wraps a handler on any message type, via a generic `apply<M, H>`. Implemented for `Identity`, `Stack` of blanket layers, and `TracingLayer`. Discharges the per-handler bound generically, so a router returns an opaque `RouterDef` while `include_router` only needs `L: BlanketLayer`.
- **Static `Router`**: now a consuming builder `Router<B, R>` carrying its registration list `R` in the type. `include`/`subscribe`/`handle` take it by value and return a new type; a builder returns `impl RouterDef<B>`. At mount, `include_router` applies the app's global `BlanketLayer` to every handler, then erases it into the new `RouterSink`.

Cross-cutting middleware (logging, metrics) now goes on the app and applies everywhere - inline and router handlers alike.

## Breaking changes (0.2.5 -> 0.3.0)

- `Router` is a consuming builder: `let mut r = Router::new(); r.include(..)` becomes `Router::new().include(..)`; a `routes()` helper returns `impl RouterDef<B>` (often `+ use<>`), not `Router<B>`.
- `Router::layer` (the 0.2.5 router-local stack from #15) is removed; the app-global layer now reaches routers.
- `Router::with_codec` / `RouterCodec` removed; use `include_with(def, codec)`.
- `include_router` requires the app-global layer to be a `BlanketLayer`.

## Status

- Library, scaffolds, `routed_service` / `logging_middleware` examples, and dispatch tests updated; a test proves the global layer reaches router handlers. fmt / clippy / tests / doctests green.
- The in-repo `nats_*` examples and generated nats projects stay red until `ruststream-nats` ships a 0.3-compatible release (the self-patch can't unify `ruststream 0.3` with a crate requiring `^0.2`). Same transient window as past major-ish bumps.