### PR TITLE
docs: refresh guides and broker-authors for 0.2.3-0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ the framework.
 [dependencies]
 ruststream = { version = "0.2", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
+schemars = "0.8"
 ```
 
 The CLI ships with the crate behind the `cli` feature:
@@ -57,13 +58,13 @@ cargo install ruststream --features cli
 ## Write a service
 
 ```rust
-use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
 use ruststream::subscriber;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 struct Order {
     id: u64,
 }
@@ -77,7 +78,7 @@ async fn handle(order: &Order) -> HandlerResult {
 #[ruststream::app]
 fn app() -> RustStream {
     RustStream::new(AppInfo::new("orders", "0.1.0"))
-        .with_broker(MemoryBroker::new(), |b| b.include(handle, JsonCodec))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle))
 }
 ```
 

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -1,20 +1,27 @@
 # Conformance
 
-The conformance harness proves a broker honours the core contract. It runs a fixed set of scenarios
-against your `TestClient`, starting from a fresh instance each time, and panics with a descriptive
-message on the first failure.
+The conformance harness proves a broker honours the core contract. It has two entry points, both of
+which panic with a descriptive message on the first failure:
+
+- `harness::run_suite` checks the **routing surface** against your in-process `TestClient`.
+- `harness::lifecycle` checks the **lazy-startup contract** end to end against a connected broker.
+
+Run both: `run_suite` for the dispatch guarantees, `lifecycle` to prove `new` -> `connect` ->
+subscribe -> publish -> ack -> `shutdown` works on the real transport.
 
 ```toml
 [dev-dependencies]
 ruststream = { version = "0.2", features = ["conformance"] }
 ```
 
-Enable your crate's own `testing` feature alongside it, since the harness drives the `TestClient` you
+Enable your crate's own `testing` feature alongside it, since `run_suite` drives the `TestClient` you
 ship there.
 
-## Running the suite
+## The routing suite
 
-`harness::run_suite` takes a factory that builds a fresh client per scenario:
+`harness::run_suite` takes a factory that builds a fresh client per scenario. The factory is
+fallible (it returns the `TestClient::start` result) and is invoked once per scenario, so scenarios
+cannot leak state into each other:
 
 ```rust
 use ruststream::conformance::harness;
@@ -25,9 +32,7 @@ async fn passes_conformance() {
 }
 ```
 
-The factory is invoked once per scenario, so scenarios cannot leak state into each other.
-
-## What it checks
+### What it checks
 
 | Scenario | Asserts |
 |---|---|
@@ -43,6 +48,40 @@ These are core-routing guarantees, the contract every broker must meet. The harn
 broker-specific semantics (durable resume, redelivery on timeout, partition assignment); those are
 not part of the contract and are verified in your own end-to-end suite against a real server.
 
+## The lifecycle check
+
+`run_suite` exercises routing through the `TestClient`; `harness::lifecycle` exercises the
+**lazy-startup contract** through the real `Broker`: synchronous construction with no I/O, then
+`connect`, a subscription opened through the broker's own `SubscriptionSource`, a publish the
+subscription receives and acks, and finally `shutdown`. It takes three factories that keep it
+broker-agnostic:
+
+```rust
+use ruststream::conformance::harness;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
+async fn passes_lifecycle() {
+    let url = std::env::var("NATS_TEST_URL").unwrap();
+    harness::lifecycle(
+        || NatsBroker::new(url.clone()),         // sync construction (no I/O)
+        |subject| SubscribeOptions::new(subject), // the broker's SubscriptionSource
+        |broker| broker.publisher(),              // a publisher from the connected broker
+    )
+    .await;
+}
+```
+
+- **`make_broker`** is **synchronous** (`Fn() -> B`). A broker that can only be built asynchronously
+  cannot satisfy it - which is the point: construct cheaply, connect lazily in `Broker::connect`.
+- **`make_source`** builds the subscription descriptor for a subject (the macro-subscriber path).
+- **`make_publisher`** produces a publisher from the connected broker.
+
+A broker with no ack semantics (Core NATS) passes by returning `AckError::Unsupported` from `ack`;
+the check accepts that as well as a successful ack. Because `lifecycle` performs a real `connect`,
+run it against a live server (gate it behind an env var like `NATS_TEST_URL`); the in-memory broker
+can run it in-process.
+
 ## Author checklist
 
 Before publishing a broker crate:
@@ -54,8 +93,10 @@ Before publishing a broker crate:
 - [ ] The crate owns its `Config`; fields without a sane default do not get a `Default`.
 - [ ] Capability traits are implemented only where the broker genuinely supports them.
 - [ ] A `TestClient` is shipped under a `testing` feature, doing core routing only.
-- [ ] `harness::run_suite` passes.
-- [ ] An end-to-end suite covers broker-specific semantics, gated behind an environment variable.
+- [ ] `harness::run_suite` passes (the routing surface).
+- [ ] `harness::lifecycle` passes against a real server, gated behind an environment variable (the
+      lazy-startup contract: sync `new`, lazy `connect`, subscribe, ack, `shutdown`).
+- [ ] An end-to-end suite covers broker-specific semantics, also gated behind that variable.
 - [ ] `Cargo.toml` metadata is complete (`description`, `license`, `repository`, `keywords`,
       `categories`), and CI checks `--no-default-features` and `--all-features`.
 

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -1,12 +1,14 @@
 # A worked example: a NATS broker
 
-This page implements the contract for Core NATS on top of the
-[`async-nats`](https://docs.rs/async-nats) client. It is a complete, realistic broker crate in
-miniature: a `Broker`, by-name subscriptions, a publisher, and a native request-reply capability.
+This page follows how the real [`ruststream-nats`](https://github.com/powersemmi/ruststream-nats)
+crate implements the contract on top of the [`async-nats`](https://docs.rs/async-nats) client. It is
+a complete broker in miniature: a `Broker`, one subscription type that serves both Core NATS and
+JetStream behind a single `SubscribeOptions` descriptor, a publisher that forwards headers, and a
+native request-reply capability.
 
 !!! note
-    Item names track the `async-nats` version you depend on; adapt the few spots noted below if the
-    crate's API has moved.
+    Item names track the `async-nats` version you depend on (0.46 here); adapt the few spots noted
+    below if the crate's API has moved.
 
 ```toml title="Cargo.toml"
 [package]
@@ -14,39 +16,46 @@ name = "ruststream-nats"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+testing = ["ruststream/conformance"]
+
 [dependencies]
 ruststream = { version = "0.2", default-features = false }
-async-nats = "0.38"
+async-nats = "0.46"
 bytes = "1"
 futures = "0.3"
 thiserror = "2"
-
-[dependencies.tokio]
-version = "1"
-features = ["time"]
+tokio = { version = "1", features = ["sync", "time"] }
+tokio-stream = "0.1"
+tracing = "0.1"
 ```
 
 ## Errors
 
-One crate-level error enum, variants by source, `#[non_exhaustive]` so new variants are not a
-breaking change.
+One crate-level enum, variants by source, `#[non_exhaustive]` so new variants are not breaking. The
+sources are boxed `std` errors, so the public API does not leak the `async-nats` error types.
 
 ```rust
-use async_nats::{ConnectError, PublishError, SubscribeError};
+use std::error::Error as StdError;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum NatsError {
-    #[error(transparent)]
-    Connect(#[from] ConnectError),
-    #[error(transparent)]
-    Subscribe(#[from] SubscribeError),
-    #[error(transparent)]
-    Publish(#[from] PublishError),
-    #[error("request to {subject} failed or timed out")]
-    Request { subject: String },
-    #[error("broker is not connected")]
+    #[error("nats connection error: {0}")]
+    Connect(#[source] Box<dyn StdError + Send + Sync>),
+    #[error("nats publish error: {0}")]
+    Publish(#[source] Box<dyn StdError + Send + Sync>),
+    #[error("nats subscribe error: {0}")]
+    Subscribe(#[source] Box<dyn StdError + Send + Sync>),
+    #[error("nats jetstream error: {0}")]
+    JetStream(#[source] Box<dyn StdError + Send + Sync>),
+    #[error("nats request timed out")]
+    RequestTimeout,
+    #[error("nats broker is not connected")]
     NotConnected,
+    #[error("invalid subscribe options: {0}")]
+    InvalidOptions(String),
 }
 ```
 
@@ -54,41 +63,58 @@ pub enum NatsError {
 
 The client only exists after `connect`, but a publisher is built while the application is being
 assembled, before `connect` runs. Share the connection through an `Arc<OnceCell<Client>>` so a
-publisher captured early reads the live client once it is set.
+publisher captured early reads the live client once it is set. `new` is synchronous and records only
+the address - that is what lets a NATS service compose with the synchronous `#[ruststream::app]`
+builder.
 
 ```rust
 use std::sync::Arc;
 
-use async_nats::Client;
 use ruststream::Broker;
 use tokio::sync::OnceCell;
 
 #[derive(Clone)]
 pub struct NatsBroker {
-    url: String,
-    client: Arc<OnceCell<Client>>,
+    client: Arc<OnceCell<async_nats::Client>>,
+    addrs: Option<String>,
 }
 
 impl NatsBroker {
+    /// Records the address; connects lazily when `Broker::connect` runs. No I/O.
     #[must_use]
-    pub fn new(url: impl Into<String>) -> Self {
+    pub fn new(addrs: impl Into<String>) -> Self {
         Self {
-            url: url.into(),
             client: Arc::new(OnceCell::new()),
+            addrs: Some(addrs.into()),
         }
     }
 
-    /// Returns a publisher sharing this broker's connection. Resolvable before `connect`; the
-    /// client is read lazily on the first publish.
+    /// Eager constructor for callers that already drive their own runtime.
+    pub async fn connect(addrs: impl async_nats::ToServerAddrs) -> Result<Self, NatsError> {
+        let client = async_nats::connect(addrs)
+            .await
+            .map_err(|e| NatsError::Connect(Box::new(e)))?;
+        Ok(Self::from_client(client))
+    }
+
+    /// Wraps an already-connected client (TLS, credentials, custom options).
+    #[must_use]
+    pub fn from_client(client: async_nats::Client) -> Self {
+        Self {
+            client: Arc::new(OnceCell::new_with(Some(client))),
+            addrs: None,
+        }
+    }
+
+    /// A publisher sharing this broker's connection cell; resolvable before `connect`.
     #[must_use]
     pub fn publisher(&self) -> NatsPublisher {
-        NatsPublisher {
-            client: Arc::clone(&self.client),
-        }
+        NatsPublisher::new(Arc::clone(&self.client))
     }
 
-    fn client(&self) -> Result<&Client, NatsError> {
-        self.client.get().ok_or(NatsError::NotConnected)
+    /// The connected client, or `NotConnected` before `connect` ran.
+    fn connected(&self) -> Result<async_nats::Client, NatsError> {
+        self.client.get().cloned().ok_or(NatsError::NotConnected)
     }
 }
 
@@ -97,162 +123,347 @@ impl Broker for NatsBroker {
 
     async fn connect(&self) -> Result<(), Self::Error> {
         self.client
-            .get_or_try_init(|| async_nats::connect(&self.url))
+            .get_or_try_init(|| async {
+                let addrs = self.addrs.as_deref().ok_or(NatsError::NotConnected)?;
+                async_nats::connect(addrs)
+                    .await
+                    .map_err(|e| NatsError::Connect(Box::new(e)))
+            })
             .await?;
         Ok(())
     }
 
     async fn shutdown(&self) -> Result<(), Self::Error> {
         if let Some(client) = self.client.get() {
-            // Best-effort flush; the connection closes once the last client clone drops.
-            let _ = client.flush().await;
+            let _ = client.drain().await; // best-effort; never blocks or panics
         }
         Ok(())
     }
 }
 ```
 
-`connect` is idempotent: `get_or_try_init` dials only the first time. `shutdown` never blocks or
-panics, as the contract requires.
+`connect` is idempotent: `get_or_try_init` dials only the first time, and a broker built with
+`from_client` finds the cell already filled. `shutdown` does all fallible teardown and never panics,
+as the contract requires.
 
-## Receiving
+## One subscription for Core and JetStream
 
-By-name subscriptions come from the `Subscribe` capability. The subscriber wraps the `async-nats`
-stream; each delivered message becomes a `NatsMessage`.
+Core NATS is fire-and-forget; JetStream is persisted and acknowledged. Rather than two subscriber
+types, model both behind a single `SubscribeOptions` descriptor and a single `NatsSubscriber`.
+`SubscribeOptions` is the `SubscriptionSource`; the broker dispatches on whether `jetstream(..)` was
+called. Each builder method maps onto one keyword of the `#[subscriber(..)]` decorator.
 
 ```rust
-use async_nats::Subscriber as Subscription;
-use futures::{Stream, StreamExt};
-use ruststream::{Subscribe, Subscriber};
+use std::time::Duration;
+
+pub use async_nats::jetstream::consumer::DeliverPolicy;
+use ruststream::SubscriptionSource;
+
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct SubscribeOptions {
+    subject: String,
+    queue_group: Option<String>,
+    stream: Option<String>, // Some(..) => JetStream
+    durable: Option<String>,
+    // JetStream tuning, elided here: filter_subject, ack_wait, max_ack_pending, deliver_policy
+}
+
+impl SubscribeOptions {
+    pub fn new(subject: impl Into<String>) -> Self {
+        Self { subject: subject.into(), queue_group: None, stream: None, durable: None }
+    }
+
+    /// Core-only load balancing. Rejected together with `jetstream`.
+    pub fn queue_group(mut self, name: impl Into<String>) -> Self {
+        self.queue_group = Some(name.into());
+        self
+    }
+
+    /// Switch to a JetStream pull consumer on `stream`.
+    pub fn jetstream(mut self, stream: impl Into<String>) -> Self {
+        self.stream = Some(stream.into());
+        self
+    }
+
+    /// Durable consumer name (JetStream only). Without it the consumer is ephemeral.
+    pub fn durable(mut self, name: impl Into<String>) -> Self {
+        self.durable = Some(name.into());
+        self
+    }
+
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    pub const fn is_jetstream(&self) -> bool {
+        self.stream.is_some()
+    }
+
+    /// Reject incompatible combinations before any I/O.
+    pub fn validate(&self) -> Result<(), NatsError> {
+        if self.subject.is_empty() {
+            return Err(NatsError::InvalidOptions("subject must be non-empty".into()));
+        }
+        if self.stream.is_some() && self.queue_group.is_some() {
+            return Err(NatsError::InvalidOptions(
+                "queue_group is Core NATS only and cannot be combined with jetstream(_)".into(),
+            ));
+        }
+        // ...and reject the JetStream-only fields (durable, ack_wait, ...) when jetstream is unset.
+        Ok(())
+    }
+}
+
+impl SubscriptionSource<NatsBroker> for SubscribeOptions {
+    type Subscriber = NatsSubscriber;
+
+    fn name(&self) -> &str {
+        self.subject()
+    }
+
+    async fn subscribe(self, broker: &NatsBroker) -> Result<NatsSubscriber, NatsError> {
+        broker.subscribe(self).await
+    }
+}
+```
+
+Because the `#[subscriber(..)]` macro accepts a builder chain, the whole descriptor sits inline in
+the decorator:
+
+```rust
+#[subscriber(SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("worker"))]
+async fn handle(order: &Order) -> HandlerResult {
+    HandlerResult::Ack
+}
+```
+
+By-name subscriptions reuse the same path: implement `Subscribe` by delegating to
+`SubscribeOptions::new(name)`, so `#[subscriber("orders")]` works too.
+
+```rust
+use ruststream::Subscribe;
 
 impl Subscribe for NatsBroker {
     type Subscriber = NatsSubscriber;
 
     async fn subscribe(&self, name: &str) -> Result<Self::Subscriber, Self::Error> {
-        let inner = self.client()?.subscribe(name.to_owned()).await?;
-        Ok(NatsSubscriber(inner))
-    }
-}
-
-pub struct NatsSubscriber(Subscription);
-
-impl Subscriber for NatsSubscriber {
-    type Message = NatsMessage;
-    // The async-nats stream ends rather than yielding per-item errors, so this never fails.
-    type Error = std::convert::Infallible;
-
-    fn stream(&mut self) -> impl Stream<Item = Result<Self::Message, Self::Error>> + Send + '_ {
-        (&mut self.0).map(|message| Ok(NatsMessage::new(message)))
+        NatsBroker::subscribe(self, SubscribeOptions::new(name)).await
     }
 }
 ```
 
-A delivered message exposes its payload and headers. Core NATS is fire-and-forget, so ack and nack
-are no-ops; see [JetStream](#jetstream-durable-consumers-with-real-acks) for the acknowledged variant.
+The broker's own `subscribe` validates the options and branches once (`queue_group_ref`,
+`stream_ref`, and `durable_ref` are small `pub(crate)` getters returning `Option<&str>`):
 
 ```rust
-use async_nats::{HeaderMap, Message};
-use bytes::Bytes;
-use ruststream::{AckError, Headers, IncomingMessage};
+use async_nats::jetstream::{self, consumer::pull::Config as PullConfig};
 
-pub struct NatsMessage {
-    message: Message,
-    headers: Headers,
+impl NatsBroker {
+    pub async fn subscribe(&self, opts: SubscribeOptions) -> Result<NatsSubscriber, NatsError> {
+        opts.validate()?;
+        if opts.is_jetstream() {
+            self.subscribe_jetstream(opts).await
+        } else {
+            self.subscribe_core(opts).await
+        }
+    }
+
+    async fn subscribe_core(&self, opts: SubscribeOptions) -> Result<NatsSubscriber, NatsError> {
+        let client = self.connected()?;
+        let subject = opts.subject().to_owned();
+        let inner = match opts.queue_group_ref() {
+            Some(group) => client.queue_subscribe(subject.clone(), group.to_owned()).await,
+            None => client.subscribe(subject.clone()).await,
+        }
+        .map_err(|e| NatsError::Subscribe(Box::new(e)))?;
+        Ok(NatsSubscriber::from_core(subject, inner))
+    }
+
+    async fn subscribe_jetstream(&self, opts: SubscribeOptions) -> Result<NatsSubscriber, NatsError> {
+        let ctx = jetstream::new(self.connected()?);
+        let stream_name = opts.stream_ref().expect("validated").to_owned();
+        let stream = ctx
+            .get_stream(&stream_name)
+            .await
+            .map_err(|e| NatsError::JetStream(Box::new(e)))?;
+        let consumer = stream
+            .create_consumer(PullConfig {
+                durable_name: opts.durable_ref().map(str::to_owned),
+                ..Default::default() // filter_subject, ack_wait, max_ack_pending, deliver_policy
+            })
+            .await
+            .map_err(|e| NatsError::JetStream(Box::new(e)))?;
+        let messages = consumer
+            .messages()
+            .await
+            .map_err(|e| NatsError::JetStream(Box::new(e)))?;
+        Ok(NatsSubscriber::from_jetstream(opts.subject().to_owned(), stream_name, messages))
+    }
+}
+```
+
+## The subscriber
+
+`NatsSubscriber` wraps either an `async-nats` core subscription or a JetStream pull stream, behind
+one `Message` type. `stream` branches with `futures::future::Either` and takes the inner stream out
+on first poll, so it is single-use (the contract allows one `stream` call).
+
+```rust
+use async_nats::jetstream::consumer::pull::Stream as PullStream;
+use futures::{Stream, future::Either};
+use ruststream::Subscriber;
+use tokio_stream::StreamExt;
+
+pub struct NatsSubscriber {
+    subject: String,
+    kind: SubscriberKind,
 }
 
-impl NatsMessage {
-    fn new(message: Message) -> Self {
-        let headers = convert_headers(message.headers.as_ref());
-        Self { message, headers }
+enum SubscriberKind {
+    Core { inner: Option<async_nats::Subscriber> },
+    JetStream { inner: Option<Box<PullStream>>, stream_name: String },
+}
+
+impl Subscriber for NatsSubscriber {
+    type Message = NatsMessage;
+    type Error = NatsError;
+
+    fn stream(&mut self) -> impl Stream<Item = Result<NatsMessage, NatsError>> + Send + '_ {
+        match &mut self.kind {
+            SubscriberKind::Core { inner } => {
+                let inner = inner.take().expect("stream called more than once");
+                Either::Left(inner.map(|m| Ok(NatsMessage::Core(Box::new(CoreMessage::new(m))))))
+            }
+            SubscriberKind::JetStream { inner, .. } => {
+                let inner = *inner.take().expect("stream called more than once");
+                Either::Right(inner.map(|item| match item {
+                    Ok(m) => Ok(NatsMessage::JetStream(Box::new(JetStreamMessage::new(m)))),
+                    Err(e) => Err(NatsError::JetStream(Box::new(e))),
+                }))
+            }
+        }
     }
+}
+```
+
+## The message
+
+`NatsMessage` is an enum: a core delivery (no ack) or a JetStream delivery (real ack). Both are
+boxed because the wrapped `async-nats` messages are large. `ack`/`nack` on a core delivery return
+`AckError::Unsupported` - a non-error the runtime accepts; on JetStream they confirm, with `nack`
+mapping to `nak` (redeliver) when the handler asks for it and to `term` (drop a poison message)
+when it does not.
+
+```rust
+use async_nats::jetstream::AckKind;
+use ruststream::{AckError, Headers, IncomingMessage};
+
+pub enum NatsMessage {
+    Core(Box<CoreMessage>),
+    JetStream(Box<JetStreamMessage>),
 }
 
 impl IncomingMessage for NatsMessage {
     fn payload(&self) -> &[u8] {
-        &self.message.payload
+        match self {
+            Self::Core(m) => &m.inner.payload,
+            Self::JetStream(m) => &m.inner.message.payload,
+        }
     }
 
     fn headers(&self) -> &Headers {
-        &self.headers
+        match self {
+            Self::Core(m) => &m.headers,
+            Self::JetStream(m) => &m.headers,
+        }
     }
 
     async fn ack(self) -> Result<(), AckError> {
-        Ok(())
+        match self {
+            Self::Core(_) => Err(AckError::Unsupported),
+            Self::JetStream(m) => m.inner.ack().await.map_err(|e| AckError::Broker(box_err(e))),
+        }
     }
 
-    async fn nack(self, _requeue: bool) -> Result<(), AckError> {
-        Ok(())
+    async fn nack(self, requeue: bool) -> Result<(), AckError> {
+        match self {
+            Self::Core(_) => Err(AckError::Unsupported),
+            Self::JetStream(m) => {
+                let kind = if requeue { AckKind::Nak(None) } else { AckKind::Term };
+                m.inner.ack_with(kind).await.map_err(|e| AckError::Broker(box_err(e)))
+            }
+        }
     }
 }
+```
 
-/// Copies NATS headers into the framework's `Headers`. Header iteration is the one spot that tracks
-/// the async-nats version; take the first value of each name.
-fn convert_headers(map: Option<&HeaderMap>) -> Headers {
-    let mut headers = Headers::default();
-    let Some(map) = map else {
-        return headers;
-    };
-    for (name, values) in map.iter() {
-        if let Some(value) = values.iter().next() {
-            headers.insert(name.to_string(), Bytes::copy_from_slice(value.as_str().as_bytes()));
+Returning `AckError::Unsupported` (rather than a real error) for core deliveries is exactly what lets
+the conformance lifecycle check pass for Core NATS. Each message converts its headers once at
+construction; the two converters are the one spot that tracks the `async-nats` version:
+
+```rust
+use bytes::Bytes;
+
+fn headers_from_nats(map: Option<&async_nats::HeaderMap>) -> Headers {
+    let mut headers = Headers::new();
+    if let Some(map) = map {
+        for (name, values) in map.iter() {
+            if let Some(first) = values.iter().next() {
+                headers.insert(name.to_string(), Bytes::copy_from_slice(first.as_ref()));
+            }
         }
     }
     headers
+}
+
+fn headers_to_nats(headers: &Headers) -> Option<async_nats::HeaderMap> {
+    if headers.is_empty() {
+        return None;
+    }
+    let mut map = async_nats::HeaderMap::new();
+    for (name, value) in headers.iter() {
+        if let Ok(text) = std::str::from_utf8(value) {
+            map.insert(name, text);
+        }
+    }
+    Some(map)
 }
 ```
 
 ## Publishing
 
-The publisher holds the shared connection cell and reads the client on each publish.
+The publisher holds the shared connection cell and reads the client on each publish, forwarding
+headers when present.
 
 ```rust
 use ruststream::{OutgoingMessage, Publisher};
 
+#[derive(Clone)]
 pub struct NatsPublisher {
-    client: Arc<OnceCell<Client>>,
-}
-
-impl NatsPublisher {
-    fn client(&self) -> Result<&Client, NatsError> {
-        self.client.get().ok_or(NatsError::NotConnected)
-    }
+    client: Arc<OnceCell<async_nats::Client>>,
 }
 
 impl Publisher for NatsPublisher {
     type Error = NatsError;
 
     async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
-        self.client()?
-            .publish(msg.name().to_owned(), Bytes::copy_from_slice(msg.payload()))
-            .await?;
-        Ok(())
+        let client = self.client.get().cloned().ok_or(NatsError::NotConnected)?;
+        let subject = msg.name().to_owned();
+        let payload = Bytes::copy_from_slice(msg.payload());
+        match headers_to_nats(msg.headers()) {
+            Some(headers) => client.publish_with_headers(subject, headers, payload).await,
+            None => client.publish(subject, payload).await,
+        }
+        .map_err(|e| NatsError::Publish(Box::new(e)))
     }
 }
 ```
 
-To forward outgoing headers, build an `async_nats::HeaderMap` from `msg.headers()` and call
-`publish_with_headers` instead.
-
-## Wiring it into an app
-
-With the broker in hand, an application looks exactly like any other; nothing about the handlers or
-codecs is NATS-specific.
-
-```rust
-use ruststream::codec::JsonCodec;
-use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
-
-let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
-    .with_broker(NatsBroker::new("nats://localhost:4222"), |b| {
-        let replies = TypedPublisher::new(b.broker().publisher());
-        b.include_publishing(confirm, replies);
-    });
-```
-
 ## Capabilities
 
-NATS supports request-reply natively, so implement `RequestReply` on the publisher. Bound the wait
-with the caller's timeout.
+NATS supports request-reply natively, so implement `RequestReply` on the publisher and bound the wait
+with the caller's timeout, mapping an elapsed timer to `RequestTimeout`.
 
 ```rust
 use std::time::Duration;
@@ -267,166 +478,42 @@ impl RequestReply for NatsPublisher {
         msg: OutgoingMessage<'_>,
         timeout: Duration,
     ) -> Result<Self::Reply, Self::Error> {
+        let client = self.client.get().cloned().ok_or(NatsError::NotConnected)?;
         let subject = msg.name().to_owned();
-        let payload = Bytes::copy_from_slice(msg.payload());
-        let request = self.client()?.request(subject.clone(), payload);
-        let reply = tokio::time::timeout(timeout, request)
+        let request = async_nats::Request::new().payload(Bytes::copy_from_slice(msg.payload()));
+        let send = async {
+            client
+                .send_request(subject, request)
+                .await
+                .map_err(|e| NatsError::Publish(Box::new(e)))
+        };
+        let reply = tokio::time::timeout(timeout, send)
             .await
-            .map_err(|_| NatsError::Request { subject: subject.clone() })?
-            .map_err(|_| NatsError::Request { subject })?;
-        Ok(NatsMessage::new(reply))
+            .map_err(|_| NatsError::RequestTimeout)??;
+        Ok(NatsMessage::Core(Box::new(CoreMessage::new(reply))))
     }
 }
 ```
 
-Report the server for AsyncAPI by implementing `DescribeServer`:
+Implement only the capabilities the transport supports: Core NATS has no batch subscribe or
+transactional publish, so `BatchSubscriber` and `TransactionalPublisher` are left out.
+`ruststream-nats` also does not currently implement `DescribeServer`; add it if you want the broker
+reported as a server in the AsyncAPI document.
+
+## Wiring it into an app
+
+With the broker in hand, an application looks exactly like any other; nothing about the handlers or
+codecs is NATS-specific.
 
 ```rust
-use ruststream::{DescribeServer, ServerSpec};
+use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
 
-impl DescribeServer for NatsBroker {
-    fn describe_server(&self) -> ServerSpec {
-        ServerSpec::new(self.url.clone(), "nats")
-    }
-}
+let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+    .with_broker(NatsBroker::new("nats://localhost:4222"), |b| {
+        let replies = TypedPublisher::new(b.broker().publisher());
+        b.include_publishing(confirm, replies);
+    });
 ```
-
-Do not implement capabilities the transport lacks. Core NATS has no batch subscribe or transactional
-publish, so `BatchSubscriber` and `TransactionalPublisher` are left out.
-
-## JetStream: durable consumers with real acks
-
-The ack and nack above are no-ops because Core NATS does not acknowledge delivery. JetStream adds
-persistence and acknowledgement, so model it as its own `SubscriptionSource` and message type, with
-durable-consumer config in the descriptor rather than the core. Add a `JetStream(String)` variant to
-`NatsError` for stream and consumer errors.
-
-The descriptor opens (or binds to) a durable pull consumer and wraps its message stream:
-
-```rust
-use async_nats::jetstream::{self, consumer::pull::Config as PullConfig};
-use async_nats::jetstream::consumer::pull::Stream as PullStream;
-use futures::{Stream, StreamExt};
-use ruststream::{Subscriber, SubscriptionSource};
-
-/// A durable JetStream pull consumer on a stream.
-pub struct JetStreamConsumer {
-    stream: String,
-    durable: String,
-}
-
-impl JetStreamConsumer {
-    #[must_use]
-    pub fn new(stream: impl Into<String>, durable: impl Into<String>) -> Self {
-        Self {
-            stream: stream.into(),
-            durable: durable.into(),
-        }
-    }
-}
-
-impl SubscriptionSource<NatsBroker> for JetStreamConsumer {
-    type Subscriber = JetStreamSubscriber;
-
-    fn name(&self) -> &str {
-        &self.stream
-    }
-
-    async fn subscribe(self, broker: &NatsBroker) -> Result<Self::Subscriber, NatsError> {
-        let context = jetstream::new(broker.client()?.clone());
-        let stream = context
-            .get_stream(&self.stream)
-            .await
-            .map_err(|e| NatsError::JetStream(e.to_string()))?;
-        let consumer = stream
-            .get_or_create_consumer(
-                &self.durable,
-                PullConfig {
-                    durable_name: Some(self.durable.clone()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|e| NatsError::JetStream(e.to_string()))?;
-        let messages = consumer
-            .messages()
-            .await
-            .map_err(|e| NatsError::JetStream(e.to_string()))?;
-        Ok(JetStreamSubscriber(messages))
-    }
-}
-
-pub struct JetStreamSubscriber(PullStream);
-
-impl Subscriber for JetStreamSubscriber {
-    type Message = JetStreamMessage;
-    type Error = NatsError;
-
-    fn stream(&mut self) -> impl Stream<Item = Result<JetStreamMessage, NatsError>> + Send + '_ {
-        (&mut self.0).map(|item| {
-            item.map(JetStreamMessage::new)
-                .map_err(|e| NatsError::JetStream(e.to_string()))
-        })
-    }
-}
-```
-
-The message carries the real acknowledgement. `ack` confirms delivery; `nack` maps to `nak` when the
-handler asks for redelivery, and to `term` when it does not (a poison message that should not come
-back).
-
-```rust
-use async_nats::jetstream::AckKind;
-use async_nats::jetstream::Message as JsMessage;
-use ruststream::{AckError, Headers, IncomingMessage};
-
-pub struct JetStreamMessage {
-    message: JsMessage,
-    headers: Headers,
-}
-
-impl JetStreamMessage {
-    fn new(message: JsMessage) -> Self {
-        let headers = convert_headers(message.headers.as_ref());
-        Self { message, headers }
-    }
-}
-
-impl IncomingMessage for JetStreamMessage {
-    fn payload(&self) -> &[u8] {
-        &self.message.payload
-    }
-
-    fn headers(&self) -> &Headers {
-        &self.headers
-    }
-
-    async fn ack(self) -> Result<(), AckError> {
-        self.message.ack().await.map_err(AckError::Broker)
-    }
-
-    async fn nack(self, requeue: bool) -> Result<(), AckError> {
-        let kind = if requeue { AckKind::Nak(None) } else { AckKind::Term };
-        self.message
-            .ack_with(kind)
-            .await
-            .map_err(AckError::Broker)
-    }
-}
-```
-
-`JsMessage` dereferences to the core message, so `payload`, `headers`, and `convert_headers` from the
-Core NATS section are reused unchanged. Mount a handler on the consumer through the descriptor:
-
-```rust
-#[subscriber(JetStreamConsumer::new("ORDERS", "workers"))]
-async fn handle(order: &Order) -> HandlerResult {
-    HandlerResult::Ack
-}
-```
-
-A handler returning `HandlerResult::retry()` triggers a `nak`; `HandlerResult::drop()` triggers a
-`term`.
 
 ## Proving it
 

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -98,9 +98,11 @@ pub trait SubscriptionSource<B: Broker> {
 
 Give the descriptor an associated constructor (`OrdersStream::new(..)`) rather than a free function,
 so users can name it directly in the decorator: `#[subscriber(OrdersStream::new("orders", "workers"))]`.
-The macro reads the type out of the constructor call. Because `type Subscriber` lives on the source,
-one broker can offer several subscription kinds (pub/sub versus streams) with different subscriber
-types.
+The macro reads the type out of the constructor call, and also accepts a builder chain on it
+(`#[subscriber(OrdersStream::new("orders").durable("workers"))]`) as long as each method returns
+`Self`. Because `type Subscriber` lives on the source, one broker can offer several subscription
+kinds (pub/sub versus streams) with different subscriber types - or, as the
+[NATS example](example-nats.md) does, serve them all from one descriptor that branches internally.
 
 ## Capability traits
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,7 @@ always compiled. Everything else is an additive, opt-in feature.
 | `macros` | ruststream-macros | `#[subscriber]`, `#[ruststream::app]`, `#[derive(Message)]` |
 | `asyncapi` | schemars, serde_norway | AsyncAPI generation and the HTML viewer |
 | `metrics` | prometheus | Prometheus middleware and exporter |
+| `logging` | tracing-subscriber | `ruststream::logging`, a colored console logger ([Logging](../guides/logging.md)) |
 | `conformance` | - | the broker-author conformance harness |
 | `cli` | clap, anyhow | the `ruststream` binary |
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -15,6 +15,8 @@ crate, and `new` writes a project.
 
 ```bash
 ruststream new my-service              # scaffold a project (default --broker memory)
+ruststream new my-service --broker nats     # Core NATS project
+ruststream new my-service --broker nats-js  # NATS JetStream project
 ruststream run                         # cargo run -- run, against ./Cargo.toml
 ruststream run -p ./my-service         # against another crate
 ruststream run --release               # release build
@@ -57,8 +59,15 @@ my-service/
 └── src/
     ├── main.rs      # #[ruststream::app], mounts the router
     ├── orders.rs    # #[subscriber] handlers, one with a reply
-    ├── routes.rs    # a Router collecting the handlers
-    └── stream.rs    # a broker-specific subscription descriptor
+    └── routes.rs    # a Router collecting the handlers
 ```
+
+`--broker` picks the broker wired into `main.rs` and the dependencies:
+
+- `memory` (default) - the in-process `MemoryBroker`, no external service; good for a first run or
+  tests.
+- `nats` - Core NATS via `ruststream-nats`.
+- `nats-js` - NATS JetStream; `orders.rs` binds the consumer with a `SubscribeOptions` builder chain
+  in the `#[subscriber(..)]` decorator (a durable pull consumer).
 
 See the [quick start](../getting-started/quickstart.md) to scaffold and run one.

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -1,0 +1,119 @@
+# Lifespan and shared state
+
+Most services need resources that are created once at startup and shared by every handler: a
+database pool, an HTTP client, parsed configuration. RustStream gives you a shared `State` type-map
+plus lifecycle hooks that run at fixed points around the run loop.
+
+## Shared state
+
+`State` is a type-map: one value per type. Put ready-made values in at build time with
+`insert_state`, and read them from any handler or middleware through the `Context`:
+
+```rust
+RustStream::new(info)
+    .insert_state(Config::from_env())
+    .with_broker(broker, |b| b.include(handle));
+```
+
+```rust
+use ruststream::runtime::{Context, HandlerResult};
+
+#[subscriber("orders")]
+async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
+    let config = ctx.get::<Config>().expect("config inserted at build time");
+    // ... use config ...
+    HandlerResult::Ack
+}
+```
+
+`ctx.get::<T>()` returns `Option<&T>`; it is `None` only if no value of that type was inserted.
+Inserting the same type again replaces the previous value.
+
+A `#[subscriber]` handler opts into the context by taking a second parameter, `ctx: &mut Context`,
+after the payload. Omit it when the handler does not need state.
+
+## Lifecycle hooks
+
+Anything that needs `async` work (connecting that pool, closing it cleanly) goes in a hook. Four
+hooks bracket the run loop:
+
+```text
+on_startup(State) -> State     # before brokers connect; build async resources
+  -> brokers connect, subscriptions open
+after_startup(&State)          # handlers are live; publish a first message, signal readiness
+  ... running ...
+  -> shutdown triggered (signal, or the run_until future resolves)
+on_shutdown(&State)            # brokers still connected
+  -> brokers shut down, in-flight handlers drained
+after_shutdown(&State)         # final teardown
+```
+
+- **`on_startup`** receives the `State` **by value** and returns it, so its future can own the state
+  across awaits - connect a resource, insert it, hand the state back. A failing `on_startup` aborts
+  startup.
+- **`after_startup`** runs once handlers are spawned. Use it to publish an initial message or signal
+  readiness. A failure here also aborts startup.
+- **`on_shutdown`** runs when shutdown begins, while brokers are still connected.
+- **`after_shutdown`** runs after brokers are down, for final async teardown.
+
+Startup hooks abort the service on error; shutdown hooks only log their error, so shutdown always
+runs to completion. Hooks of the same kind run in registration order.
+
+## Passing a database connection
+
+The common case: open a pool before serving, share it with every handler, close it on the way out.
+
+```rust
+use ruststream::runtime::{AppInfo, Context, HandlerResult, RustStream};
+use sqlx::PgPool;
+
+#[subscriber("orders")]
+async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
+    let pool = ctx.get::<PgPool>().expect("pool inserted in on_startup");
+    if sqlx::query("insert into orders (id) values ($1)")
+        .bind(order.id as i64)
+        .execute(pool)
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    HandlerResult::Ack
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        // before connect: open the pool and put it in shared state
+        .on_startup(|mut state| async move {
+            let pool = PgPool::connect("postgres://localhost/orders").await?;
+            state.insert(pool);
+            Ok::<_, sqlx::Error>(state)
+        })
+        // after shutdown: close it cleanly
+        .after_shutdown(|state| async move {
+            if let Some(pool) = state.get::<PgPool>() {
+                pool.close().await;
+            }
+            Ok::<_, sqlx::Error>(())
+        })
+        .with_broker(broker, |b| b.include(handle))
+}
+```
+
+The hook's error type is inferred from the `Ok::<_, E>(..)` annotation; it only needs to implement
+`std::error::Error + Send + Sync`. The pool is `Clone` and `Send + Sync`, so every concurrent handler
+borrows the one instance from `State` - no per-message connection setup.
+
+## Shutdown timeout
+
+By default `run` waits indefinitely for in-flight handlers to finish after shutdown is triggered.
+Bound that wait with `shutdown_timeout`; handlers still running after it are aborted:
+
+```rust
+use std::time::Duration;
+
+RustStream::new(info)
+    .shutdown_timeout(Duration::from_secs(10))
+    .with_broker(broker, |b| b.include(handle));
+```

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,0 +1,57 @@
+# Logging
+
+RustStream emits structured [`tracing`](https://docs.rs/tracing) events throughout dispatch,
+publishing, and the service lifecycle. Like any well-behaved library it installs no subscriber on its
+own - that choice belongs to the application. The `logging` feature is the batteries-included answer:
+a colored console subscriber driven by `RUST_LOG`.
+
+This is separate from the [`TracingLayer`](middleware.md#built-in-layers) middleware. `TracingLayer`
+*emits* an event per message; the `logging` feature installs a subscriber that *renders* events
+(RustStream's own and yours) to the terminal. Use them together to see per-message logs.
+
+## With the generated CLI
+
+When the `logging` feature is enabled, the `#[ruststream::app]` CLI calls the logger for you on the
+`run` command, so a scaffolded service logs out of the box:
+
+```toml
+ruststream = { version = "0.2", features = ["macros", "memory", "json", "logging"] }
+```
+
+```bash
+RUST_LOG=ruststream=debug,info cargo run -- run
+```
+
+Output goes to **stderr** (keeping stdout clean for `asyncapi gen`), with colors enabled
+automatically when stderr is a terminal.
+
+## By hand
+
+Install the default logger once, early in `main`:
+
+```rust
+ruststream::logging::init()?;
+tracing::info!("service starting");
+```
+
+`init` reads the filter from `RUST_LOG`, falling back to `info`. Tune the defaults through the
+`Logging` builder:
+
+```rust
+use ruststream::logging::Logging;
+
+Logging::new()
+    .with_default_filter("ruststream=debug,info")  // used when RUST_LOG is unset
+    .with_target(false)                            // hide the event target column
+    .try_init()?;
+```
+
+`init` / `try_init` never replace an existing subscriber: a second call (or one after another crate
+installed a subscriber) returns `LoggingInitError::AlreadyInitialized` rather than panicking.
+
+## Bring your own subscriber
+
+The `logging` feature is optional sugar. Because RustStream only emits `tracing` events, any
+subscriber works - install `tracing-subscriber`, `tracing-bunyan-formatter`, an OpenTelemetry layer,
+or whatever your stack uses, and the same events flow through it. Skip the `logging` feature when you
+do.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -20,9 +20,16 @@ let app = RustStream::new(info)
 The first layer added is the outermost. The global stack is static: it has zero runtime dispatch
 cost, and its type grows as you call `layer`.
 
-!!! note "Routers opt out"
+!!! note "Routers carry their own stack"
     The global stack does not wrap handlers brought in via `include_router`, because a router is
-    finalized independently. Wrap those handlers inside the router if you need the same behaviour.
+    finalized independently. Give the router its own middleware with `Router::layer`, which wraps
+    every handler registered after it:
+
+    ```rust
+    let mut router = Router::new().layer(TracingLayer::default());
+    router.include(handle);
+    b.include_router(router);
+    ```
 
 ## Writing a layer
 
@@ -66,19 +73,82 @@ let handler = base_handler.with(LogLayer);
 
 This is the right tool when only some handlers need a layer. It composes with the global stack.
 
+## Why middleware is static by default
+
+The layers above are resolved at compile time: `with`/`layer` build a concrete, nested handler type
+(`Logged<Typed<..>>`), and `Handler::handle` returns an `impl Future` whose type is known. The
+compiler monomorphizes the whole chain into one state machine and inlines across the layer
+boundaries, so a static layer adds no dispatch cost and no allocation - it is a zero-cost
+abstraction.
+
+Making every middleware dynamic (`dyn`) would throw that away. `Handler::handle` is an `async fn in
+trait`, so its future is an anonymous `impl Future` - and a trait with an `impl Trait` return is not
+object-safe. To store middleware behind `dyn`, the future has to be boxed (`Pin<Box<dyn Future>>`):
+one heap allocation per layer per message, and the call can no longer be inlined or specialized
+across the `dyn` boundary. `dyn` + `async` does not optimize, so paying that cost on every handler -
+when the chain is almost always known at compile time - would be the wrong default.
+
 ## Dynamic middleware
 
-The static layers above are resolved at compile time. When you need a runtime-built chain (a list of
-layers decided from config, or layers stored behind `dyn`), use the dynamic stack: `DynStack`,
-`DynMiddleware`, and `Next`. A `DynMiddleware` has an around/next signature, so it can short-circuit
-or wrap the call:
+When the chain genuinely is decided at runtime (layers toggled by config, or held behind `dyn`), opt
+into the dynamic stack for exactly those handlers: `DynStack`, `DynMiddleware`, and `Next`. A
+`DynMiddleware` has an around/next signature - it inspects the input and context, then either calls
+`next.run(..)` to continue or short-circuits with its own result. Because it is object-safe, it
+returns a boxed future explicitly:
 
 ```rust
-use ruststream::runtime::{DynMiddleware, Next};
+use std::future::Future;
+use std::pin::Pin;
+
+use ruststream::runtime::{Context, DynMiddleware, HandlerResult, Next};
+
+struct Audit {
+    service: String,
+}
+
+impl<I: Send + Sync> DynMiddleware<I> for Audit {
+    fn handle<'a>(
+        &'a self,
+        input: &'a I,
+        ctx: &'a mut Context<'_>,
+        next: Next<'a, I>,
+    ) -> Pin<Box<dyn Future<Output = HandlerResult> + Send + 'a>> {
+        Box::pin(async move {
+            tracing::info!(service = %self.service, channel = ctx.name(), "handling");
+            next.run(input, ctx).await
+        })
+    }
+}
 ```
 
-Each dynamic layer costs one boxed future per call, against zero for the static layers, so prefer
-static layers unless you genuinely need runtime composition.
+Build the chain at runtime and fold it into a single `DynStack`, which is itself an ordinary
+`Layer` - apply it with `with`, `Router::layer`, or the global `layer`. Here it wraps one handler,
+running on the decoded `Order`:
+
+```rust
+use std::sync::Arc;
+
+use ruststream::codec::JsonCodec;
+use ruststream::runtime::{DynStack, HandlerExt, HandlerMetadata, typed};
+
+// inside with_broker(...):
+let subscriber = b.broker().subscribe("orders");
+
+let mut middleware: Vec<Arc<dyn DynMiddleware<Order>>> = Vec::new();
+if config.audit {
+    middleware.push(Arc::new(Audit { service: "orders".to_owned() }));
+}
+let stack = DynStack::new(middleware); // empty list -> a no-op layer
+
+let handler = (|order: &Order, _ctx: &mut Context| async { HandlerResult::Ack }).with(stack);
+b.handle(subscriber, typed(JsonCodec, handler), HandlerMetadata::typed::<Order>("orders"));
+```
+
+`DynStack<I>` is generic over the input it wraps: build it over the decoded type (`DynStack<Order>`)
+to run after decoding, or over the broker's raw message type to run before. Middleware in the same
+`DynStack` runs in list order, outermost first. Each dynamic layer costs one boxed future per call,
+against zero for the static layers, so keep the static chain as the default and reach for `DynStack`
+only where runtime composition earns it.
 
 ## Publish-side middleware
 
@@ -87,6 +157,8 @@ pipeline; see [Publishing and replies](publishing.md#the-publish-pipeline).
 
 ## Built-in layers
 
-- `layers::TracingLayer` emits a tracing span per message.
+- `layers::TracingLayer` emits a tracing event per message (DEBUG on arrival, INFO on ack, WARN on
+  nack). To render those events on the console, enable the `logging` feature; see
+  [Logging](logging.md).
 - The `metrics` feature ships a layer that records Prometheus counters and a duration histogram; see
   [Metrics](metrics.md).

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -75,6 +75,22 @@ The macro reads the descriptor type out of the constructor call, so the compiler
 descriptor against the broker it is mounted on. A descriptor is any type that implements
 `SubscriptionSource<B>`; see [Broker authors](../broker-authors/index.md#subscription-sources).
 
+The source may also be a builder chain on that constructor, so fluent options stay inline. A NATS
+JetStream consumer, for example:
+
+```rust
+use ruststream_nats::SubscribeOptions;
+
+#[subscriber(SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("workers"))]
+async fn handle(order: &Order) -> HandlerResult {
+    HandlerResult::Ack
+}
+```
+
+The macro follows the chain down to the base `Type::new(..)` to name the source type, so each method
+in the chain must return `Self`. Free functions are rejected, since their type is not visible to the
+macro.
+
 ## Mounting handlers
 
 Inside `with_broker`, mount a definition with `include`. It decodes the payload with the default
@@ -201,7 +217,42 @@ RustStream::new(info).with_broker(broker, |b| {
 ```
 
 The application's global middleware (added with `layer`) does not wrap router handlers, since a
-router is finalized independently. Wrap handlers inside the router if you need that.
+router is finalized independently. Give the router its own stack with `Router::layer`, applied to
+every handler registered after it (the same composition as `RustStream::layer`). It changes the
+router's type, so let the builder function's return type follow from it:
+
+```rust title="routes.rs"
+use ruststream::runtime::{Identity, Router, Stack};
+use ruststream::runtime::layers::TracingLayer;
+
+pub fn orders() -> Router<MyBroker, Stack<TracingLayer, Identity>> {
+    let mut router = Router::new().layer(TracingLayer::default());
+    router.include(handle);
+    router.include(other_handler);
+    router
+}
+```
+
+### Composing and mounting
+
+A `Router` mirrors the broker scope: alongside `include` and `include_publishing` it has
+`with_codec` (a per-handler codec, as [above](#where-the-codec-comes-from)) and the manual
+`handle` / `subscribe`. Build routers per module, then combine them however suits the service:
+
+```rust
+// Mount several routers on one broker - include_router can be called more than once.
+RustStream::new(info).with_broker(broker, |b| {
+    b.include_router(routes::orders());
+    b.include_router(routes::shipping());
+});
+
+// Or merge groups into one router before mounting.
+let mut all = routes::orders();
+all.merge(routes::shipping());
+```
+
+`merge` appends another router's registrations in order; the merged router's own layer was already
+baked into its handlers, so the two need not share a middleware stack.
 
 ## Publishers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,9 @@ nav:
   - Guides:
       - guides/subscribers.md
       - guides/publishing.md
+      - guides/lifespan.md
       - guides/middleware.md
+      - guides/logging.md
       - guides/asyncapi.md
       - guides/metrics.md
       - guides/testing.md


### PR DESCRIPTION
Sweeps the documentation for everything added between 0.2.3 and 0.2.5, and aligns the broker-authors pages with the current `ruststream-nats`. All code snippets in the touched pages were compiled against 0.2.5.

## New guides
- **Lifespan and shared state** - the `State` type-map, `insert_state`, the four lifecycle hooks (`on_startup`/`after_startup`/`on_shutdown`/`after_shutdown`), and an end-to-end "pass a database pool through `on_startup`" example.
- **Logging** - the `logging` feature (`logging::init` / the `Logging` builder, CLI auto-init on `run`), and how it differs from the `TracingLayer` middleware.

## Updated guides
- **Middleware** - explains *why* middleware is static by default (`dyn` + `async` does not optimize: a boxed future per layer, no inlining across the `dyn` boundary), with a full `DynMiddleware` + `DynStack` example; documents `Router::layer` for wrapping router handlers.
- **Subscribers** - builder-chain subscriber sources (`#[subscriber(SubscribeOptions::new(..).jetstream(..))]`); the Routers section now covers `Router::layer`, `merge`, and mounting several routers.
- **CLI** - documents `--broker memory|nats|nats-js`; fixes the stale scaffold layout (`routes.rs`, no `stream.rs`).
- **Installation** - adds the `logging` feature row.

## Broker authors
- Rewrites the **NATS worked example** to match the real `ruststream-nats`: async-nats 0.46, the boxed-source error enum, lazy `new`/`connect`/`from_client`, one `SubscribeOptions` descriptor and one `NatsSubscriber` serving both Core and JetStream, the `NatsMessage` enum (`Unsupported` ack for Core, real ack/nak/term for JetStream), header conversion, and `RequestReply`.
- **Conformance** - documents `harness::lifecycle` (the lazy-startup contract) next to `run_suite`, and adds it to the checklist.

## README
- The install snippet now lists `schemars`, which the example derives (the snippet did not compile without it).