### PR TITLE
docs: restructure guides into sections, embed compiled examples, fact fixes

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -7,6 +7,9 @@ on:
       - docs/**
       - mkdocs.yml
       - overrides/**
+      - examples/**
+      # the testing guide embeds its snippets from these test files
+      - tests/doc_testing_*.rs
       - Cargo.toml
       - .github/workflows/docs-deploy.yml
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - mkdocs.yml
       - overrides/**
       - examples/**
+      # the testing guide embeds its snippets from these test files
+      - tests/doc_testing_*.rs
       - .github/workflows/docs.yml
   pull_request:
     branches: [main]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,10 @@ required-features = ["macros", "json"]
 name = "nats_jetstream"
 required-features = ["macros", "json"]
 
+[[example]]
+name = "nats_request_reply"
+required-features = ["macros"]
+
 [package]
 name = "ruststream"
 version.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,47 @@ name = "quickstart"
 required-features = ["macros", "memory", "json"]
 
 [[example]]
+name = "tutorial"
+path = "examples/tutorial/main.rs"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "subscribers"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "publishing"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "routing"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "codecs"
+required-features = ["macros", "memory", "json", "cbor"]
+
+[[example]]
+name = "middleware"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "middleware_app_scope"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "middleware_router_scope"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "context"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
+name = "lifespan"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
 name = "asyncapi_http"
 required-features = ["macros", "memory", "asyncapi"]
 
@@ -112,7 +153,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-stream = "0.1"
 tempfile = "3"
 axum = "0.8"
-ruststream-nats = "0.2"
+# `testing` pulls the in-memory NATS test broker used by tests/doc_testing_nats.rs (the
+# snippet source for the testing guide).
+ruststream-nats = { version = "0.2", features = ["testing"] }
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ only, so you assert on handler behaviour, middleware, and decoding exactly as in
 
 ## Documentation
 
-- Guide and tutorials: <https://powersemmi.github.io/ruststream/>
+- Guide and tutorials: <https://powersemmi.github.io/ruststream/latest>
 - API reference: <https://docs.rs/ruststream>
-- Writing a broker: <https://powersemmi.github.io/ruststream/broker-authors/>
+- Writing a broker: <https://powersemmi.github.io/ruststream/latest/broker-authors/>
 
 ## Ecosystem
 
@@ -123,4 +123,4 @@ just test     # the test suite
 
 Licensed under the [Apache-2.0](./LICENSE) license.
 
-<sub>Inspired by [FastStream](https://github.com/airtai/faststream).</sub>
+<sub>Inspired by [FastStream](https://github.com/ag2ai/faststream).</sub>

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -37,7 +37,7 @@ async fn passes_conformance() {
 | Scenario | Asserts |
 |---|---|
 | ordering | messages are delivered in publish order |
-| publish after subscribe | a message published before a subscriber attaches is still delivered |
+| publish after subscribe | a subscriber receives only messages published after it attached; earlier publishes are not buffered |
 | ack consumes delivery | an acked message is not redelivered |
 | nack with requeue redelivers | `nack(requeue = true)` delivers the message again |
 | nack without requeue drops | `nack(requeue = false)` does not redeliver |

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -6,72 +6,18 @@ development and tests; production brokers are separate crates you add as a depen
 Handlers, routers, codecs, and middleware are broker-agnostic, so moving between brokers is a
 one-line change at `with_broker`.
 
-## In-memory (built-in)
+| Broker | Crate | Transport |
+|---|---|---|
+| [Memory](memory.md) | `ruststream` (feature `memory`) | in-process, for development and tests |
+| [NATS](nats.md) | [`ruststream-nats`](https://github.com/powersemmi/ruststream-nats) | Core NATS and JetStream |
 
-The `memory` feature provides `MemoryBroker`, an in-process broadcast broker. It needs no external
-service, which makes it ideal for examples, unit tests, and prototypes.
-
-```toml
-ruststream = { version = "0.2", features = ["macros", "memory"] }
-```
-
-```rust
-use ruststream::memory::MemoryBroker;
-
-let broker = MemoryBroker::new();
-```
-
-It does core routing only and does not emulate any real broker's delivery semantics. See
-[Testing](../guides/testing.md).
-
-## NATS
-
-[`ruststream-nats`](https://github.com/powersemmi/ruststream-nats) is the NATS broker. It covers
-Core NATS subjects and JetStream durable consumers.
-
-```toml
-ruststream = { version = "0.2", features = ["macros"] }
-ruststream-nats = "0.2"
-serde = { version = "1", features = ["derive"] }
-```
-
-`NatsBroker::new` is synchronous and does no I/O, so a NATS service is assembled with the same
-`#[ruststream::app]` macro as any other broker. The runtime connects the broker once at startup,
-before opening subscriptions.
-
-### Core subscription
-
-A `#[subscriber("subject")]` handler binds straight to a NATS subject:
-
-```rust
---8<-- "examples/nats_core.rs:handler"
-```
-
-Wire it onto the broker; the `with_broker` / `include` part is identical to the in-memory broker.
-
-```rust
---8<-- "examples/nats_core.rs:app"
-```
-
-### JetStream durable consumer
-
-To consume from JetStream instead, override the handler's by-name source with `SubscribeOptions`,
-naming the stream and a durable consumer so progress survives restarts. The handler's
-`HandlerResult::Ack` acks back to JetStream. `include_on` is the source-override form, so it takes
-the codec explicitly.
-
-```rust
---8<-- "examples/nats_jetstream.rs:include_on"
-```
-
-See the crate's documentation for connection options, authentication, and JetStream configuration.
-For how a NATS broker implements the contract from the inside, read the
-[worked example](../broker-authors/example-nats.md).
+To implement a broker for another transport, see [Broker authors](../broker-authors/index.md).
 
 ## Switching brokers
 
-The same handlers and routers run on either broker, and both build synchronously, so only the
-broker construction differs by one line inside `with_broker`.
+Every broker constructs synchronously and connects lazily (the runtime calls `Broker::connect` once
+at startup), so the same handlers and routers run on any of them; only the broker construction
+differs by one line inside `with_broker`.
 
 === "Memory"
 
@@ -100,3 +46,7 @@ broker construction differs by one line inside `with_broker`.
             })
     }
     ```
+
+Subscriptions that need broker-specific options (consumer groups, durable names) use that broker's
+descriptor in the `#[subscriber(..)]` decorator; see
+[broker-specific descriptors](../guides/subscribers.md#broker-specific-descriptors).

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -1,0 +1,49 @@
+# Memory
+
+The `memory` feature provides `MemoryBroker`, an in-process broker. It needs no external service,
+which makes it ideal for examples, unit tests, and prototypes; the CLI scaffold uses it by default
+so a fresh project runs with zero dependencies.
+
+```toml
+ruststream = { version = "0.2", features = ["macros", "memory", "json"] }
+```
+
+```rust
+use ruststream::memory::MemoryBroker;
+
+let broker = MemoryBroker::new();
+```
+
+## Semantics
+
+- **Exact name matching.** A subscription to `orders` receives messages published to `orders`; no
+  wildcard or pattern matching (those are broker-specific; the NATS test broker has real subject
+  matching).
+- **Fan-out.** Every subscriber of a name receives every message published to it after the
+  subscription opened; messages published earlier are not buffered.
+- **Ack is a no-op; `nack(requeue: true)` redelivers** the same payload to the same subscriber.
+- **Cheap to clone.** Clones share state, so a clone held by a test observes everything the app
+  publishes.
+
+It does core routing only and does not emulate any real broker's delivery semantics (durable
+cursors, redelivery timers, partitions, dead-letter routing).
+
+## Subscription source
+
+`MemoryBroker` implements `Subscribe`, so `#[subscriber("orders")]` works directly. Its descriptor
+type is `MemorySource` - it carries no extra options (the in-memory broker has none) but keeps the
+descriptor form uniform across brokers. From the
+[`routed_service`](https://github.com/powersemmi/ruststream/tree/main/examples/routed_service)
+example:
+
+```rust
+use ruststream::memory::MemorySource;
+
+--8<-- "examples/routed_service/orders.rs:descriptor"
+```
+
+## As a test client
+
+`MemoryBroker` implements the `TestClient` trait itself: `MemoryBroker::start()` gives a client
+whose `publish` and `expect_published` drive and observe the broker from the outside. See
+[Testing](../guides/testing.md#testing-handlers-with-memorybroker) for the full pattern.

--- a/docs/brokers/nats.md
+++ b/docs/brokers/nats.md
@@ -54,7 +54,28 @@ I/O. See the crate's documentation for connection options and authentication.
 ## Request-reply
 
 NATS supports request-reply natively, so `NatsPublisher` implements the `RequestReply` capability:
-`request(msg, timeout)` publishes with a reply inbox and resolves with the reply message.
+`request(msg, timeout)` publishes with a reply inbox and resolves with the reply message, or fails
+with a timeout error when nothing answers in time:
+
+```rust
+use std::time::Duration;
+
+use ruststream::{IncomingMessage, OutgoingMessage, RequestReply};
+
+--8<-- "examples/nats_request_reply.rs:request"
+```
+
+Any NATS responder answers it: another service, or `nats reply questions 'pong'` from the CLI. The
+runnable program is
+[`examples/nats_request_reply.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/nats_request_reply.rs) -
+it sends the request from an `after_startup` hook, through a publisher built before `connect` (the
+lazy-startup contract resolves the connection on first use).
+
+The in-memory test broker implements `RequestReply` too, and additionally hands the request's
+reply inbox to handlers as the `reply-to` header, so a responder is testable in-process: read
+`ctx.headers().reply_to()` and publish the answer to that subject. Against a real server the
+requester side above is fully supported; the reply inbox of an *incoming* request is not yet
+exposed to handlers, so the responder end of an RPC pair is today another NATS service.
 
 ## Testing
 

--- a/docs/brokers/nats.md
+++ b/docs/brokers/nats.md
@@ -1,0 +1,70 @@
+# NATS
+
+[`ruststream-nats`](https://github.com/powersemmi/ruststream-nats) is the NATS broker. It covers
+Core NATS subjects and JetStream durable consumers, and ships an in-memory test broker under its
+`testing` feature.
+
+```toml
+ruststream = { version = "0.2", features = ["macros"] }
+ruststream-nats = "0.2"
+serde = { version = "1", features = ["derive"] }
+```
+
+`NatsBroker::new` is synchronous and does no I/O, so a NATS service is assembled with the same
+`#[ruststream::app]` macro as any other broker. The runtime connects the broker once at startup,
+before opening subscriptions.
+
+## Core subscription
+
+A `#[subscriber("subject")]` handler binds straight to a NATS subject:
+
+```rust
+--8<-- "examples/nats_core.rs:handler"
+```
+
+Wire it onto the broker; the `with_broker` / `include` part is identical to the in-memory broker.
+
+```rust
+--8<-- "examples/nats_core.rs:app"
+```
+
+## JetStream durable consumer
+
+To consume from JetStream instead, override the handler's by-name source with `SubscribeOptions`,
+naming the stream and a durable consumer so progress survives restarts. The handler's
+`HandlerResult::Ack` acks back to JetStream. `include_on` is the source-override form, so it takes
+the codec explicitly.
+
+```rust
+--8<-- "examples/nats_jetstream.rs:include_on"
+```
+
+The `SubscribeOptions` builder also sits directly in the `#[subscriber(..)]` decorator (the macro
+follows the chain), which is what the `nats-js` CLI scaffold generates:
+
+```rust
+--8<-- "examples/nats_jetstream.rs:decorator"
+```
+
+Beyond `jetstream` and `durable`, the builder carries `queue_group` (Core NATS load balancing),
+`filter_subject`, `ack_wait`, `max_ack_pending`, and `deliver_policy`. Incompatible combinations
+(for example `queue_group` together with `jetstream`) are rejected with a clear error before any
+I/O. See the crate's documentation for connection options and authentication.
+
+## Request-reply
+
+NATS supports request-reply natively, so `NatsPublisher` implements the `RequestReply` capability:
+`request(msg, timeout)` publishes with a reply inbox and resolves with the reply message.
+
+## Testing
+
+The `testing` feature ships `NatsTestBroker` / `NatsTestClient`: an in-process broker with real
+NATS subject matching (`*` and `>` wildcards), header propagation, and request-reply - no
+`nats-server`, no docker. See
+[Testing against in-memory NATS](../guides/testing.md#testing-handlers-against-in-memory-nats).
+
+JetStream edge cases (durable resume, `ack_wait` redelivery, retention) are not simulated; test
+them against a real server, gated behind `NATS_TEST_URL`.
+
+For how this broker implements the contract from the inside, read the
+[worked example](../broker-authors/example-nats.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,7 +34,8 @@ always compiled. Everything else is an additive, opt-in feature.
 | `conformance` | - | the broker-author conformance harness |
 | `cli` | clap, anyhow | the `ruststream` binary |
 
-Codec features are mutually compatible; enable as many as you need. To drop the bundled JSON codec
+Codec features are mutually compatible; enable as many as you need (see
+[Codecs](../guides/codecs.md)). To drop the bundled JSON codec
 (for a broker crate that only needs the trait surface and runtime), disable defaults:
 
 ```toml
@@ -59,9 +60,14 @@ The `memory` broker is for local development and tests. For production, depend o
 which re-exports what it needs from `ruststream`:
 
 ```toml
-# illustrative - substitute the real broker crate
+[dependencies]
+ruststream-nats = "0.2"
+
+[dev-dependencies]
+# the broker's in-memory test client, for handler tests
 ruststream-nats = { version = "0.2", features = ["testing"] }
 ```
 
-Each broker crate documents its own `Config` and capabilities. To write one yourself, see
+Each broker crate documents its own `Config` and capabilities; the available brokers are listed
+under [Brokers](../brokers/index.md). To write one yourself, see
 [Broker authors](../broker-authors/index.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,8 +18,7 @@ my-service/
 └── src/
     ├── main.rs      # #[ruststream::app] builds the service and mounts the router
     ├── orders.rs    # handlers as #[subscriber] functions (one publishes a reply)
-    ├── routes.rs    # collects the handlers into a Router
-    └── stream.rs    # a broker-specific subscription descriptor
+    └── routes.rs    # collects the handlers into a Router
 ```
 
 ## Run it
@@ -45,20 +44,7 @@ ruststream asyncapi gen --yaml
 ## What the entry point looks like
 
 ```rust title="src/main.rs"
-mod orders;
-mod routes;
-mod stream;
-
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, RustStream};
-
-#[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("my-service", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
-        let router = routes::orders(b.broker());
-        b.include_router(router);
-    })
-}
+--8<-- "examples/tutorial/main.rs:main"
 ```
 
 You write a function that builds the service; the macro turns it into a `main` that dispatches
@@ -67,5 +53,5 @@ You write a function that builds the service; the macro turns it into a `main` t
 ## Next
 
 - Understand each piece in the [tutorial](tutorial.md).
-- Learn the handler forms in [Subscribers & publishers](../guides/subscribers.md).
+- Learn the handler forms in [Subscribers](../guides/subscribers.md).
 - Drive everything from the [CLI](../guides/cli.md).

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -30,40 +30,26 @@ turns it into a mountable definition named after the function.
 ```rust title="src/orders.rs"
 use ruststream::runtime::HandlerResult;
 use ruststream::subscriber;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
-pub struct Order {
-    pub id: u64,
-    pub quantity: u32,
-}
-
-#[subscriber("orders")]
-pub async fn handle(order: &Order) -> HandlerResult {
-    println!("order {} x{}", order.id, order.quantity);
-    HandlerResult::Ack
-}
+--8<-- "examples/tutorial/orders.rs:order"
 ```
 
 A handler returns a [`HandlerResult`](../guides/subscribers.md#acking): `Ack`, or a `nack` that drops
-or requeues the message. Returning `()` or `Result<_, E>` also works - they convert into a result.
+or requeues the message. Returning `()` or `Result<(), E>` also works - they convert into a result
+(`Ok` acks, `Err` drops).
 
 ## 3. Wire it into an app
 
 ```rust title="src/main.rs"
 mod orders;
 
-use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, RustStream};
 
 use crate::orders::handle;
 
-#[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("orders-service", "0.1.0"))
-        .with_broker(MemoryBroker::new(), |b| b.include(handle))
-}
+--8<-- "examples/quickstart.rs:app"
 ```
 
 The macro turns `handle` into a value named after the function, so you import and pass it directly.
@@ -71,7 +57,8 @@ The macro turns `handle` into a value named after the function, so you import an
 !!! tip "Codec defaults"
     `include` decodes with the default codec - `json` if enabled, otherwise `cbor`, otherwise
     `msgpack` - so it needs no codec argument. To decode with a different one everywhere, set it
-    once with `with_broker_codec(broker, codec, |b| ...)`.
+    once with `with_broker_codec(broker, codec, |b| ...)`. See
+    [Codecs](../guides/codecs.md) for the full resolution rules.
 
 Run it:
 
@@ -84,18 +71,7 @@ cargo run -- run
 To publish a reply, return the reply value and name the destination with `publish(..)`:
 
 ```rust title="src/orders.rs"
-use serde::Serialize;
-
-#[derive(Debug, Serialize)]
-pub struct Confirmation {
-    pub id: u64,
-    pub accepted: bool,
-}
-
-#[subscriber("orders", publish("confirmations"))]
-pub async fn confirm(order: &Order) -> Confirmation {
-    Confirmation { id: order.id, accepted: order.quantity > 0 }
-}
+--8<-- "examples/tutorial/orders.rs:confirm"
 ```
 
 Mount it with a publisher that carries the reply codec:
@@ -114,32 +90,14 @@ inside a handler.
 ## 5. Organize with a router
 
 As handlers grow, keep them in their own module and collect them into a
-[`Router`](../guides/subscribers.md#routers):
+[`Router`](../guides/routing.md):
 
 ```rust title="src/routes.rs"
-use ruststream::codec::JsonCodec;
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{Router, TypedPublisher};
-
-use crate::orders;
-
-pub fn orders(broker: &MemoryBroker) -> Router<MemoryBroker> {
-    let replies = TypedPublisher::new(broker.publisher());
-    let mut router = Router::new();
-    router.include_publishing(orders::confirm, replies);
-    router.include(orders::handle);
-    router
-}
+--8<-- "examples/tutorial/routes.rs:routes"
 ```
 
 ```rust title="src/main.rs"
-#[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("orders-service", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
-        let router = routes::orders(b.broker());
-        b.include_router(router);
-    })
-}
+--8<-- "examples/tutorial/main.rs:main"
 ```
 
 ## 6. Inspect the AsyncAPI document
@@ -181,11 +139,18 @@ line:
 
 Each broker crate documents its own `Config`. Subscriptions that need broker-specific options
 (consumer groups, durable names) use that broker's descriptor in the decorator, see
-[Subscribers & publishers](../guides/subscribers.md#broker-specific-descriptors). The available
+[broker-specific descriptors](../guides/subscribers.md#broker-specific-descriptors). The available
 brokers are listed under [Brokers](../brokers/index.md).
+
+!!! info "The complete service is a compiled example"
+    Every snippet on this page is embedded from
+    [`examples/tutorial`](https://github.com/powersemmi/ruststream/tree/main/examples/tutorial)
+    in the repository, which CI builds on every change. Run it yourself with
+    `cargo run --example tutorial --features macros,memory,json -- run`.
 
 ## Next steps
 
 - [Middleware](../guides/middleware.md) - cross-cutting logic around handlers.
+- [Lifespan](../guides/lifespan.md) - shared state and startup/shutdown hooks.
+- [Testing](../guides/testing.md) - test the handlers you just wrote, in-process.
 - [Metrics](../guides/metrics.md) - Prometheus counters and histograms.
-- [Testing](../guides/testing.md) - the in-memory test client.

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -43,13 +43,18 @@ document.
 ## Servers
 
 Record the servers your service connects to so they appear in the document's `servers` section.
-Build a `ServerSpec` directly, or get one from a broker that implements `DescribeServer`:
+Build a `ServerSpec` directly:
 
 ```rust
+use ruststream::ServerSpec;
+
 let app = RustStream::new(info)
-    .server("production", broker.describe_server())
+    .server("production", ServerSpec::new("nats.example.com:4222", "nats"))
     .with_broker(broker, |b| b.include(handle));
 ```
+
+A broker crate may also implement the `DescribeServer` capability, in which case
+`broker.describe_server()` produces the spec for you (none of the shipped brokers do yet).
 
 ## Serving the document
 
@@ -66,7 +71,8 @@ let html = render_viewer_html("/asyncapi.json", &ViewerOptions::default());
 ```
 
 Serve that HTML and the spec JSON from two routes in your own server. By default the viewer loads its
-assets from a CDN; override the URLs through `ViewerOptions` for offline or locked-down deployments.
+assets from a CDN; override the base URL with `ViewerOptions::with_cdn_base` for offline or
+locked-down deployments (`with_title` sets the page title).
 
 ## A complete server
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -37,11 +37,7 @@ a crate other than the working directory.
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, RustStream};
 
-#[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("my-service", "0.1.0"))
-        .with_broker(MemoryBroker::new(), |b| { /* mount handlers */ })
-}
+--8<-- "examples/quickstart.rs:app"
 ```
 
 Because the dispatch lives in the generated binary, both `ruststream run` and a plain

--- a/docs/guides/codecs.md
+++ b/docs/guides/codecs.md
@@ -1,0 +1,92 @@
+# Codecs and serialization
+
+A codec turns wire bytes into your typed payload and back. It is a separate seam from the broker:
+the pipeline on the consume side is `bytes -> Codec -> typed payload -> handler`, and the publish
+side runs it in reverse. Codecs are compile-time types, so decoding has no dynamic dispatch.
+
+## Built-in codecs
+
+| Codec | Feature | Pulls in | Wire format |
+|---|---|---|---|
+| `JsonCodec` | `json` *(default)* | serde_json | JSON |
+| `MsgpackCodec` | `msgpack` | rmp-serde | MessagePack |
+| `CborCodec` | `cbor` | ciborium | CBOR |
+
+Codec features are strictly additive; enable as many as you need. Message types only need to derive
+`serde::Deserialize` (and `Serialize` for replies).
+
+## The default codec
+
+`DefaultCodec` is a feature-selected alias: `json` if enabled, otherwise `cbor`, otherwise
+`msgpack`. It is what `include(def)` and `TypedPublisher::new(publisher)` use when nothing names a
+codec, which is why neither takes a codec argument. It exists only when at least one codec feature
+is enabled; with no codec features, only the explicit-codec methods are available.
+
+## Where the decode codec comes from
+
+The decode codec is fixed at compile time. `include` takes no codec argument; it resolves one from
+the most specific level you set, from narrowest to widest:
+
+### Per handler
+
+Override a single mounting:
+
+=== "Router"
+
+    ```rust
+    router.with_codec(CborCodec).include(handle);
+    ```
+
+=== "with_broker"
+
+    ```rust
+    --8<-- "examples/codecs.rs:per_handler"
+    ```
+
+### Per scope
+
+Set one codec for every handler in a `with_broker` scope:
+
+```rust
+use ruststream::codec::CborCodec;
+
+--8<-- "examples/codecs.rs:scope"
+```
+
+### Default
+
+When nothing above names a codec, `include` uses [`DefaultCodec`](#the-default-codec).
+
+## The publish side
+
+Publishers mirror the same rules: `TypedPublisher::new(publisher)` encodes replies with the default
+codec, and `TypedPublisher::with_codec(publisher, codec)` names one. `include_publishing(def,
+publisher)` reuses the publisher's codec to decode the incoming request, so one mounting names one
+codec. The request and reply formats can still differ: mount with `include_publishing_on` and name
+the decode codec explicitly.
+
+There is no per-message-type codec (no associated codec on a message trait): the codec is a
+property of the mounting, not of the type.
+
+## Decode failures
+
+When decoding fails, the message is dropped by default (a nack without requeue). The policy is
+configurable on the typed adapter when you build handlers by hand: `typed(codec, handler)` returns
+a `Typed` wrapper whose `on_decode_failure` accepts a `DecodeFailure` mode (`Drop` or `Requeue`).
+
+```rust
+use ruststream::runtime::{DecodeFailure, typed};
+
+// inside with_broker(...):
+--8<-- "examples/codecs.rs:decode_failure"
+```
+
+Requeue with care: a payload that can never decode will redeliver forever unless the broker has a
+dead-letter or max-deliveries policy. The codec examples above are
+[`examples/codecs.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/codecs.rs).
+
+## Custom codecs
+
+A codec is any type implementing the `Codec` trait, so you can supply your own (a schema-registry
+envelope, an encrypting wrapper) and pass it anywhere a built-in codec goes: `include_on`,
+`with_broker_codec`, `Router::with_codec`, or `TypedPublisher::with_codec`.

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -1,0 +1,109 @@
+# Context and state
+
+Everything a handler can reach besides its payload arrives through two objects with different
+lifetimes:
+
+| Level | Type | Lives for | Holds |
+|---|---|---|---|
+| Application | `State` | the whole service | shared resources: pools, clients, configuration |
+| Delivery | `Context` | one message | the channel name, a headers working copy, access to `State` and named publishers |
+
+`State` is filled once, at startup. A `Context` is built fresh for every delivery and threaded as
+`&mut` through the middleware chain into the handler, so middleware and the handler observe (and
+can enrich) the same per-message view.
+
+## Application level: `State`
+
+`State` is a type-map: one value per type, `Send + Sync`. Two ways to fill it:
+
+- **At build time** with `RustStream::insert_state(value)` - for values that need no async work
+  (parsed configuration, a constructed client).
+- **In an `on_startup` hook** with `state.insert(value)` - for resources that need `await` to
+  create (a database pool). See [Lifespan](lifespan.md) for the hook contract.
+
+Inserting a second value of the same type replaces the first. Handlers read it through the context
+with `ctx.get::<T>()`, which returns `Option<&T>` - `None` only if nothing of that type was
+inserted. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
+references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when
+a shared value must change at runtime.
+
+```rust
+--8<-- "examples/context.rs:state"
+```
+
+## Delivery level: `Context`
+
+A `#[subscriber]` handler opts in by declaring a second parameter after the payload; omit it when
+the handler needs nothing but the message. The macro resolves the type itself, so `Context` needs
+no import when it appears only in handler signatures:
+
+```rust
+--8<-- "examples/context.rs:handler"
+```
+
+What the context exposes:
+
+| Method | Returns | Purpose |
+|---|---|---|
+| `name()` | `&str` | the channel / subject the message arrived on |
+| `headers()` | `&Headers` | the working copy of the message headers |
+| `headers_mut()` | `&mut Headers` | the same copy, for middleware to enrich |
+| `get::<T>()` | `Option<&T>` | shared application state |
+| `publisher(name)` | `Option<ScopedPublisher>` | a [named publisher](publishing.md#publishing-from-inside-a-handler) |
+
+Closure handlers (the manual `typed(codec, |msg, ctx| ...)` form) always take the context as their
+second argument.
+
+## The headers working copy
+
+`ctx.headers()` is not the broker message itself: each delivery clones the incoming headers into a
+working copy that lives in the context. That makes it a scratchpad for the dispatch chain -
+middleware earlier in the chain can stamp values onto it with `headers_mut()`, and the handler
+reads the enriched result:
+
+```rust
+--8<-- "examples/context.rs:enrich"
+```
+
+Mounted globally, the layer runs before every handler, so `handle` above always finds
+`x-request-id`:
+
+```rust
+--8<-- "examples/context.rs:app"
+```
+
+Two boundaries to keep in mind:
+
+- Mutations stay within the delivery: the broker message and other subscribers' deliveries are
+  untouched.
+- Outgoing messages do not inherit the copy. Replies and manual publishes start from fresh
+  headers; attach outgoing metadata in the [publish pipeline](publishing.md#the-publish-pipeline)
+  (a `PublishLayer` or `PublishMiddleware`) instead.
+
+## Publishing through the context
+
+`ctx.publisher("name")` resolves a publisher registered with `RustStream::publisher(name, p)` and
+returns `None` when nothing is registered under that name. Sends through it run the application's
+dynamic publish middleware - the same chain as a macro reply - so a manual publish is not a hole
+in the pipeline:
+
+```rust
+--8<-- "examples/publishing.rs:forward"
+```
+
+A closure handler cannot return a future that borrows the context across `.await`; publish from a
+`#[subscriber]` handler or a struct handler with `async fn handle`, both of which own the borrow.
+See [Publishing](publishing.md#publishing-from-inside-a-handler).
+
+## Context in middleware
+
+Every middleware form receives the same `&mut Context` the handler will see, which is what makes
+the enrichment pattern work:
+
+- A static layer's `Handler::handle(&self, msg, ctx)` - as in the example above.
+- A dynamic `DynMiddleware::handle(&self, input, ctx, next)` - inspect or enrich, then
+  `next.run(input, ctx)`.
+
+The middleware forms themselves are covered in [Middleware](middleware.md). The full program for
+this page is
+[`examples/context.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/context.rs).

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -7,7 +7,7 @@ plus lifecycle hooks that run at fixed points around the run loop.
 ## Shared state
 
 `State` is a type-map: one value per type. Put ready-made values in at build time with
-`insert_state`, and read them from any handler or middleware through the `Context`:
+`insert_state` (or from a [startup hook](#lifecycle-hooks), as the `Database` below is):
 
 ```rust
 RustStream::new(info)
@@ -15,22 +15,19 @@ RustStream::new(info)
     .with_broker(broker, |b| b.include(handle));
 ```
 
-```rust
-use ruststream::runtime::{Context, HandlerResult};
+Read them from any handler or middleware through the `Context`:
 
-#[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let config = ctx.get::<Config>().expect("config inserted at build time");
-    // ... use config ...
-    HandlerResult::Ack
-}
+```rust
+--8<-- "examples/lifespan.rs:handler"
 ```
 
 `ctx.get::<T>()` returns `Option<&T>`; it is `None` only if no value of that type was inserted.
 Inserting the same type again replaces the previous value.
 
 A `#[subscriber]` handler opts into the context by taking a second parameter, `ctx: &mut Context`,
-after the payload. Omit it when the handler does not need state.
+after the payload. Omit it when the handler does not need state. Everything else the context
+carries (the headers working copy, named publishers) is covered in
+[Context and state](context.md).
 
 ## Lifecycle hooks
 
@@ -38,21 +35,22 @@ Anything that needs `async` work (connecting that pool, closing it cleanly) goes
 hooks bracket the run loop:
 
 ```text
-on_startup(State) -> State     # before brokers connect; build async resources
+on_startup(State) -> State       # before brokers connect; build async resources
   -> brokers connect, subscriptions open
-after_startup(&State)          # handlers are live; publish a first message, signal readiness
+after_startup(Arc<State>)        # handlers are live; publish a first message, signal readiness
   ... running ...
   -> shutdown triggered (signal, or the run_until future resolves)
-on_shutdown(&State)            # brokers still connected
+on_shutdown(Arc<State>)          # brokers still connected
   -> brokers shut down, in-flight handlers drained
-after_shutdown(&State)         # final teardown
+after_shutdown(Arc<State>)       # final teardown
 ```
 
 - **`on_startup`** receives the `State` **by value** and returns it, so its future can own the state
   across awaits - connect a resource, insert it, hand the state back. A failing `on_startup` aborts
-  startup.
-- **`after_startup`** runs once handlers are spawned. Use it to publish an initial message or signal
-  readiness. A failure here also aborts startup.
+  startup. The later hooks receive the state as a shared `Arc<State>`.
+- **`after_startup`** runs once subscriptions are open and handlers are live. Use it to publish an
+  initial message or signal readiness (the [testing guide](testing.md) uses it as the "handlers are
+  live" gate). A failure here also aborts startup.
 - **`on_shutdown`** runs when shutdown begins, while brokers are still connected.
 - **`after_shutdown`** runs after brokers are down, for final async teardown.
 
@@ -62,53 +60,24 @@ runs to completion. Hooks of the same kind run in registration order.
 ## Passing a database connection
 
 The common case: open a pool before serving, share it with every handler, close it on the way out.
+The `Database` below is a stand-in for any async resource - a `sqlx::PgPool` or an HTTP client
+slots in the same way, only its `connect` / `close` calls differ:
 
 ```rust
-use ruststream::runtime::{AppInfo, Context, HandlerResult, RustStream};
-use sqlx::PgPool;
-
-#[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let pool = ctx.get::<PgPool>().expect("pool inserted in on_startup");
-    if sqlx::query("insert into orders (id) values ($1)")
-        .bind(order.id as i64)
-        .execute(pool)
-        .await
-        .is_err()
-    {
-        return HandlerResult::retry();
-    }
-    HandlerResult::Ack
-}
-
-#[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("orders", "0.1.0"))
-        // before connect: open the pool and put it in shared state
-        .on_startup(|mut state| async move {
-            let pool = PgPool::connect("postgres://localhost/orders").await?;
-            state.insert(pool);
-            Ok::<_, sqlx::Error>(state)
-        })
-        // after shutdown: close it cleanly
-        .after_shutdown(|state| async move {
-            if let Some(pool) = state.get::<PgPool>() {
-                pool.close().await;
-            }
-            Ok::<_, sqlx::Error>(())
-        })
-        .with_broker(broker, |b| b.include(handle))
-}
+--8<-- "examples/lifespan.rs:hooks"
 ```
 
 The hook's error type is inferred from the `Ok::<_, E>(..)` annotation; it only needs to implement
-`std::error::Error + Send + Sync`. The pool is `Clone` and `Send + Sync`, so every concurrent handler
-borrows the one instance from `State` - no per-message connection setup.
+`std::error::Error + Send + Sync`. The resource is `Clone` and `Send + Sync`, so every concurrent
+handler borrows the one instance from `State` - no per-message connection setup. The runnable
+program is
+[`examples/lifespan.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/lifespan.rs).
 
 ## Shutdown timeout
 
 By default `run` waits indefinitely for in-flight handlers to finish after shutdown is triggered.
-Bound that wait with `shutdown_timeout`; handlers still running after it are aborted:
+Bound that wait with `shutdown_timeout`, as the example above does; handlers still running after it
+are aborted:
 
 ```rust
 use std::time::Duration;

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -26,8 +26,8 @@ collect into an existing registry instead of a fresh one, use `Metrics::with_reg
 | `ruststream_consume_duration_seconds` | histogram | `name` |
 | `ruststream_messages_published_total` | counter | `name`, `status` |
 
-`name` is the subscription or destination name; `status` is the outcome (`ack`, `requeue`, `drop`
-for consume; `ok`, `error` for publish).
+`name` is the subscription or destination name; `status` is the outcome (`ack` or `nack` for
+consume; `ok` or `error` for publish).
 
 ## Exporting
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,35 +1,45 @@
 # Middleware
 
 Middleware wraps handlers with cross-cutting logic: tracing, metrics, auth, retries. RustStream has
-two middleware levels, both built on the same `Layer` machinery, applied at different points in the
+two middleware scopes, both built on the same `Layer` machinery, applied at different points in the
 dispatch path.
 
-## Global middleware
+## Middleware scopes
 
-Add a layer to the whole application with `layer`, before `with_broker`. Every handler registered on
-a broker scope is wrapped with it.
+Today the two scopes are independent: a layer lives either on the **application** or on a
+**router**, and one does not see the other's handlers.
+
+**Application scope.** Add a layer to the whole application with `RustStream::layer`, before
+`with_broker`. Every handler registered directly on a broker scope is wrapped with it - but not the
+handlers a router brings in, because a router is finalized independently:
 
 ```rust
-use ruststream::runtime::layers::TracingLayer;
-
-let app = RustStream::new(info)
-    .layer(TracingLayer::default())
-    .with_broker(broker, |b| b.include(handle));
+--8<-- "examples/middleware_app_scope.rs:app_scope"
 ```
 
-The first layer added is the outermost. The global stack is static: it has zero runtime dispatch
-cost, and its type grows as you call `layer`.
+**Router scope.** Give a router its own middleware with `Router::layer`, which wraps every handler
+registered on it after the call (see [Routing](routing.md#router-middleware)). Handlers mounted
+directly on the broker scope stay outside it:
 
-!!! note "Routers carry their own stack"
-    The global stack does not wrap handlers brought in via `include_router`, because a router is
-    finalized independently. Give the router its own middleware with `Router::layer`, which wraps
-    every handler registered after it:
+```rust
+--8<-- "examples/middleware_router_scope.rs:router_scope"
+```
 
-    ```rust
-    let mut router = Router::new().layer(TracingLayer::default());
-    router.include(handle);
-    b.include_router(router);
-    ```
+The two programs are
+[`middleware_app_scope.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/middleware_app_scope.rs)
+and
+[`middleware_router_scope.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/middleware_router_scope.rs);
+`LogLayer` is the hand-written layer from the next section, and the built-in
+`layers::TracingLayer` mounts the same way.
+
+!!! warning "Planned for 0.3: routers inherit the application scope"
+    The separation above is the 0.2 behaviour. In 0.3 a router will inherit the application's
+    stack, so app-level layers will wrap router handlers too (composing outside the router's own
+    `Router::layer` stack). Until then, a layer that must cover everything has to be added in both
+    places explicitly.
+
+The first layer added is the outermost. Both stacks are static: zero runtime dispatch cost, and
+the type grows as you call `layer`.
 
 ## Writing a layer
 
@@ -38,28 +48,13 @@ A layer transforms one handler into another. Implement `Layer<H>`:
 ```rust
 use ruststream::runtime::{Context, Handler, HandlerResult, Layer};
 
-struct LogLayer;
-
-struct Logged<H>(H);
-
-impl<H> Layer<H> for LogLayer {
-    type Handler = Logged<H>;
-    fn layer(&self, inner: H) -> Logged<H> {
-        Logged(inner)
-    }
-}
-
-impl<M, H: Handler<M>> Handler<M> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
-        // pre
-        let result = self.0.handle(msg, ctx).await;
-        // post
-        result
-    }
-}
+--8<-- "examples/middleware.rs:layer_impl"
 ```
 
 `Identity` is the no-op layer (the default global stack), and `Stack<Inner, Outer>` composes two.
+The `ctx` here is the same per-delivery [`Context`](context.md) the handler receives, so a layer
+can enrich the [headers working copy](context.md#the-headers-working-copy) before the handler
+reads it.
 
 ## Per-handler middleware
 
@@ -102,53 +97,34 @@ use std::pin::Pin;
 
 use ruststream::runtime::{Context, DynMiddleware, HandlerResult, Next};
 
-struct Audit {
-    service: String,
-}
-
-impl<I: Send + Sync> DynMiddleware<I> for Audit {
-    fn handle<'a>(
-        &'a self,
-        input: &'a I,
-        ctx: &'a mut Context<'_>,
-        next: Next<'a, I>,
-    ) -> Pin<Box<dyn Future<Output = HandlerResult> + Send + 'a>> {
-        Box::pin(async move {
-            tracing::info!(service = %self.service, channel = ctx.name(), "handling");
-            next.run(input, ctx).await
-        })
-    }
-}
+--8<-- "examples/middleware.rs:dyn_middleware"
 ```
 
-Build the chain at runtime and fold it into a single `DynStack`, which is itself an ordinary
-`Layer` - apply it with `with`, `Router::layer`, or the global `layer`. Here it wraps one handler,
-running on the decoded `Order`:
+Only the *list* is dynamic. Build it at runtime, freeze it into a `DynStack`, and the result is an
+ordinary static `Layer` - compose it into the application stack with `layer`, exactly like a
+hand-written one. The rest of the dispatch chain stays static; the boxing cost is paid only inside
+the stack:
 
 ```rust
 use std::sync::Arc;
 
-use ruststream::codec::JsonCodec;
-use ruststream::runtime::{DynStack, HandlerExt, HandlerMetadata, typed};
+use ruststream::memory::MemoryMessage;
+use ruststream::runtime::DynStack;
 
-// inside with_broker(...):
-let subscriber = b.broker().subscribe("orders");
-
-let mut middleware: Vec<Arc<dyn DynMiddleware<Order>>> = Vec::new();
-if config.audit {
-    middleware.push(Arc::new(Audit { service: "orders".to_owned() }));
-}
-let stack = DynStack::new(middleware); // empty list -> a no-op layer
-
-let handler = (|order: &Order, _ctx: &mut Context| async { HandlerResult::Ack }).with(stack);
-b.handle(subscriber, typed(JsonCodec, handler), HandlerMetadata::typed::<Order>("orders"));
+--8<-- "examples/middleware.rs:dyn_stack"
 ```
 
-`DynStack<I>` is generic over the input it wraps: build it over the decoded type (`DynStack<Order>`)
-to run after decoding, or over the broker's raw message type to run before. Middleware in the same
-`DynStack` runs in list order, outermost first. Each dynamic layer costs one boxed future per call,
-against zero for the static layers, so keep the static chain as the default and reach for `DynStack`
-only where runtime composition earns it.
+The full program, with the chain toggled by an environment variable, is
+[`examples/middleware.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/middleware.rs).
+
+`DynStack<I>` is generic over the input it wraps. In the application stack it wraps the whole
+decoding handler, so it is built over the broker's raw message type (`DynStack<MemoryMessage>`
+above) and runs before decoding - a middleware generic over `I`, like `Audit`, works at either
+level. To run on the decoded value instead, build a `DynStack<Order>` and apply it to the inner
+typed handler with `with` (the manual registration form). Middleware in the same `DynStack` runs
+in list order, outermost first. Each dynamic layer costs one boxed future per call, against zero
+for the static layers, so keep the static chain as the default and reach for `DynStack` only where
+runtime composition earns it.
 
 ## Publish-side middleware
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -11,10 +11,7 @@ sends it:
 ```rust
 use ruststream::subscriber;
 
-#[subscriber("requests", publish("responses"))]
-async fn respond(req: &Request) -> Response {
-    Response { ok: true }
-}
+--8<-- "examples/publishing.rs:reply"
 ```
 
 Mount it with `include_publishing`, handing it a [`TypedPublisher`] that carries the broker
@@ -30,8 +27,9 @@ RustStream::new(info).with_broker(broker, |b| {
 });
 ```
 
-The first `JsonCodec` decodes the incoming request; the `TypedPublisher`'s codec encodes the reply.
-They are separate seams, so the request and reply formats can differ.
+The `TypedPublisher`'s codec encodes the reply, and `include_publishing` reuses it to decode the
+incoming request. To decode the request with a different codec, mount with `include_publishing_on`
+and name it explicitly; see [Codecs](codecs.md#the-publish-side).
 
 ## Publishing from inside a handler
 
@@ -46,16 +44,9 @@ let app = RustStream::new(info)
 ```
 
 ```rust
-use ruststream::runtime::{Context, HandlerResult, Outgoing};
+use ruststream::runtime::{HandlerResult, Outgoing};
 
-#[subscriber("ingress")]
-async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
-    if let Some(publisher) = ctx.publisher("egress") {
-        let out = Outgoing::new("egress", serde_json::to_vec(event).unwrap());
-        let _ = publisher.publish(out).await;
-    }
-    HandlerResult::Ack
-}
+--8<-- "examples/publishing.rs:forward"
 ```
 
 !!! note "Handlers that publish must own their context"
@@ -74,21 +65,28 @@ Two kinds of transform run before a message leaves the process, and they compose
   concerns (publish metrics, a dead-letter wrapper) applied to every published message. They run
   outside the static layers, then the message is sent.
 
-```rust
-// static, per-publisher
-let replies = TypedPublisher::new(b.broker().publisher())
-    .layer(EnvelopeLayer);
+A static `PublishLayer` implements `apply(&mut Outgoing)`:
 
-// dynamic, app-wide
-let app = RustStream::new(info)
-    .publish_layer(metrics.publish_layer())
-    .with_broker(broker, |b| b.include_publishing(respond, replies));
+```rust
+--8<-- "examples/publishing.rs:static_layer"
 ```
 
-A static `PublishLayer` implements `apply(&mut Outgoing)`. A dynamic middleware implements
-`PublishMiddleware` with an around/next signature, so it can short-circuit, retry, or observe.
+A dynamic middleware implements `PublishMiddleware` with an around/next signature, so it can
+short-circuit, retry, or observe:
+
+```rust
+--8<-- "examples/publishing.rs:dynamic_middleware"
+```
+
+Both levels compose on the application:
+
+```rust
+--8<-- "examples/publishing.rs:pipeline"
+```
+
 Manual publishes through `ctx.publisher(..)` run through the dynamic pipeline (the static layer is a
-property of a specific `TypedPublisher`).
+property of a specific `TypedPublisher`). The full program is
+[`examples/publishing.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/publishing.rs).
 
 ## Batch publishing
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -1,0 +1,81 @@
+# Routing
+
+As a service grows, handlers move out of `main.rs` into their own modules. A `Router` collects a
+module's handlers into one mountable group; `include_router` mounts the whole group on a broker
+scope.
+
+## Building a router
+
+A `Router` mirrors the broker scope: alongside `include` and `include_publishing` it has
+`with_codec` (a per-handler codec, see [Codecs](codecs.md#per-handler)) and the manual `handle` /
+`subscribe` registrations:
+
+```rust title="routes.rs"
+use ruststream::runtime::Router;
+
+--8<-- "examples/routing.rs:builders"
+```
+
+```rust title="main.rs"
+RustStream::new(info).with_broker(broker, |b| {
+    b.include_router(routes::orders());
+});
+```
+
+Handlers that publish a reply register on the router the same way as on the scope, with a
+`TypedPublisher` built from the broker:
+
+```rust title="routes.rs"
+--8<-- "examples/tutorial/routes.rs:routes"
+```
+
+## Router middleware
+
+The application's global middleware (added with `RustStream::layer`) does not wrap router handlers,
+since a router is finalized independently. Give the router its own stack with `Router::layer`,
+applied to every handler registered after it (the same composition as `RustStream::layer`). It
+changes the router's type, so let the builder function's return type follow from it:
+
+```rust title="routes.rs"
+use ruststream::runtime::{Identity, Router, Stack};
+use ruststream::runtime::layers::TracingLayer;
+
+--8<-- "examples/logging_middleware.rs:layered_router"
+```
+
+See [Middleware](middleware.md) for what a layer is and how to write one, and
+[`examples/logging_middleware.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/logging_middleware.rs)
+for this router in a running service.
+
+!!! warning "Planned for 0.3: routers inherit the application scope"
+    In 0.2 the router stack and the application stack are separate (`RustStream::layer` does not
+    wrap router handlers). In 0.3 routers will inherit the application scope, so app-level layers
+    will wrap router handlers too, composing outside the router's own stack. See
+    [middleware scopes](middleware.md#middleware-scopes).
+
+## Composing and mounting
+
+Build routers per module, then combine them however suits the service:
+
+```rust
+// Mount several routers on one broker - include_router can be called more than once.
+RustStream::new(info).with_broker(broker, |b| {
+    b.include_router(routes::orders());
+    b.include_router(routes::shipping());
+});
+```
+
+Or merge groups into one router before mounting (the whole program is
+[`examples/routing.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/routing.rs)):
+
+```rust
+--8<-- "examples/routing.rs:merge"
+```
+
+`merge` appends another router's registrations in order; the merged router's own layer was already
+baked into its handlers, so the two need not share a middleware stack.
+
+## Next
+
+- The handler contract and the `#[subscriber]` macro: [Subscribers](subscribers.md).
+- How the decode codec is resolved for `include`: [Codecs](codecs.md).

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -1,8 +1,9 @@
-# Subscribers and publishers
+# Subscribers
 
 A subscriber binds a handler to one subscription. The `#[subscriber]` macro is the ergonomic way to
-declare one; this guide covers the handler contract, the macro forms, how handlers are mounted, and
-how to group them with a router.
+declare one; this guide covers the handler contract, the macro forms, and how handlers are mounted.
+Grouping handlers into modules is covered in [Routing](routing.md), and how payloads are decoded in
+[Codecs](codecs.md).
 
 ## The handler contract
 
@@ -12,10 +13,7 @@ A handler is an `async fn` whose first parameter is a reference to the decoded p
 use ruststream::runtime::HandlerResult;
 use ruststream::subscriber;
 
-#[subscriber("orders")]
-async fn handle(order: &Order) -> HandlerResult {
-    HandlerResult::Ack
-}
+--8<-- "examples/subscribers.rs:contract"
 ```
 
 The macro turns the function into a value named after it (here `handle`) that implements the
@@ -27,16 +25,12 @@ Declare an optional second parameter, `&mut Context`, to read headers, the subsc
 shared state, or to publish from inside the handler:
 
 ```rust
-use ruststream::runtime::{Context, HandlerResult};
-
-#[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
-    if let Some(id) = ctx.headers().correlation_id() {
-        // ...
-    }
-    HandlerResult::Ack
-}
+--8<-- "examples/subscribers.rs:context"
 ```
+
+The macro resolves the context type itself, so the `Context` name needs no import when it appears
+only in `#[subscriber]` signatures. The full context surface - the headers working copy, state
+access, named publishers - is covered in [Context and state](context.md).
 
 ### Acking
 
@@ -48,7 +42,8 @@ The return type is anything that converts into a [`HandlerResult`]:
 | `HandlerResult::retry()` | nack with requeue (redeliver later) |
 | `HandlerResult::drop()` | nack without requeue (discard or dead-letter) |
 | `()` | always `Ack` |
-| `Result<_, E>` | `Ack` on `Ok`, `drop` on `Err` |
+| `Result<(), E>` | `Ack` on `Ok`, `drop` on `Err` |
+| `Result<HandlerResult, E>` | the inner result on `Ok`, `drop` on `Err` |
 
 On the message itself, ack consumes `self`, so the type system prevents acking twice.
 
@@ -81,10 +76,7 @@ JetStream consumer, for example:
 ```rust
 use ruststream_nats::SubscribeOptions;
 
-#[subscriber(SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("workers"))]
-async fn handle(order: &Order) -> HandlerResult {
-    HandlerResult::Ack
-}
+--8<-- "examples/nats_jetstream.rs:decorator"
 ```
 
 The macro follows the chain down to the base `Type::new(..)` to name the source type, so each method
@@ -93,8 +85,7 @@ macro.
 
 ## Mounting handlers
 
-Inside `with_broker`, mount a definition with `include`. It decodes the payload with the default
-codec - `json` if enabled, otherwise `cbor`, otherwise `msgpack`:
+Inside `with_broker`, mount a definition with `include`:
 
 ```rust
 RustStream::new(info).with_broker(broker, |b| {
@@ -102,57 +93,12 @@ RustStream::new(info).with_broker(broker, |b| {
 });
 ```
 
-### Where the codec comes from
+`include` decodes the payload with the codec resolved from the most specific level you set - per
+handler, per scope, or the feature-selected default. See
+[where the codec comes from](codecs.md#where-the-decode-codec-comes-from).
 
-The decode codec is fixed at compile time. `include` takes no codec argument; it resolves one from
-the most specific level you set, from narrowest to widest:
-
-**1. Per handler.** Override a single mounting:
-
-=== "Router"
-
-    ```rust
-    router.with_codec(CborCodec).include(handle);
-    ```
-
-=== "with_broker"
-
-    ```rust
-    // name the source and the codec for this one handler
-    b.include_on(handle.source(), handle, CborCodec);
-    ```
-
-**2. Per scope.** Set one codec for every handler in a `with_broker` scope:
-
-```rust
-use ruststream::codec::CborCodec;
-
-RustStream::new(info).with_broker_codec(broker, CborCodec, |b| {
-    b.include(handle);          // decodes with CborCodec
-    b.include(other_handler);   // also CborCodec
-});
-```
-
-**3. Default.** When nothing above names a codec, `include` uses `DefaultCodec` - `json` if the
-feature is enabled, otherwise `cbor`, otherwise `msgpack`.
-
-The reply side mirrors this: `TypedPublisher::new(publisher)` uses the default codec,
-`TypedPublisher::with_codec(publisher, codec)` names one, and `include_publishing(def, publisher)`
-reuses the publisher's codec to decode the request.
-
-### Codecs
-
-| Codec | Feature | Wire format |
-|---|---|---|
-| `JsonCodec` | `json` | JSON |
-| `MsgpackCodec` | `msgpack` | MessagePack |
-| `CborCodec` | `cbor` | CBOR |
-
-A codec is any type implementing the `Codec` trait, so you can supply your own.
-
-When decoding fails, the message is dropped by default. The decode-failure behaviour is configurable
-on the typed adapter when you build handlers by hand (see the API reference for `Typed` and
-`DecodeFailure`).
+To group handlers per module and mount them all at once, collect them into a `Router`; see
+[Routing](routing.md).
 
 ## Macro or manual
 
@@ -163,13 +109,9 @@ struct handler, and `HandlerMetadata`. Both forms below register the same handle
 === "Macro"
 
     ```rust
-    use ruststream::codec::JsonCodec;
     use ruststream::subscriber;
 
-    #[subscriber("orders")]
-    async fn handle(order: &Order) -> HandlerResult {
-        HandlerResult::Ack
-    }
+    --8<-- "examples/subscribers.rs:contract"
 
     // inside with_broker(...):
     b.include(handle);
@@ -183,76 +125,12 @@ struct handler, and `HandlerMetadata`. Both forms below register the same handle
     use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, typed};
 
     // inside with_broker(...):
-    b.subscribe(
-        Name::new("orders"),
-        typed(JsonCodec, |order: &Order, _ctx: &mut Context| async { HandlerResult::Ack }),
-        HandlerMetadata::typed::<Order>("orders"),
-    );
+    --8<-- "examples/subscribers.rs:manual"
     ```
 
 Reach for the manual form when a handler needs state the macro cannot express (a struct handler with
-fields), or to set a non-default decode-failure policy. Otherwise the macro is less to maintain.
-
-## Routers
-
-Group handlers in their own module by collecting them into a `Router`, then mount the whole group
-with `include_router`. The router-level `include` and `include_publishing` mirror the scope methods:
-
-```rust title="routes.rs"
-use ruststream::codec::JsonCodec;
-use ruststream::runtime::Router;
-
-pub fn orders() -> Router<MyBroker> {
-    let mut router = Router::new();
-    router.include(handle);
-    router.include(other_handler);
-    router
-}
-```
-
-```rust title="main.rs"
-RustStream::new(info).with_broker(broker, |b| {
-    b.include_router(routes::orders());
-});
-```
-
-The application's global middleware (added with `layer`) does not wrap router handlers, since a
-router is finalized independently. Give the router its own stack with `Router::layer`, applied to
-every handler registered after it (the same composition as `RustStream::layer`). It changes the
-router's type, so let the builder function's return type follow from it:
-
-```rust title="routes.rs"
-use ruststream::runtime::{Identity, Router, Stack};
-use ruststream::runtime::layers::TracingLayer;
-
-pub fn orders() -> Router<MyBroker, Stack<TracingLayer, Identity>> {
-    let mut router = Router::new().layer(TracingLayer::default());
-    router.include(handle);
-    router.include(other_handler);
-    router
-}
-```
-
-### Composing and mounting
-
-A `Router` mirrors the broker scope: alongside `include` and `include_publishing` it has
-`with_codec` (a per-handler codec, as [above](#where-the-codec-comes-from)) and the manual
-`handle` / `subscribe`. Build routers per module, then combine them however suits the service:
-
-```rust
-// Mount several routers on one broker - include_router can be called more than once.
-RustStream::new(info).with_broker(broker, |b| {
-    b.include_router(routes::orders());
-    b.include_router(routes::shipping());
-});
-
-// Or merge groups into one router before mounting.
-let mut all = routes::orders();
-all.merge(routes::shipping());
-```
-
-`merge` appends another router's registrations in order; the merged router's own layer was already
-baked into its handlers, so the two need not share a middleware stack.
+fields), or to set a non-default [decode-failure policy](codecs.md#decode-failures). Otherwise the
+macro is less to maintain.
 
 ## Publishers
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,64 +1,158 @@
 # Testing
 
-RustStream's test support exercises **core routing only**: it dispatches messages to your registered
-handlers so you can assert on handler behaviour, middleware, decoding, and any database stubs. It
-does not simulate broker-specific semantics.
+RustStream services are tested at two levels:
+
+1. **In-process tests** drive your real handlers, middleware, and codecs through an in-memory
+   broker - no server, no docker, no network. This is the default test path and it covers handler
+   logic end to end: decode, dispatch, ack, and any replies your handlers publish.
+2. **Integration tests** run against a real broker, gated behind an environment variable, and cover
+   the semantics only a real server has (durable consumers, redelivery timers, partitions).
 
 !!! warning "What the test client does and does not do"
-    The test client is a handler-stub dispatcher. Publishing a message fans it out to the
-    subscribers whose name matches, runs your handler, and treats ack/nack as effectively a no-op.
-    It does **not** model JetStream durable cursors, `ack_wait` redelivery, `max_ack_pending`,
-    retention, Kafka offsets or consumer groups, or RabbitMQ exchanges and dead-letter routing.
-    Those are real-broker concerns. Test them end to end against a real broker, not the stub.
+    An in-memory test broker is a handler-stub dispatcher: publishing fans the message out to the
+    subscribers whose subject matches, runs your handler, and treats ack/nack as broker-side no-ops
+    (a nack with requeue redelivers the same payload to the same subscriber). It does **not** model
+    JetStream durable cursors, `ack_wait` redelivery, `max_ack_pending`, retention, Kafka offsets or
+    consumer groups, or RabbitMQ exchanges and dead-letter routing. Those are real-broker concerns;
+    test them in the [integration suite](#integration-tests-against-a-real-broker).
 
-## Unit-testing handlers
+## The `TestClient` contract
 
-For local tests use `MemoryBroker` (the `memory` feature), or, for a real broker crate, the
-`TestClient` it ships under its `testing` feature. The handlers, middleware, and codecs are declared
-once on the production setup and shared with the test.
+Every in-memory test transport implements the `TestClient` trait from `ruststream::testing`:
 
-A test starts the in-memory broker, publishes a message as if from an external producer, and asserts
-the handler observed it. The `TestClient` trait provides `start`, `publish`, `subscribe`, and
-`shutdown`:
+| Method | Purpose |
+|---|---|
+| `start()` | starts a fresh, isolated in-memory broker |
+| `broker()` | the broker handle, for registering with a `RustStream` app |
+| `publish(name, payload)` | publishes as if from an external producer |
+| `subscribe(name)` | opens a raw subscription, for asserting on deliveries directly |
+| `publisher()` | a bound publisher, for publishing with headers or in a loop |
+| `expect_published(name, count, timeout)` | waits until `count` messages were published to `name` |
+| `shutdown()` | tears the in-memory broker down |
+
+`expect_published` resolves as soon as `count` messages have been observed on `name`; when the
+timeout elapses first it returns the messages observed so far, so assert on the returned
+messages, not just on `Ok`. It records **all** publishes - the ones your test sends and the ones
+your handlers send - which is what makes reply assertions one-liners.
+
+Two implementations ship today:
+
+- `MemoryBroker` (the `memory` feature of `ruststream`) implements `TestClient` itself - exact name
+  matching, broker-agnostic.
+- `ruststream-nats` ships `NatsTestClient` / `NatsTestBroker` under its `testing` feature - real
+  NATS subject matching (`*` and `>` wildcards), request-reply, header propagation.
+
+## Testing handlers with `MemoryBroker`
+
+The handlers, middleware, and codecs under test are the production ones; only the broker is
+swapped. The test starts the in-memory broker, runs the app on it, publishes a message as an
+external producer would, and asserts on what the handler published back.
+
+The handler under test (in a real service it lives in your handler module and the test imports
+it):
 
 ```rust
-use ruststream::memory::MemoryBroker;
-use ruststream::testing::TestClient;
+--8<-- "tests/doc_testing_memory.rs:handler"
+```
+
+The test:
+
+```rust
+--8<-- "tests/doc_testing_memory.rs:test"
+```
+
+!!! info "This test runs in this repository's CI"
+    The code above is embedded from
+    [`tests/doc_testing_memory.rs`](https://github.com/powersemmi/ruststream/blob/main/tests/doc_testing_memory.rs),
+    which `cargo test --all-features` runs on every change - the example cannot silently rot.
+
+Three details carry the pattern:
+
+- **Readiness.** The in-memory broker does not buffer: a message published before the subscription
+  opens is lost. `after_startup` runs once every subscription is open, so a `Notify` signalled
+  there is the cheapest reliable "handlers are live" gate (no sleeps, no polling).
+- **Shutdown.** `run_until` resolves when the supplied future does, so the test owns the service's
+  lifetime; `service.await` then surfaces any startup or shutdown error.
+- **Assertions.** For a handler that publishes, assert through `expect_published`. For a handler
+  with side effects only, assert on its observable effect - a value pushed to a channel, a counter,
+  a stubbed repository inserted via [shared state](lifespan.md#shared-state).
+
+## Testing handlers against in-memory NATS
+
+For a NATS service, test against the NATS-flavoured test broker instead, so subject semantics are
+the real ones: `orders.*` matches one token, `orders.>` matches the tail, queue-group names are
+accepted, and request-reply works. Enable the broker crate's `testing` feature in
+dev-dependencies:
+
+```toml title="Cargo.toml"
+[dev-dependencies]
+ruststream-nats = { version = "0.2", features = ["testing"] }
+```
+
+The same pattern as above, with a wildcard subscriber that audits every order event (this file
+also runs in this repository's CI):
+
+```rust
+--8<-- "tests/doc_testing_nats.rs:test"
+```
+
+The test broker also implements `RequestReply`, so a handler that responds to requests is testable
+in-process: publish with `publisher().request(..)` and assert on the reply.
+
+### Handlers declared with a JetStream descriptor
+
+A descriptor like `SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("workers")` names
+a real JetStream consumer; it implements `SubscriptionSource` for the real `NatsBroker` only,
+because durable names and ack waits have no in-process meaning. To unit-test that handler's logic,
+mount the same definition on the test broker with an explicit by-name source - `include_on`
+overrides the macro's source and takes the codec explicitly:
+
+```rust
+use ruststream::Name;
+use ruststream::codec::JsonCodec;
+
+.with_broker(client.broker().clone(), |b| {
+    b.include_on(Name::new("orders.created"), handle, JsonCodec);
+})
+```
+
+What that mount does **not** cover - durable resume, `ack_wait` redelivery, `max_ack_pending` - is
+exactly what the integration suite is for.
+
+## Integration tests against a real broker
+
+Behaviour that depends on real broker semantics belongs in a separate suite gated behind an
+environment variable, so the default `cargo test` stays fast and offline:
+
+```rust title="tests/integration_nats.rs"
+fn test_url() -> Option<String> {
+    std::env::var("NATS_TEST_URL").ok()
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handler_acks_orders() {
-    let client = MemoryBroker::start().await.unwrap();
-
-    // register handlers on client.broker(), drive the app, then:
-    client.publish("orders", br#"{"id":1}"#).await.unwrap();
-
-    // assert via your handler's observable effect (a channel, a counter, a stubbed DB)
-    client.shutdown().await.unwrap();
+async fn durable_consumer_resumes_after_restart() {
+    let Some(url) = test_url() else {
+        eprintln!("skipping: set NATS_TEST_URL to run");
+        return;
+    };
+    // connect NatsBroker::new(url), drive the real JetStream consumer ...
 }
 ```
 
-Assert on what your handler does (a value pushed to a channel, a counter, a stub database call),
-exactly as you would in production. That is the behaviour the stub is there to verify.
+Run it explicitly against a live server:
 
-## End-to-end tests
-
-Behaviour that depends on real broker semantics (durable resume, redelivery on timeout, partition
-assignment, dead-letter routing) belongs in a separate integration suite gated behind an environment
-variable, so it runs only when a real broker is available:
-
-```rust
-#[tokio::test]
-#[ignore = "requires a running broker; set BROKER_TEST_URL"]
-async fn redelivers_after_ack_wait() {
-    // connect to the real broker via BROKER_TEST_URL
-}
+```bash
+docker run -d -p 4222:4222 nats:latest -js
+NATS_TEST_URL=nats://127.0.0.1:4222 cargo test --test integration_nats
 ```
 
-Run it explicitly with `cargo test -- --ignored` against a live server. This mirrors the
-`with_real = true` path: the default test run stays fast and offline, and real semantics are checked
-where they actually live.
+This mirrors faststream's `with_real=True` split: handler logic on the in-memory path, broker
+semantics on the real one. Keep both suites over the same handler modules so the production code
+has a single source of truth.
 
 ## For broker authors
 
-If you are implementing a broker, the conformance harness proves your implementation honours the core
-contract. See [Conformance](../broker-authors/conformance.md).
+If you are implementing a broker, ship a `TestClient` under a `testing` feature and prove it with
+the conformance harness: `run_suite` checks the routing surface of the test client, `lifecycle`
+checks the lazy-startup contract against the real transport. See
+[Conformance](../broker-authors/conformance.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ Two architectural commitments shape the framework:
 - :material-download: **[Installation](getting-started/installation.md)** - features and crate setup.
 - :material-rocket-launch: **[Quick start](getting-started/quickstart.md)** - scaffold a service with the CLI.
 - :material-school: **[Tutorial](getting-started/tutorial.md)** - build a service step by step.
+- :material-test-tube: **[Testing](guides/testing.md)** - test handlers in-process, no server needed.
+- :material-transit-connection-variant: **[Brokers](brokers/index.md)** - the in-memory broker and NATS.
 - :material-server-network: **[Broker authors](broker-authors/index.md)** - implement the contract and pass conformance.
 
 </div>

--- a/examples/codecs.rs
+++ b/examples/codecs.rs
@@ -1,0 +1,61 @@
+//! Codec selection from the Codecs guide: a per-scope codec, a per-handler override, and a
+//! non-default decode-failure policy.
+//!
+//! ```text
+//! cargo run --example codecs --features macros,memory,json,cbor -- run
+//! ```
+
+use ruststream::codec::{CborCodec, JsonCodec};
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{
+    AppInfo, Context, DecodeFailure, HandlerMetadata, HandlerResult, RustStream, SubscriberDef,
+    typed,
+};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders")]
+async fn handle(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("audit")]
+async fn audit(order: &Order) -> HandlerResult {
+    println!("audited order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    let info = AppInfo::new("codecs", "0.1.0");
+    // --8<-- [start:scope]
+    RustStream::new(info)
+        .with_broker_codec(MemoryBroker::new(), CborCodec, |b| {
+            b.include(handle); // decodes with CborCodec
+            b.include(audit); // also CborCodec
+        })
+        // --8<-- [end:scope]
+        .with_broker(MemoryBroker::new(), |b| {
+            // --8<-- [start:per_handler]
+            // name the source and the codec for this one handler
+            b.include_on(handle.source(), handle, JsonCodec);
+            // --8<-- [end:per_handler]
+            // --8<-- [start:decode_failure]
+            let strict = typed(JsonCodec, |_order: &Order, _ctx: &mut Context| async {
+                HandlerResult::Ack
+            })
+            .on_decode_failure(DecodeFailure::Requeue);
+            b.handle(
+                b.broker().subscribe("orders"),
+                strict,
+                HandlerMetadata::typed::<Order>("orders"),
+            );
+            // --8<-- [end:decode_failure]
+        })
+}

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -1,0 +1,90 @@
+//! The Context guide's example: a handler reading all three things the per-delivery `Context`
+//! carries (the channel name, the headers working copy, shared state), and a middleware that
+//! enriches the headers before the handler runs.
+//!
+//! ```text
+//! cargo run --example context --features macros,memory,json -- run
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{
+    AppInfo, Context, Handler, HandlerResult, Identity, Layer, RustStream, Stack,
+};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+// --8<-- [start:state]
+/// Shared configuration: inserted once at build time, read by every handler.
+#[derive(Debug)]
+struct AppConfig {
+    reject_zero_ids: bool,
+}
+// --8<-- [end:state]
+
+// --8<-- [start:handler]
+#[subscriber("orders")]
+async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
+    // 1. The channel the message arrived on.
+    println!("received on {}", ctx.name());
+
+    // 2. The headers working copy - including what middleware added on the way in.
+    if let Some(id) = ctx.headers().get("x-request-id") {
+        println!("request {}", String::from_utf8_lossy(id));
+    }
+
+    // 3. App-level shared state.
+    let config = ctx
+        .get::<AppConfig>()
+        .expect("config inserted at build time");
+    if config.reject_zero_ids && order.id == 0 {
+        return HandlerResult::drop();
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:handler]
+
+// --8<-- [start:enrich]
+/// A layer that stamps a request id onto the context headers before the handler runs.
+#[derive(Clone)]
+struct RequestId;
+
+struct WithRequestId<H>(H);
+
+impl<H> Layer<H> for RequestId {
+    type Handler = WithRequestId<H>;
+    fn layer(&self, inner: H) -> WithRequestId<H> {
+        WithRequestId(inner)
+    }
+}
+
+static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
+
+impl<M: Send + Sync, H: Handler<M>> Handler<M> for WithRequestId<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        if ctx.headers().get("x-request-id").is_none() {
+            let id = format!("req-{}", NEXT_REQUEST.fetch_add(1, Ordering::Relaxed));
+            ctx.headers_mut().insert("x-request-id", id.into_bytes());
+        }
+        self.0.handle(msg, ctx).await
+    }
+}
+// --8<-- [end:enrich]
+
+// --8<-- [start:app]
+#[ruststream::app]
+fn app() -> RustStream<Stack<RequestId, Identity>> {
+    RustStream::new(AppInfo::new("context", "0.1.0"))
+        .insert_state(AppConfig {
+            reject_zero_ids: true,
+        })
+        .layer(RequestId)
+        .with_broker(MemoryBroker::new(), |b| b.include(handle))
+}
+// --8<-- [end:app]

--- a/examples/lifespan.rs
+++ b/examples/lifespan.rs
@@ -1,0 +1,84 @@
+//! Shared state and lifecycle hooks from the Lifespan guide: a resource opened in `on_startup`,
+//! shared with handlers through `State`, and closed in `after_shutdown`.
+//!
+//! The `Database` here is a stand-in for any async resource (a `sqlx::PgPool`, an HTTP client);
+//! only its `connect` / `close` calls would differ.
+//!
+//! ```text
+//! cargo run --example lifespan --features macros,memory,json -- run
+//! ```
+
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+/// A stand-in for a connection pool: cheap to clone, shared by every handler.
+#[derive(Debug, Clone)]
+struct Database;
+
+#[derive(Debug, thiserror::Error)]
+#[error("database error")]
+struct DbError;
+
+impl Database {
+    async fn connect(url: &str) -> Result<Self, DbError> {
+        println!("connecting to {url}");
+        tokio::task::yield_now().await; // stands in for the real network round trip
+        Ok(Self)
+    }
+
+    async fn insert_order(&self, id: u64) -> Result<(), DbError> {
+        println!("insert order {id}");
+        tokio::task::yield_now().await;
+        Ok(())
+    }
+
+    async fn close(&self) {
+        println!("closing the database");
+        tokio::task::yield_now().await;
+    }
+}
+
+// --8<-- [start:handler]
+#[subscriber("orders")]
+async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
+    let db = ctx
+        .get::<Database>()
+        .expect("database inserted in on_startup");
+    if db.insert_order(order.id).await.is_err() {
+        return HandlerResult::retry();
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:handler]
+
+// --8<-- [start:hooks]
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        // before brokers connect: open the resource and put it in shared state
+        .on_startup(|mut state| async move {
+            let db = Database::connect("postgres://localhost/orders").await?;
+            state.insert(db);
+            Ok::<_, DbError>(state)
+        })
+        // after brokers shut down: close it cleanly
+        .after_shutdown(|state| async move {
+            if let Some(db) = state.get::<Database>() {
+                db.close().await;
+            }
+            Ok::<_, DbError>(())
+        })
+        // bound the post-shutdown drain of in-flight handlers
+        .shutdown_timeout(Duration::from_secs(10))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle))
+}
+// --8<-- [end:hooks]

--- a/examples/logging_middleware.rs
+++ b/examples/logging_middleware.rs
@@ -47,12 +47,14 @@ async fn reject(order: &Order) -> HandlerResult {
 ///
 /// The layer is added first, so both `confirm` and `reject` registered after it are wrapped.
 /// `TracingLayer::with_target("orders")` would route the events under a custom tracing target.
+// --8<-- [start:layered_router]
 fn routes() -> Router<MemoryBroker, Stack<TracingLayer, Identity>> {
     let mut router = Router::new().layer(TracingLayer::default());
     router.include(confirm);
     router.include(reject);
     router
 }
+// --8<-- [end:layered_router]
 
 #[ruststream::app]
 fn app() -> RustStream {

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,0 +1,105 @@
+//! The middleware forms from the Middleware guide: a hand-written static layer and a dynamic
+//! middleware chain built at runtime, both composed into the application stack.
+//!
+//! ```text
+//! AUDIT=1 cargo run --example middleware --features macros,memory,json -- run
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use ruststream::memory::{MemoryBroker, MemoryMessage};
+use ruststream::runtime::{
+    AppInfo, Context, DynMiddleware, DynStack, Handler, HandlerResult, Identity, Layer, Next,
+    RustStream, Stack,
+};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders")]
+async fn handle(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("returns")]
+async fn returns(order: &Order) -> HandlerResult {
+    println!("got return for order {}", order.id);
+    HandlerResult::Ack
+}
+
+// --8<-- [start:layer_impl]
+#[derive(Clone)]
+struct LogLayer;
+
+struct Logged<H>(H);
+
+impl<H> Layer<H> for LogLayer {
+    type Handler = Logged<H>;
+    fn layer(&self, inner: H) -> Logged<H> {
+        Logged(inner)
+    }
+}
+
+impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        println!("-> {}", ctx.name());
+        let result = self.0.handle(msg, ctx).await;
+        println!("<- {}", ctx.name());
+        result
+    }
+}
+// --8<-- [end:layer_impl]
+
+// --8<-- [start:dyn_middleware]
+struct Audit {
+    service: String,
+}
+
+impl<I: Send + Sync> DynMiddleware<I> for Audit {
+    fn handle<'a>(
+        &'a self,
+        input: &'a I,
+        ctx: &'a mut Context<'_>,
+        next: Next<'a, I>,
+    ) -> Pin<Box<dyn Future<Output = HandlerResult> + Send + 'a>> {
+        Box::pin(async move {
+            println!("[{}] handling {}", self.service, ctx.name());
+            next.run(input, ctx).await
+        })
+    }
+}
+// --8<-- [end:dyn_middleware]
+
+// The application stack's type names every layer, the dynamic chain included.
+#[ruststream::app]
+fn app() -> RustStream<Stack<DynStack<MemoryMessage>, Stack<LogLayer, Identity>>> {
+    let audit_enabled = std::env::var("AUDIT").is_ok();
+    let info = AppInfo::new("middleware", "0.1.0");
+    // --8<-- [start:dyn_stack]
+    // The chain is decided at runtime...
+    let mut middleware: Vec<Arc<dyn DynMiddleware<MemoryMessage>>> = Vec::new();
+    if audit_enabled {
+        middleware.push(Arc::new(Audit {
+            service: "orders".to_owned(),
+        }));
+    }
+    let stack = DynStack::new(middleware); // empty list -> a no-op layer
+
+    // ...but the frozen DynStack is an ordinary static Layer: compose it into the
+    // application stack like any other (HandlerExt::with works too, per handler).
+    RustStream::new(info)
+        .layer(LogLayer)
+        .layer(stack)
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include(handle);
+            b.include(returns);
+        })
+    // --8<-- [end:dyn_stack]
+}

--- a/examples/middleware_app_scope.rs
+++ b/examples/middleware_app_scope.rs
@@ -1,0 +1,77 @@
+//! Application-scope middleware: a layer added with `RustStream::layer` wraps every handler
+//! registered directly on a broker scope.
+//!
+//! It does NOT wrap handlers mounted through `include_router` - a router carries its own stack
+//! (see `middleware_router_scope.rs`). Planned for 0.3: routers inherit the application scope,
+//! and this distinction goes away.
+//!
+//! ```text
+//! cargo run --example middleware_app_scope --features macros,memory,json -- run
+//! ```
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{
+    AppInfo, Context, Handler, HandlerResult, Identity, Layer, Router, RustStream, Stack,
+};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders")]
+async fn orders(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("shipments")]
+async fn shipments(order: &Order) -> HandlerResult {
+    println!("got shipment for order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("audit")]
+async fn audit(order: &Order) -> HandlerResult {
+    println!("audited order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[derive(Clone)]
+struct LogLayer;
+
+struct Logged<H>(H);
+
+impl<H> Layer<H> for LogLayer {
+    type Handler = Logged<H>;
+    fn layer(&self, inner: H) -> Logged<H> {
+        Logged(inner)
+    }
+}
+
+impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        println!("app layer -> {}", ctx.name());
+        self.0.handle(msg, ctx).await
+    }
+}
+
+// --8<-- [start:app_scope]
+#[ruststream::app]
+fn app() -> RustStream<Stack<LogLayer, Identity>> {
+    RustStream::new(AppInfo::new("app-scope", "0.1.0"))
+        // wraps every handler registered directly on a broker scope below
+        .layer(LogLayer)
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include(orders); //    wrapped by LogLayer
+            b.include(shipments); // wrapped by LogLayer
+
+            // Mounted through a router: NOT wrapped by the app stack (until 0.3).
+            let mut router = Router::new();
+            router.include(audit);
+            b.include_router(router);
+        })
+}
+// --8<-- [end:app_scope]

--- a/examples/middleware_router_scope.rs
+++ b/examples/middleware_router_scope.rs
@@ -1,0 +1,77 @@
+//! Router-scope middleware: a layer added with `Router::layer` wraps every handler registered
+//! after it on that router.
+//!
+//! Handlers mounted directly on the broker scope are outside the router's stack (and the app has
+//! none here). Planned for 0.3: routers inherit the application scope, and the two scopes
+//! compose instead of being separate (see `middleware_app_scope.rs` for the other side).
+//!
+//! ```text
+//! cargo run --example middleware_router_scope --features macros,memory,json -- run
+//! ```
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{
+    AppInfo, Context, Handler, HandlerResult, Identity, Layer, Router, RustStream, Stack,
+};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[subscriber("orders")]
+async fn orders(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("shipments")]
+async fn shipments(order: &Order) -> HandlerResult {
+    println!("got shipment for order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("audit")]
+async fn audit(order: &Order) -> HandlerResult {
+    println!("audited order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[derive(Clone)]
+struct LogLayer;
+
+struct Logged<H>(H);
+
+impl<H> Layer<H> for LogLayer {
+    type Handler = Logged<H>;
+    fn layer(&self, inner: H) -> Logged<H> {
+        Logged(inner)
+    }
+}
+
+impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        println!("router layer -> {}", ctx.name());
+        self.0.handle(msg, ctx).await
+    }
+}
+
+// --8<-- [start:router_scope]
+fn routes() -> Router<MemoryBroker, Stack<LogLayer, Identity>> {
+    // wraps every handler registered on this router after it
+    let mut router = Router::new().layer(LogLayer);
+    router.include(orders); //    wrapped by LogLayer
+    router.include(shipments); // wrapped by LogLayer
+    router
+}
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("router-scope", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include_router(routes());
+        b.include(audit); // directly on the scope: outside the router's stack
+    })
+}
+// --8<-- [end:router_scope]

--- a/examples/nats_jetstream.rs
+++ b/examples/nats_jetstream.rs
@@ -40,6 +40,16 @@ async fn handle(order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
+// The descriptor can also sit directly in the decorator: the macro follows the builder chain, so
+// this handler mounts with a plain `include` and no separate source argument.
+// --8<-- [start:decorator]
+#[subscriber(SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("orders-audit"))]
+async fn audit(order: &Order) -> HandlerResult {
+    println!("audited order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:decorator]
+
 #[ruststream::app]
 fn app() -> RustStream {
     RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker(
@@ -54,6 +64,7 @@ fn app() -> RustStream {
                 JsonCodec,
             );
             // --8<-- [end:include_on]
+            b.include(audit);
         },
     )
 }

--- a/examples/nats_request_reply.rs
+++ b/examples/nats_request_reply.rs
@@ -1,0 +1,37 @@
+//! Request-reply over Core NATS: the publisher implements the `RequestReply` capability.
+//!
+//! `request` publishes with a reply inbox and resolves with the reply message, bounded by the
+//! caller's timeout. Start a responder first (any NATS service; here the `nats` CLI), then run
+//! the example - after startup it sends one request and prints the reply:
+//!
+//! ```text
+//! nats reply questions 'pong'          # in another terminal
+//! cargo run --example nats_request_reply --features macros -- run
+//! ```
+
+use std::time::Duration;
+
+use ruststream::runtime::{AppInfo, RustStream};
+use ruststream::{IncomingMessage, OutgoingMessage, RequestReply};
+use ruststream_nats::{NatsBroker, NatsError};
+
+#[ruststream::app]
+fn app() -> RustStream {
+    let broker = NatsBroker::new("nats://localhost:4222");
+    // Built before connect: the publisher resolves the live connection on first use.
+    let requester = broker.publisher();
+    RustStream::new(AppInfo::new("requester", "0.1.0"))
+        .after_startup(move |_state| async move {
+            // --8<-- [start:request]
+            let reply = requester
+                .request(
+                    OutgoingMessage::new("questions", b"what is the answer?"),
+                    Duration::from_secs(2),
+                )
+                .await?;
+            println!("reply: {}", String::from_utf8_lossy(reply.payload()));
+            // --8<-- [end:request]
+            Ok::<_, NatsError>(())
+        })
+        .register_broker(broker)
+}

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -1,0 +1,103 @@
+//! The publishing forms from the Publishing guide: a reply handler, a named publisher resolved
+//! from the context, and the two-level publish pipeline (static layer + dynamic middleware).
+//!
+//! ```text
+//! cargo run --example publishing --features macros,memory,json -- run
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{
+    AppInfo, HandlerResult, Outgoing, PublishLayer, PublishMiddleware, PublishNext, RustStream,
+    TypedPublisher,
+};
+use ruststream::subscriber;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    id: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    ok: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Event {
+    id: u64,
+}
+
+// --8<-- [start:reply]
+#[subscriber("requests", publish("responses"))]
+async fn respond(req: &Request) -> Response {
+    println!("responding to request {}", req.id);
+    Response { ok: true }
+}
+// --8<-- [end:reply]
+
+// --8<-- [start:forward]
+#[subscriber("ingress")]
+async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
+    if let Some(publisher) = ctx.publisher("egress") {
+        let out = Outgoing::new("egress", serde_json::to_vec(event).expect("serializable"));
+        if publisher.publish(out).await.is_err() {
+            return HandlerResult::retry();
+        }
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:forward]
+
+// --8<-- [start:static_layer]
+/// A static, per-publisher transform: stamps an envelope header on every outgoing message.
+struct EnvelopeLayer;
+
+impl PublishLayer for EnvelopeLayer {
+    fn apply(&self, out: &mut Outgoing) {
+        out.headers_mut().insert("x-envelope", b"1".to_vec());
+    }
+}
+// --8<-- [end:static_layer]
+
+// --8<-- [start:dynamic_middleware]
+/// A dynamic, app-wide middleware: observes every publish, then passes it on.
+struct AuditPublish;
+
+impl PublishMiddleware for AuditPublish {
+    fn on_publish<'a>(
+        &'a self,
+        out: &'a mut Outgoing,
+        next: PublishNext<'a>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            println!("publishing to {}", out.name());
+            next.run(out).await
+        })
+    }
+}
+// --8<-- [end:dynamic_middleware]
+
+#[ruststream::app]
+fn app() -> RustStream {
+    let broker = MemoryBroker::new();
+    let egress = broker.publisher();
+    // --8<-- [start:pipeline]
+    RustStream::new(AppInfo::new("publishing", "0.1.0"))
+        // dynamic, app-wide: wraps every published message
+        .publish_layer(AuditPublish)
+        // a named publisher, resolvable from any handler's context
+        .publisher("egress", egress)
+        .with_broker(broker, |b| {
+            // static, per-publisher: composed onto this TypedPublisher at compile time
+            let replies = TypedPublisher::new(b.broker().publisher()).layer(EnvelopeLayer);
+            b.include_publishing(respond, replies);
+            b.include(forward);
+        })
+    // --8<-- [end:pipeline]
+}

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -9,6 +9,7 @@ use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
 use ruststream::subscriber;
 use serde::Deserialize;
 
+// --8<-- [start:handler]
 #[derive(Debug, Deserialize)]
 struct Order {
     id: u64,
@@ -19,9 +20,12 @@ async fn handle(order: &Order) -> HandlerResult {
     println!("got order {}", order.id);
     HandlerResult::Ack
 }
+// --8<-- [end:handler]
 
+// --8<-- [start:app]
 #[ruststream::app]
 fn app() -> RustStream {
     RustStream::new(AppInfo::new("orders", "0.1.0"))
         .with_broker(MemoryBroker::new(), |b| b.include(handle))
 }
+// --8<-- [end:app]

--- a/examples/routed_service/orders.rs
+++ b/examples/routed_service/orders.rs
@@ -32,6 +32,7 @@ pub(crate) struct Confirmation {
 /// name - the slot where a real broker takes its own descriptor (a NATS `SubscribeOptions`, say).
 /// The return value is the reply: the `publish("confirmations")` clause makes the runtime encode it
 /// and send it through the publisher wired in [`routes`](crate::routes).
+// --8<-- [start:descriptor]
 #[subscriber(MemorySource::new("orders"), publish("confirmations"))]
 pub(crate) async fn confirm(order: &Order) -> Confirmation {
     Confirmation {
@@ -39,6 +40,7 @@ pub(crate) async fn confirm(order: &Order) -> Confirmation {
         accepted: order.quantity > 0,
     }
 }
+// --8<-- [end:descriptor]
 
 /// Logs cancellations, bound by plain name. No reply, so it returns a plain [`HandlerResult`].
 #[subscriber("cancellations")]

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -1,0 +1,59 @@
+//! Router composition from the Routing guide: per-module router builders, merged and mounted on
+//! one broker.
+//!
+//! ```text
+//! cargo run --example routing --features macros,memory,json -- run
+//! ```
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct Shipment {
+    order_id: u64,
+}
+
+#[subscriber("orders")]
+async fn accept(order: &Order) -> HandlerResult {
+    println!("accepted order {}", order.id);
+    HandlerResult::Ack
+}
+
+#[subscriber("shipments")]
+async fn dispatch(shipment: &Shipment) -> HandlerResult {
+    println!("dispatched shipment for order {}", shipment.order_id);
+    HandlerResult::Ack
+}
+
+// --8<-- [start:builders]
+fn orders() -> Router<MemoryBroker> {
+    let mut router = Router::new();
+    router.include(accept);
+    router
+}
+
+fn shipping() -> Router<MemoryBroker> {
+    let mut router = Router::new();
+    router.include(dispatch);
+    router
+}
+// --8<-- [end:builders]
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("routing", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        // --8<-- [start:merge]
+        // Merge groups into one router, then mount the result.
+        let mut all = orders();
+        all.merge(shipping());
+        b.include_router(all);
+        // --8<-- [end:merge]
+    })
+}

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -1,0 +1,53 @@
+//! The handler forms from the Subscribers guide: the basic contract, the context parameter, and
+//! the manual (macro-free) registration.
+//!
+//! ```text
+//! cargo run --example subscribers --features macros,memory,json -- run
+//! ```
+
+use ruststream::Name;
+use ruststream::codec::JsonCodec;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, RustStream, typed};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+// --8<-- [start:contract]
+#[subscriber("orders")]
+async fn handle(order: &Order) -> HandlerResult {
+    println!("got order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:contract]
+
+// --8<-- [start:context]
+#[subscriber("orders")]
+async fn with_context(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
+    if let Some(id) = ctx.headers().correlation_id() {
+        println!("order {} correlates to {id}", order.id);
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:context]
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("subscribers", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(handle);
+        b.include(with_context);
+        // --8<-- [start:manual]
+        b.subscribe(
+            Name::new("orders"),
+            typed(JsonCodec, |_order: &Order, _ctx: &mut Context| async {
+                HandlerResult::Ack
+            }),
+            HandlerMetadata::typed::<Order>("orders"),
+        );
+        // --8<-- [end:manual]
+    })
+}

--- a/examples/tutorial/main.rs
+++ b/examples/tutorial/main.rs
@@ -1,0 +1,24 @@
+//! The Getting-started tutorial service, exactly as the docs build it: a message type and two
+//! handlers in [`orders`], a router in [`routes`], and the `#[ruststream::app]` entry point here.
+//!
+//! ```text
+//! cargo run --example tutorial --features macros,memory,json -- run
+//! ```
+
+// --8<-- [start:main]
+mod orders;
+mod routes;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, RustStream};
+
+// --8<-- [start:app]
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders-service", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        let router = routes::orders(b.broker());
+        b.include_router(router);
+    })
+}
+// --8<-- [end:app]
+// --8<-- [end:main]

--- a/examples/tutorial/orders.rs
+++ b/examples/tutorial/orders.rs
@@ -1,0 +1,35 @@
+//! The tutorial's message types and handlers.
+
+use ruststream::runtime::HandlerResult;
+use ruststream::subscriber;
+use serde::{Deserialize, Serialize};
+
+// --8<-- [start:order]
+#[derive(Debug, Deserialize)]
+pub(crate) struct Order {
+    pub(crate) id: u64,
+    pub(crate) quantity: u32,
+}
+
+#[subscriber("orders")]
+pub(crate) async fn handle(order: &Order) -> HandlerResult {
+    println!("order {} x{}", order.id, order.quantity);
+    HandlerResult::Ack
+}
+// --8<-- [end:order]
+
+// --8<-- [start:confirm]
+#[derive(Debug, Serialize)]
+pub(crate) struct Confirmation {
+    pub(crate) id: u64,
+    pub(crate) accepted: bool,
+}
+
+#[subscriber("orders", publish("confirmations"))]
+pub(crate) async fn confirm(order: &Order) -> Confirmation {
+    Confirmation {
+        id: order.id,
+        accepted: order.quantity > 0,
+    }
+}
+// --8<-- [end:confirm]

--- a/examples/tutorial/routes.rs
+++ b/examples/tutorial/routes.rs
@@ -1,0 +1,16 @@
+//! The tutorial's router: collects the [`orders`](crate::orders) handlers into one group.
+
+// --8<-- [start:routes]
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{Router, TypedPublisher};
+
+use crate::orders;
+
+pub(crate) fn orders(broker: &MemoryBroker) -> Router<MemoryBroker> {
+    let replies = TypedPublisher::new(broker.publisher());
+    let mut router = Router::new();
+    router.include_publishing(orders::confirm, replies);
+    router.include(orders::handle);
+    router
+}
+// --8<-- [end:routes]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: ["."]
       check_paths: true
+      dedent_subsections: true
   - pymdownx.tabbed:
       alternate_style: true
 
@@ -72,18 +73,26 @@ nav:
       - getting-started/installation.md
       - getting-started/quickstart.md
       - getting-started/tutorial.md
-  - Guides:
+  - Writing services:
       - guides/subscribers.md
       - guides/publishing.md
-      - guides/lifespan.md
+      - guides/routing.md
+      - guides/codecs.md
       - guides/middleware.md
+      - guides/context.md
+      - guides/lifespan.md
+  - Observability:
       - guides/logging.md
-      - guides/asyncapi.md
       - guides/metrics.md
+      - guides/asyncapi.md
+  - Testing:
       - guides/testing.md
+  - CLI:
       - guides/cli.md
   - Brokers:
       - brokers/index.md
+      - brokers/memory.md
+      - brokers/nats.md
   - Broker authors:
       - broker-authors/index.md
       - broker-authors/example-nats.md

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -46,9 +46,11 @@ impl std::fmt::Debug for State {
 /// Per-delivery context, threaded through middleware and into the handler.
 ///
 /// Carries the channel ([`name`](Self::name)), a mutable working copy of the message
-/// [`headers`](Self::headers) (middleware may modify them; the copy is also what outgoing replies
-/// start from), shared application [state](Self::get), and access to named
-/// [`publisher`](Self::publisher)s for publishing from inside a handler.
+/// [`headers`](Self::headers) (middleware may enrich them for the handler; the broker message
+/// itself is untouched), shared application [state](Self::get), and access to named
+/// [`publisher`](Self::publisher)s for publishing from inside a handler. Outgoing messages do not
+/// inherit the copy: replies and manual publishes start from fresh headers, shaped by the publish
+/// pipeline.
 #[derive(Debug)]
 pub struct Context<'a> {
     name: &'a str,

--- a/tests/doc_testing_memory.rs
+++ b/tests/doc_testing_memory.rs
@@ -1,0 +1,85 @@
+//! The `MemoryBroker` example from docs/guides/testing.md, kept compiling and passing here.
+//! The guide embeds this file via snippet markers; keep the marked sections in sync with the
+//! surrounding prose when editing.
+#![cfg(all(feature = "macros", feature = "memory", feature = "json"))]
+
+// --8<-- [start:handler]
+use ruststream::subscriber;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+    quantity: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct Confirmation {
+    id: u64,
+    accepted: bool,
+}
+
+#[subscriber("orders", publish("confirmations"))]
+async fn confirm(order: &Order) -> Confirmation {
+    Confirmation {
+        id: order.id,
+        accepted: order.quantity > 0,
+    }
+}
+// --8<-- [end:handler]
+
+// --8<-- [start:test]
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
+use ruststream::testing::TestClient;
+use tokio::sync::Notify;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirms_valid_orders() {
+    let client = MemoryBroker::start().await.expect("start test broker");
+
+    // The app under test: production wiring, in-memory broker. Cloning the broker
+    // shares its state, so the client observes everything the app does.
+    let ready = Arc::new(Notify::new());
+    let on_ready = Arc::clone(&ready);
+    let app = RustStream::new(AppInfo::new("orders-test", "0.0.0"))
+        .after_startup(move |_state| async move {
+            on_ready.notify_one();
+            Ok::<_, Infallible>(())
+        })
+        .with_broker(client.broker().clone(), |b| {
+            let replies = TypedPublisher::new(b.broker().publisher());
+            b.include_publishing(confirm, replies);
+        });
+
+    let stop = Arc::new(Notify::new());
+    let stop_signal = Arc::clone(&stop);
+    let service = tokio::spawn(app.run_until(async move { stop_signal.notified().await }));
+
+    // Subscriptions are not buffered: wait for after_startup (it runs once they are open),
+    // then publish as an external producer.
+    ready.notified().await;
+    client
+        .publish("orders", br#"{"id":1,"quantity":2}"#)
+        .await
+        .expect("publish");
+
+    // The handler decoded the order and published a confirmation.
+    let replies = client
+        .expect_published("confirmations", 1, Duration::from_secs(1))
+        .await
+        .expect("expect_published");
+    assert_eq!(replies.len(), 1, "expected one confirmation");
+    let confirmation: serde_json::Value =
+        serde_json::from_slice(replies[0].payload()).expect("valid JSON reply");
+    assert_eq!(confirmation["id"], 1);
+    assert_eq!(confirmation["accepted"], true);
+
+    stop.notify_one();
+    service.await.expect("join").expect("clean shutdown");
+}
+// --8<-- [end:test]

--- a/tests/doc_testing_nats.rs
+++ b/tests/doc_testing_nats.rs
@@ -1,0 +1,73 @@
+//! The in-memory NATS example from docs/guides/testing.md, kept compiling and passing here.
+//! The guide embeds this file via snippet markers; keep the marked sections in sync with the
+//! surrounding prose when editing.
+#![cfg(all(feature = "macros", feature = "json"))]
+
+// --8<-- [start:test]
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
+use ruststream::subscriber;
+use ruststream::testing::TestClient;
+use ruststream_nats::testing::NatsTestClient;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Deserialize)]
+struct Event {
+    id: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct AuditRecord {
+    id: u64,
+}
+
+#[subscriber("orders.*", publish("audit"))]
+async fn audit(event: &Event) -> AuditRecord {
+    AuditRecord { id: event.id }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wildcard_subscriber_audits_all_order_events() {
+    let client = NatsTestClient::start().await.expect("start test broker");
+
+    let ready = Arc::new(Notify::new());
+    let on_ready = Arc::clone(&ready);
+    let app = RustStream::new(AppInfo::new("audit-test", "0.0.0"))
+        .after_startup(move |_state| async move {
+            on_ready.notify_one();
+            Ok::<_, Infallible>(())
+        })
+        .with_broker(client.broker().clone(), |b| {
+            let records = TypedPublisher::new(b.broker().publisher());
+            b.include_publishing(audit, records);
+        });
+
+    let stop = Arc::new(Notify::new());
+    let stop_signal = Arc::clone(&stop);
+    let service = tokio::spawn(app.run_until(async move { stop_signal.notified().await }));
+
+    ready.notified().await;
+    client
+        .publish("orders.created", br#"{"id":1}"#)
+        .await
+        .expect("publish");
+    client
+        .publish("orders.updated", br#"{"id":2}"#)
+        .await
+        .expect("publish");
+
+    // Both subjects matched "orders.*", so the handler ran twice and audited both.
+    let records = client
+        .expect_published("audit", 2, Duration::from_secs(1))
+        .await
+        .expect("expect_published");
+    assert_eq!(records.len(), 2, "expected two audit records");
+
+    stop.notify_one();
+    service.await.expect("join").expect("clean shutdown");
+}
+// --8<-- [end:test]


### PR DESCRIPTION
# Description

A full pass over the docs site: structure, accuracy, and example hygiene.

**Structure.** Navigation is reorganized into framework-part sections in the spirit of the fastapi / faststream docs: Getting started, Writing services (subscribers, publishing, routing, codecs, middleware, context, lifespan), Observability (logging, metrics, AsyncAPI), Testing, CLI, Brokers (overview / memory / NATS), Broker authors, API reference. New pages: routing and codecs (split out of subscribers), context (the State / Context levels, the headers working copy, context in middleware), per-broker pages.

**Testing guide.** Rewritten around real, runnable code: a MemoryBroker handler test and an in-memory NATS test (`ruststream-nats` `testing` feature, wildcard subjects), readiness via `after_startup`, `expect_published` assertions, and the env-gated integration suite for real-broker semantics.

**Compiled examples.** Every substantial code block is embedded from `examples/` (or `tests/doc_testing_*.rs` for the testing guide) via pymdownx.snippets section markers, so CI compiles and runs what the docs show. New examples: `tutorial/` (multi-file), `subscribers`, `publishing`, `routing`, `codecs`, `middleware` (dynamic stack composed into the app scope), `middleware_app_scope` / `middleware_router_scope` (the two middleware scopes, with a note on the planned 0.3 scope inheritance), `lifespan`, `context`. The docs workflows rebuild the site when snippet sources change. Also adds `nats_request_reply` - a runnable requester example for the NATS `RequestReply` capability, embedded into the NATS broker page together with a note on the responder-side asymmetry (the in-memory test broker exposes the reply inbox as the `reply-to` header; the real broker does not yet).

**Fact fixes against the code.** The scaffold has no `stream.rs`; consume metric status values are `ack`/`nack`; the publish-after-subscribe conformance row was inverted; lifecycle hooks receive `Arc<State>`; no shipped broker implements `DescribeServer`; `Result` conversions are `Result<(), E>` / `Result<HandlerResult, E>`; stale `Context` rustdoc about reply headers corrected. README links now point at the versioned site (`/latest`) and the faststream link follows the org move to ag2ai.

**Stacked on #19**: `examples/middleware.rs` composes `DynStack<MemoryMessage>` into the application stack, which needs the `Clone`-bound fix. Merge #19 first; this PR then retargets to main.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature (`tests/doc_testing_memory.rs`, `tests/doc_testing_nats.rs` - the testing guide's examples run as part of the suite)
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable
- [x] `mkdocs build --strict` passes (snippet paths are checked via `check_paths`)
