### PR TITLE
chore: add context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/powersemmi/ruststream",
+  "public_key": "pk_uUlur6QCUlrZ8v1BsB2Wn"
+}


### PR DESCRIPTION
Adds `context7.json` at the repo root so [Context7](https://context7.com) can index the project's docs.