### PR TITLE
runtime: publishing handlers get the Context and ack control over replies

### DIFF
--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -8,7 +8,8 @@ alwaysApply: false
   decoded payload by reference (`&T`, where `T: serde::Deserialize`); an optional second parameter is
   `ctx: &mut ruststream::runtime::Context`.
 - The return type drives acknowledgement: `HandlerResult`, `()` (always acks), or `Result<_, E>` (an
-  `Err` nacks). For a reply handler, return the reply value and add a `publish("subject")` clause.
+  `Err` nacks). For a reply handler, add a `publish("subject")` clause and return the reply value,
+  or `Result<Reply, HandlerResult>` for explicit ack control.
 - Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream`. Do not write
   your own `main` or `#[tokio::main]`.
 - Construct brokers synchronously (`MemoryBroker::new()`, `NatsBroker::new(url)`); the runtime
@@ -89,9 +90,25 @@ let replies = TypedPublisher::new(b.broker().publisher()); // default codec
 b.include_publishing(confirm, replies);
 ```
 
+Return `Result<Reply, HandlerResult>` to control acknowledgement: `Ok(reply)` publishes and acks,
+`Err(result)` publishes nothing and the dispatcher acts on the returned `HandlerResult`. Spell the
+`Result` out in the signature (a type alias is treated as a plain reply type). A failed reply
+publish nacks the incoming message with `requeue = true`.
+
+```rust
+#[subscriber("orders", publish("confirmations"))]
+async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
+    if order.id == 0 {
+        return Err(HandlerResult::drop());
+    }
+    Ok(Confirmation { id: order.id, accepted: true })
+}
+```
+
 ## Choosing a codec
 
-`include` uses `DefaultCodec`. Name one per scope, or per call on a `Router`.
+`include` uses `DefaultCodec`. No mounting call takes a codec argument; change the default for a
+scope with `with_broker_codec`, or for a `Router` chain with `with_codec`.
 
 ```rust
 use ruststream::codec::CborCodec;
@@ -101,8 +118,8 @@ RustStream::new(info).with_broker_codec(broker, CborCodec, |b| {
     b.include(handle);
 });
 
-// one handler, on a Router
-Router::<MemoryBroker>::new().include_with(handle, CborCodec);
+// on a Router: with_codec applies to the includes after it (it can change mid-chain)
+Router::<MemoryBroker>::new().with_codec(CborCodec).include(handle);
 ```
 
 ## Routers
@@ -131,16 +148,15 @@ fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
 ## Broker-specific subscriptions
 
 For options the by-name form can't express (NATS JetStream, consumer groups), override the source
-with `include_on`. It is the source-override form, so it takes the codec explicitly.
+with `include_on`. The codec resolves the same way as for `include` (the default, or the scope /
+chain codec).
 
 ```rust
-use ruststream::codec::JsonCodec;
 use ruststream_nats::SubscribeOptions;
 
 b.include_on(
     SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("worker"),
     handle,
-    JsonCodec,
 );
 ```
 

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -106,6 +106,38 @@ fn type_from_constructor_path(path: &Path) -> syn::Result<Type> {
     }))
 }
 
+/// If `ty` is syntactically `Result<Reply, HandlerResult>` (under any path prefix, e.g.
+/// `std::result::Result` / `ruststream::runtime::HandlerResult`), returns the reply type.
+///
+/// The check is token-based: a type alias hiding the `Result` is not recognized and is treated as
+/// a plain reply type, which then fails to compile with a `Serialize` error the user can act on.
+fn publish_result_reply(ty: &Type) -> Option<&Type> {
+    let Type::Path(TypePath { qself: None, path }) = ty else {
+        return None;
+    };
+    let last = path.segments.last()?;
+    if last.ident != "Result" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    let mut args = args.args.iter();
+    let (Some(syn::GenericArgument::Type(ok)), Some(syn::GenericArgument::Type(err)), None) =
+        (args.next(), args.next(), args.next())
+    else {
+        return None;
+    };
+    let Type::Path(TypePath {
+        qself: None,
+        path: err_path,
+    }) = err
+    else {
+        return None;
+    };
+    (err_path.segments.last()?.ident == "HandlerResult").then_some(ok)
+}
+
 fn unsupported_source(expr: &Expr) -> syn::Error {
     syn::Error::new_spanned(
         expr,
@@ -120,17 +152,28 @@ fn unsupported_source(expr: &Expr) -> syn::Error {
 /// /// Processes incoming orders.
 /// #[subscriber("orders")]
 /// async fn handle(order: &Order) -> HandlerResult { HandlerResult::Ack }
-/// // later: broker_scope.include(handle, JsonCodec);
+/// // later: broker_scope.include(handle);
 ///
 /// // reply form: the return value is encoded and published to "responses" through the
 /// // TypedPublisher (broker + reply codec) passed at wiring time.
 /// #[subscriber("requests", publish("responses"))]
 /// async fn reply(req: &Request) -> Response { /* ... */ }
-/// // later: broker_scope.include_publishing(reply, JsonCodec, typed_publisher);
+/// // later: broker_scope.include_publishing(reply, typed_publisher);
+///
+/// // reply form with explicit ack control: `Ok` publishes the reply, `Err` skips it and the
+/// // dispatcher acts on the returned HandlerResult.
+/// #[subscriber("requests", publish("responses"))]
+/// async fn confirm(req: &Request) -> Result<Response, HandlerResult> { /* ... */ }
 /// ```
 ///
 /// Without `publish(..)` the handler returns any `IntoHandlerResult` (a `HandlerResult`, `()`, or
-/// `Result<_, E>`). With `publish(..)` it returns the reply value to publish.
+/// `Result<_, E>`). With `publish(..)` it returns the reply value to publish, or
+/// `Result<Reply, HandlerResult>` to control acknowledgement: `Err(result)` publishes nothing and
+/// returns `result` to the dispatcher. The `Result` form is detected syntactically, so spell it
+/// out in the signature (a type alias is treated as a plain reply type).
+///
+/// In both forms the handler may declare an optional second parameter, the per-delivery
+/// `&mut Context`, to read app state or publish manually.
 #[proc_macro_attribute]
 pub fn subscriber(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as SubscriberArgs);
@@ -187,11 +230,21 @@ fn expand_app(attr: &TokenStream2, func: &ItemFn) -> syn::Result<TokenStream> {
     .into())
 }
 
-fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
-    let vis = &func.vis;
-    let name = &func.sig.ident;
-    let block = &func.block;
+/// The pieces of the handler shared by both expansion forms, extracted from the signature.
+struct HandlerParts<'a> {
+    vis: &'a syn::Visibility,
+    name: &'a Ident,
+    block: &'a syn::Block,
+    pat: &'a syn::Pat,
+    input_ty: &'a Type,
+    description: TokenStream2,
+    source_ty: TokenStream2,
+    source_expr: TokenStream2,
+    input_schema: TokenStream2,
+    ctx_param: TokenStream2,
+}
 
+fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<HandlerParts<'a>> {
     let first = func.sig.inputs.first().ok_or_else(|| {
         syn::Error::new_spanned(
             &func.sig,
@@ -210,7 +263,7 @@ fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
             "the message parameter must be a reference `&T`",
         ));
     };
-    let input_ty = &reference.elem;
+    let input_ty = &*reference.elem;
     let description = doc_description(&func.attrs);
     let (source_ty, source_expr) = source_tokens(&args.source)?;
 
@@ -233,44 +286,111 @@ fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
         quote!(_ctx)
     };
 
+    Ok(HandlerParts {
+        vis: &func.vis,
+        name: &func.sig.ident,
+        block: &func.block,
+        pat,
+        input_ty,
+        description,
+        source_ty,
+        source_expr,
+        input_schema,
+        ctx_param,
+    })
+}
+
+fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
+    let parts = handler_parts(args, func)?;
     let body = if let Some(reply_topic) = &args.publish {
-        let reply_ty = match &func.sig.output {
-            ReturnType::Type(_, ty) => &**ty,
-            ReturnType::Default => {
-                return Err(syn::Error::new_spanned(
-                    &func.sig,
-                    "a publishing handler must return the reply value",
-                ));
+        expand_publishing(&parts, func, reply_topic)?
+    } else {
+        expand_subscribing(&parts)
+    };
+    Ok(body.into())
+}
+
+fn expand_publishing(
+    parts: &HandlerParts<'_>,
+    func: &ItemFn,
+    reply_topic: &LitStr,
+) -> syn::Result<TokenStream2> {
+    let HandlerParts {
+        vis,
+        name,
+        block,
+        pat,
+        input_ty,
+        description,
+        source_ty,
+        source_expr,
+        input_schema,
+        ctx_param,
+    } = parts;
+
+    let declared_ty = match &func.sig.output {
+        ReturnType::Type(_, ty) => &**ty,
+        ReturnType::Default => {
+            return Err(syn::Error::new_spanned(
+                &func.sig,
+                "a publishing handler must return the reply value",
+            ));
+        }
+    };
+    // `-> Result<Reply, HandlerResult>` lets the handler skip the publish: `Err(result)` is
+    // returned to the dispatcher as-is. A plain `-> Reply` is wrapped in `Ok` here. The check
+    // is syntactic, so a type alias hiding the `Result` is treated as a plain reply type.
+    let (reply_ty, call_body) = match publish_result_reply(declared_ty) {
+        Some(reply_ty) => (reply_ty, quote!((async move #block).await)),
+        None => (
+            declared_ty,
+            quote!(::core::result::Result::Ok((async move #block).await)),
+        ),
+    };
+    Ok(quote! {
+        #[allow(non_camel_case_types)]
+        #vis struct #name;
+
+        impl ::ruststream::runtime::PublishingDef for #name {
+            type Input = #input_ty;
+            type Reply = #reply_ty;
+            type Source = #source_ty;
+
+            fn source(&self) -> Self::Source { #source_expr }
+            fn reply_name(&self) -> &str { #reply_topic }
+
+            fn description(&self) -> ::core::option::Option<&str> {
+                #description
             }
-        };
-        quote! {
-            #[allow(non_camel_case_types)]
-            #vis struct #name;
 
-            impl ::ruststream::runtime::PublishingDef for #name {
-                type Input = #input_ty;
-                type Reply = #reply_ty;
-                type Source = #source_ty;
+            #input_schema
 
-                fn source(&self) -> Self::Source { #source_expr }
-                fn reply_name(&self) -> &str { #reply_topic }
-
-                fn description(&self) -> ::core::option::Option<&str> {
-                    #description
-                }
-
-                #input_schema
-
-                fn call(
-                    &self,
-                    #pat: &#input_ty,
-                ) -> impl ::core::future::Future<Output = #reply_ty> + ::core::marker::Send {
-                    async move #block
-                }
+            async fn call(
+                &self,
+                #pat: &#input_ty,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_>,
+            ) -> ::core::result::Result<#reply_ty, ::ruststream::runtime::HandlerResult> {
+                #call_body
             }
         }
-    } else {
-        quote! {
+    })
+}
+
+fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
+    let HandlerParts {
+        vis,
+        name,
+        block,
+        pat,
+        input_ty,
+        description,
+        source_ty,
+        source_expr,
+        input_schema,
+        ctx_param,
+    } = parts;
+
+    quote! {
             #[derive(Clone, Copy)]
             #[allow(non_camel_case_types)]
             #vis struct #name;
@@ -302,10 +422,7 @@ fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
 
                 fn into_handler(self) -> Self { self }
             }
-        }
-    };
-
-    Ok(body.into())
+    }
 }
 
 /// Derives [`Message`](../ruststream/trait.Message.html) metadata: the type name and its doc

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -39,6 +39,18 @@ async fn respond(req: &Request) -> Response {
 }
 // --8<-- [end:reply]
 
+// --8<-- [start:reply_result]
+// `Ok` publishes the reply and acks; `Err` publishes nothing and the dispatcher acts on the
+// returned HandlerResult (here: drop the malformed request instead of replying).
+#[subscriber("validated-requests", publish("responses"))]
+async fn validate(req: &Request) -> Result<Response, HandlerResult> {
+    if req.id == 0 {
+        return Err(HandlerResult::drop());
+    }
+    Ok(Response { ok: true })
+}
+// --8<-- [end:reply_result]
+
 // --8<-- [start:forward]
 #[subscriber("ingress")]
 async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
@@ -97,6 +109,8 @@ fn app() -> RustStream {
             // static, per-publisher: composed onto this TypedPublisher at compile time
             let replies = TypedPublisher::new(b.broker().publisher()).layer(EnvelopeLayer);
             b.include_publishing(respond, replies);
+            let validated = TypedPublisher::new(b.broker().publisher());
+            b.include_publishing(validate, validated);
             b.include(forward);
         })
     // --8<-- [end:pipeline]

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -51,8 +51,16 @@ pub trait PublishingDef: Send + Sync {
         None
     }
 
-    /// Runs the handler body, producing the reply.
-    fn call(&self, input: &Self::Input) -> impl Future<Output = Self::Reply> + Send;
+    /// Runs the handler body.
+    ///
+    /// `Ok(reply)` is encoded and published to [`reply_name`](Self::reply_name), then the incoming
+    /// message is acked. `Err(result)` skips publishing and the dispatcher acts on the returned
+    /// [`HandlerResult`] (for example [`HandlerResult::retry`] to ask for redelivery).
+    fn call(
+        &self,
+        input: &Self::Input,
+        ctx: &mut Context<'_>,
+    ) -> impl Future<Output = Result<Self::Reply, HandlerResult>> + Send;
 }
 
 /// Builds the registration metadata for a publishing definition mounted under `name`.
@@ -72,7 +80,9 @@ pub(crate) fn publishing_metadata<D: PublishingDef>(name: String, def: &D) -> Ha
 ///
 /// `C` decodes the incoming message; the reply is encoded by the [`TypedPublisher`] (with its static
 /// [`PublishLayer`] stack `PL`) and sent to the definition's
-/// [`reply_name`](PublishingDef::reply_name).
+/// [`reply_name`](PublishingDef::reply_name). A handler returning `Err(result)` skips the publish;
+/// a failed reply publish nacks the incoming message with `requeue = true`, so the broker
+/// redelivers it instead of silently losing the reply.
 pub struct PublishingHandler<D, C, P, PC, PL> {
     pub(crate) def: D,
     pub(crate) codec: C,
@@ -99,7 +109,7 @@ where
     PC: Codec,
     PL: PublishLayer,
 {
-    async fn handle(&self, msg: &M, _ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
             Ok(value) => value,
             Err(err) => {
@@ -107,10 +117,14 @@ where
                 return HandlerResult::drop();
             }
         };
-        let reply = self.def.call(&input).await;
+        let reply = match self.def.call(&input, ctx).await {
+            Ok(reply) => reply,
+            Err(result) => return result,
+        };
         let name = self.def.reply_name();
         if let Err(err) = self.publisher.publish(name, &reply, &self.pipeline).await {
             warn!(target: "ruststream::dispatch", error = %err, "reply publish failed");
+            return HandlerResult::retry();
         }
         HandlerResult::Ack
     }

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -450,3 +450,150 @@ async fn macro_publisher_replies_cross_broker() {
     shutdown.notify_one();
     run.await.unwrap().unwrap();
 }
+
+#[derive(Serialize, Deserialize)]
+struct Confirmation {
+    id: u32,
+    accepted: bool,
+}
+
+static CONFIRM_REJECTED: AtomicU32 = AtomicU32::new(0);
+static CONFIRM_ACCEPTED: AtomicU32 = AtomicU32::new(0);
+
+#[subscriber("confirm-in", publish("confirm-out"))]
+async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
+    if order.id == 0 {
+        CONFIRM_REJECTED.fetch_add(1, Ordering::SeqCst);
+        return Err(HandlerResult::drop());
+    }
+    Ok(Confirmation {
+        id: order.id,
+        accepted: true,
+    })
+}
+
+#[subscriber("confirm-out")]
+async fn confirm_sink(c: &Confirmation) -> HandlerResult {
+    if c.accepted {
+        CONFIRM_ACCEPTED.store(c.id, Ordering::SeqCst);
+    }
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publishing_result_form_controls_ack_and_publish() {
+    let broker = MemoryBroker::new();
+    let ingress = broker.publisher();
+    let replies = TypedPublisher::new(broker.publisher());
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include_publishing(confirm, replies);
+        b.include(confirm_sink);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // Err(HandlerResult) skips the publish entirely.
+    let rejected = serde_json::to_vec(&Order { id: 0, total: 0.0 }).unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = ingress
+                .publish(OutgoingMessage::new("confirm-in", &rejected))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if CONFIRM_REJECTED.load(Ordering::SeqCst) >= 3 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "Err branch of the publishing handler did not run",
+    );
+    assert_eq!(
+        CONFIRM_ACCEPTED.load(Ordering::SeqCst),
+        0,
+        "Err(..) must not publish a reply",
+    );
+
+    // Ok(reply) publishes and acks.
+    let accepted = serde_json::to_vec(&Order { id: 6, total: 1.0 }).unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = ingress
+                .publish(OutgoingMessage::new("confirm-in", &accepted))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if CONFIRM_ACCEPTED.load(Ordering::SeqCst) == 6 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "Ok branch did not publish the reply");
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+/// App state read from the publishing handler's optional `&mut Context` parameter.
+#[derive(Clone, Copy)]
+struct Bump(u32);
+
+static CTX_REPLY: AtomicU32 = AtomicU32::new(0);
+
+#[subscriber("ctx-in", publish("ctx-out"))]
+async fn ctx_reply(req: &Request, ctx: &mut Context) -> Response {
+    let bump = ctx.get::<Bump>().map_or(0, |b| b.0);
+    Response {
+        doubled: req.n + bump,
+    }
+}
+
+#[subscriber("ctx-out")]
+async fn ctx_sink(resp: &Response) -> HandlerResult {
+    CTX_REPLY.store(resp.doubled, Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publishing_handler_reads_context_state() {
+    let broker = MemoryBroker::new();
+    let ingress = broker.publisher();
+    let replies = TypedPublisher::new(broker.publisher());
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .insert_state(Bump(100))
+        .with_broker(broker, |b| {
+            b.include_publishing(ctx_reply, replies);
+            b.include(ctx_sink);
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Request { n: 1 }).unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = ingress
+                .publish(OutgoingMessage::new("ctx-in", &payload))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if CTX_REPLY.load(Ordering::SeqCst) == 101 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "publishing handler did not read app state from the context",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
# Description

Stacked on #27 (merged; rebased onto main after the squash-merges).

- PublishingDef::call now takes the per-delivery &mut Context (read app state, resolve named publishers) and returns Result<Reply, HandlerResult>: Ok(reply) is encoded, published, and the incoming message acked; Err(result) publishes nothing and the dispatcher acts on the returned HandlerResult.
- #[subscriber(.., publish(..))] handlers may declare the optional second &mut Context parameter, like the plain form, and may return Result<Reply, HandlerResult> for explicit ack control:

  ```rust
  #[subscriber("orders", publish("confirmations"))]
  async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
      if order.quantity == 0 {
          return Err(HandlerResult::retry());
      }
      Ok(Confirmation { id: order.id, accepted: true })
  }
  ```

  The Result form is detected syntactically from the written signature; a plain -> Reply is wrapped in Ok, so existing handlers keep working.
- The .cursor/rules/usage.mdc prompt is caught up with the 0.3 API in a separate commit: Router::with_codec(..).include(..) instead of the removed include_with, the codec-free include_on, and the new Result reply form.
- A failed reply publish now nacks the incoming message with requeue = true so the broker redelivers it, instead of acking and silently losing the reply.

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc here; the docs site lands in #31)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
