### PR TITLE
runtime: drop the derived I: Clone bound on DynStack

### DIFF
--- a/src/runtime/dynstack.rs
+++ b/src/runtime/dynstack.rs
@@ -81,8 +81,15 @@ impl<I> std::fmt::Debug for Next<'_, I> {
 }
 
 /// A [`Layer`] that runs a frozen list of [`DynMiddleware`] before the handler it wraps.
-#[derive(Clone)]
 pub struct DynStack<I>(Arc<[Arc<dyn DynMiddleware<I>>]>);
+
+// Manual impl: `derive(Clone)` would demand `I: Clone`, but the field is an `Arc` and the input
+// type (often a non-Clone broker message) is never cloned.
+impl<I> Clone for DynStack<I> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
 
 impl<I> DynStack<I> {
     /// Builds a stack from a list of middleware, applied in iteration order (first runs outermost).


### PR DESCRIPTION
# Description

`#[derive(Clone)]` on `DynStack<I>` generated `impl<I: Clone> Clone`, demanding `Clone` from the input type even though the only field is an `Arc` and the input is never cloned. Broker message types are typically not `Clone`, so a `DynStack<M>` over raw deliveries could not be composed into the application stack (`RustStream::with_broker` requires `L: Clone`) - the intended way to mount a runtime-built middleware chain.

Replaced the derive with a manual `impl<I> Clone` that clones the `Arc`. Additive: it only removes a bound.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (a why-comment on the manual impl; no public-surface doc changes needed)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable - the new `examples/middleware.rs` in the stacked docs PR composes `DynStack<MemoryMessage>` into the app stack and is the compile-time regression check for this fix