### PR TITLE
asyncapi: wire the Message trait into the generated document

### DIFF
--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -241,6 +241,7 @@ struct HandlerParts<'a> {
     source_ty: TokenStream2,
     source_expr: TokenStream2,
     input_schema: TokenStream2,
+    message_meta: TokenStream2,
     ctx_param: TokenStream2,
 }
 
@@ -278,6 +279,22 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         }
     };
 
+    // Captures the input type's `Message` name / description when it implements that trait, via
+    // the same autoref-specialization probe; `None` otherwise.
+    let message_meta = quote! {
+        fn message_name(&self) -> ::core::option::Option<&'static str> {
+            #[allow(unused_imports)]
+            use ::ruststream::__private::NoMessageProbe as _;
+            ::ruststream::__private::Probe::<#input_ty>::new().message_name()
+        }
+
+        fn message_description(&self) -> ::core::option::Option<&'static str> {
+            #[allow(unused_imports)]
+            use ::ruststream::__private::NoMessageProbe as _;
+            ::ruststream::__private::Probe::<#input_ty>::new().message_description()
+        }
+    };
+
     // Optional second handler parameter: the per-delivery `&mut Context`. If the user declares it,
     // bind it to their name; otherwise generate an ignored binding.
     let ctx_param = if let Some(FnArg::Typed(PatType { pat, .. })) = func.sig.inputs.get(1) {
@@ -296,6 +313,7 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         source_ty,
         source_expr,
         input_schema,
+        message_meta,
         ctx_param,
     })
 }
@@ -325,6 +343,7 @@ fn expand_publishing(
         source_ty,
         source_expr,
         input_schema,
+        message_meta,
         ctx_param,
     } = parts;
 
@@ -365,6 +384,8 @@ fn expand_publishing(
 
             #input_schema
 
+            #message_meta
+
             async fn call(
                 &self,
                 #pat: &#input_ty,
@@ -387,6 +408,7 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
         source_ty,
         source_expr,
         input_schema,
+        message_meta,
         ctx_param,
     } = parts;
 
@@ -419,6 +441,8 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
                 }
 
                 #input_schema
+
+                #message_meta
 
                 fn into_handler(self) -> Self { self }
             }

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -102,6 +102,9 @@ pub struct Operation {
     pub channel: Reference,
     /// The messages this operation handles.
     pub messages: Vec<Reference>,
+    /// Optional human description, typically from the handler's doc comment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Reusable `AsyncAPI` components.
@@ -206,7 +209,11 @@ pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
 
     for handler in app.handlers() {
         let name = handler.name.as_ref();
-        let message_name = message_name(handler.input_type);
+        // A `Message` impl on the input type names the component; the type name is the fallback.
+        let message_name = handler
+            .message_name
+            .as_ref()
+            .map_or_else(|| message_name(handler.input_type), ToString::to_string);
 
         channels.entry(name.to_owned()).or_insert_with(|| Channel {
             address: name.to_owned(),
@@ -224,6 +231,7 @@ pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
                 messages: vec![Reference::new(format!(
                     "#/channels/{name}/messages/{message_name}"
                 ))],
+                description: handler.description.as_ref().map(ToString::to_string),
             },
         );
 
@@ -231,7 +239,13 @@ pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
             .entry(message_name.clone())
             .or_insert_with(|| MessageObject {
                 name: message_name,
-                description: handler.description.as_ref().map(ToString::to_string),
+                // The `Message` description documents the type itself; the handler doc (already
+                // on the operation) doubles as a fallback so plain types keep their description.
+                description: handler
+                    .message_description
+                    .as_ref()
+                    .or(handler.description.as_ref())
+                    .map(ToString::to_string),
                 payload: handler
                     .payload_schema
                     .as_deref()

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -209,11 +209,27 @@ pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
 
     for handler in app.handlers() {
         let name = handler.name.as_ref();
-        // A `Message` impl on the input type names the component; the type name is the fallback.
+        let payload = handler
+            .payload_schema
+            .as_deref()
+            .and_then(|json| serde_json::from_str::<Value>(json).ok());
+        // The JsonSchema derive captures the type's own doc comment (and a schemars title /
+        // rename), so a documented payload type feeds the component without a Message impl.
+        let schema_str = |key: &str| {
+            payload
+                .as_ref()
+                .and_then(|schema| schema.get(key))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        };
+        // A `Message` impl on the input type names the component; the schema title is next; the
+        // type name is the fallback.
         let message_name = handler
             .message_name
             .as_ref()
-            .map_or_else(|| message_name(handler.input_type), ToString::to_string);
+            .map(ToString::to_string)
+            .or_else(|| schema_str("title"))
+            .unwrap_or_else(|| message_name(handler.input_type));
 
         channels.entry(name.to_owned()).or_insert_with(|| Channel {
             address: name.to_owned(),
@@ -235,21 +251,21 @@ pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
             },
         );
 
+        // Message::DESCRIPTION wins, then the type's own doc comment from the schema, then the
+        // handler doc (already on the operation) so plain types keep their description.
+        let message_description = handler
+            .message_description
+            .as_ref()
+            .map(ToString::to_string)
+            .or_else(|| schema_str("description"))
+            .or_else(|| handler.description.as_ref().map(ToString::to_string));
+
         messages
             .entry(message_name.clone())
             .or_insert_with(|| MessageObject {
                 name: message_name,
-                // The `Message` description documents the type itself; the handler doc (already
-                // on the operation) doubles as a fallback so plain types keep their description.
-                description: handler
-                    .message_description
-                    .as_ref()
-                    .or(handler.description.as_ref())
-                    .map(ToString::to_string),
-                payload: handler
-                    .payload_schema
-                    .as_deref()
-                    .and_then(|json| serde_json::from_str(json).ok()),
+                description: message_description,
+                payload,
             });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,4 +153,39 @@ pub mod __private {
             serde_json::to_string(&schemars::schema_for!(T)).ok()
         }
     }
+
+    /// The trait fallback for [`Message`](crate::Message) metadata: chosen for any `T` the
+    /// inherent methods below do not cover.
+    pub trait NoMessageProbe {
+        /// Returns `None` (the probed type does not implement `Message`).
+        fn message_name(&self) -> Option<&'static str>;
+        /// Returns `None` (the probed type does not implement `Message`).
+        fn message_description(&self) -> Option<&'static str>;
+    }
+
+    impl<T> NoMessageProbe for Probe<T> {
+        fn message_name(&self) -> Option<&'static str> {
+            None
+        }
+
+        fn message_description(&self) -> Option<&'static str> {
+            None
+        }
+    }
+
+    impl<T: crate::Message> Probe<T> {
+        /// Returns [`Message::NAME`](crate::Message::NAME) for `T` (inherent; preferred over the
+        /// trait fallback).
+        #[must_use]
+        pub fn message_name(&self) -> Option<&'static str> {
+            Some(T::NAME)
+        }
+
+        /// Returns [`Message::DESCRIPTION`](crate::Message::DESCRIPTION) for `T` (inherent;
+        /// preferred over the trait fallback).
+        #[must_use]
+        pub fn message_description(&self) -> Option<&'static str> {
+            T::DESCRIPTION
+        }
+    }
 }

--- a/src/runtime/metadata.rs
+++ b/src/runtime/metadata.rs
@@ -23,6 +23,12 @@ pub struct HandlerMetadata {
     /// [`schemars::JsonSchema`] (captured under the `asyncapi` feature). Feeds the `AsyncAPI`
     /// message payload schema.
     pub payload_schema: Option<String>,
+    /// The input type's [`Message`](crate::Message) name, when it implements that trait. Overrides
+    /// the `input_type`-derived name in the `AsyncAPI` document.
+    pub message_name: Option<Cow<'static, str>>,
+    /// The input type's [`Message`](crate::Message) description, when it implements that trait.
+    /// Feeds the `AsyncAPI` message description.
+    pub message_description: Option<Cow<'static, str>>,
 }
 
 impl HandlerMetadata {
@@ -36,6 +42,8 @@ impl HandlerMetadata {
             output_type: None,
             description: None,
             payload_schema: None,
+            message_name: None,
+            message_description: None,
         }
     }
 
@@ -51,6 +59,8 @@ impl HandlerMetadata {
             output_type: None,
             description: None,
             payload_schema: None,
+            message_name: None,
+            message_description: None,
         }
     }
 
@@ -79,6 +89,20 @@ impl HandlerMetadata {
     #[must_use]
     pub fn with_payload_schema(mut self, schema: impl Into<String>) -> Self {
         self.payload_schema = Some(schema.into());
+        self
+    }
+
+    /// Builder-style setter for the [`Message`](crate::Message) name of the input type.
+    #[must_use]
+    pub fn with_message_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.message_name = Some(name.into());
+        self
+    }
+
+    /// Builder-style setter for the [`Message`](crate::Message) description of the input type.
+    #[must_use]
+    pub fn with_message_description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
+        self.message_description = Some(description.into());
         self
     }
 }

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -51,6 +51,18 @@ pub trait PublishingDef: Send + Sync {
         None
     }
 
+    /// The input type's [`Message`](crate::Message) name, when it implements that trait. The macro
+    /// fills this in; the default omits it.
+    fn message_name(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// The input type's [`Message`](crate::Message) description, when it implements that trait.
+    /// The macro fills this in; the default omits it.
+    fn message_description(&self) -> Option<&'static str> {
+        None
+    }
+
     /// Runs the handler body.
     ///
     /// `Ok(reply)` is encoded and published to [`reply_name`](Self::reply_name), then the incoming
@@ -72,6 +84,12 @@ pub(crate) fn publishing_metadata<D: PublishingDef>(name: String, def: &D) -> Ha
     }
     if let Some(schema) = def.input_schema() {
         meta = meta.with_payload_schema(schema);
+    }
+    if let Some(message_name) = def.message_name() {
+        meta = meta.with_message_name(message_name);
+    }
+    if let Some(message_description) = def.message_description() {
+        meta = meta.with_message_description(message_description);
     }
     meta
 }

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -37,6 +37,18 @@ pub trait SubscriberDef: Sized {
         None
     }
 
+    /// The input type's [`Message`](crate::Message) name, when it implements that trait. The macro
+    /// fills this in; the default omits it.
+    fn message_name(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// The input type's [`Message`](crate::Message) description, when it implements that trait.
+    /// The macro fills this in; the default omits it.
+    fn message_description(&self) -> Option<&'static str> {
+        None
+    }
+
     /// Consumes the definition, returning the handler.
     fn into_handler(self) -> Self::Handler;
 }
@@ -49,6 +61,12 @@ pub(crate) fn subscriber_metadata<D: SubscriberDef>(name: String, def: &D) -> Ha
     }
     if let Some(schema) = def.input_schema() {
         meta = meta.with_payload_schema(schema);
+    }
+    if let Some(message_name) = def.message_name() {
+        meta = meta.with_message_name(message_name);
+    }
+    if let Some(message_description) = def.message_description() {
+        meta = meta.with_message_description(message_description);
     }
     meta
 }

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -117,3 +117,58 @@ fn build_spec_emits_payload_schema() {
     assert!(props.get("id").is_some());
     assert!(props.get("total").is_some());
 }
+
+/// An order with custom `Message` metadata: the manual impl overrides both the component name and
+/// the description in the generated document.
+#[derive(serde::Deserialize)]
+struct RenamedOrder {
+    #[allow(dead_code)]
+    id: u32,
+}
+
+impl ruststream::Message for RenamedOrder {
+    const NAME: &'static str = "CustomOrder";
+    const DESCRIPTION: Option<&'static str> = Some("An order, renamed for the wire.");
+}
+
+/// Receives renamed orders.
+#[ruststream::subscriber("renamed-orders")]
+async fn handle_renamed(order: &RenamedOrder) -> HandlerResult {
+    let _ = order;
+    HandlerResult::Ack
+}
+
+#[test]
+fn message_impl_names_and_describes_the_component() {
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle_renamed));
+
+    let spec = build_spec(&app);
+
+    let message = spec
+        .components
+        .messages
+        .get("CustomOrder")
+        .expect("Message::NAME must name the component");
+    assert_eq!(
+        message.description.as_deref(),
+        Some("An order, renamed for the wire."),
+        "Message::DESCRIPTION must describe the component",
+    );
+
+    let operation = spec
+        .operations
+        .get("receive_renamed_orders")
+        .expect("operation must exist");
+    assert_eq!(
+        operation.description.as_deref(),
+        Some("Receives renamed orders."),
+        "the handler doc comment must land on the operation",
+    );
+
+    let channel = spec.channels.get("renamed-orders").expect("channel");
+    assert!(
+        channel.messages.contains_key("CustomOrder"),
+        "the channel must reference the renamed component",
+    );
+}

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -172,3 +172,51 @@ fn message_impl_names_and_describes_the_component() {
         "the channel must reference the renamed component",
     );
 }
+
+/// A shipment, documented only by its doc comment.
+#[derive(serde::Deserialize, ruststream::schemars::JsonSchema)]
+#[schemars(title = "WireShipment")]
+struct Shipment {
+    #[allow(dead_code)]
+    id: u32,
+}
+
+/// Receives shipments.
+#[ruststream::subscriber("shipments")]
+async fn handle_shipment(shipment: &Shipment) -> HandlerResult {
+    let _ = shipment;
+    HandlerResult::Ack
+}
+
+#[test]
+fn schema_doc_comment_feeds_message_metadata() {
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle_shipment));
+
+    let spec = build_spec(&app);
+
+    // No Message impl: the schemars title names the component and the type's own doc comment
+    // becomes the message description.
+    let message = spec
+        .components
+        .messages
+        .get("WireShipment")
+        .expect("the schema title must name the component");
+    assert_eq!(
+        message.description.as_deref(),
+        Some("A shipment, documented only by its doc comment."),
+        "the type's doc comment must describe the component",
+    );
+    assert!(
+        spec.channels["shipments"]
+            .messages
+            .contains_key("WireShipment"),
+        "the channel must reference the schema-titled component",
+    );
+
+    // The handler doc comment stays on the operation.
+    assert_eq!(
+        spec.operations["receive_shipments"].description.as_deref(),
+        Some("Receives shipments."),
+    );
+}


### PR DESCRIPTION
# Description

Stacked on #28.

Message (NAME / DESCRIPTION) and its derive existed but fed nothing. Now the #[subscriber] macro probes the input type for a Message impl (the same inherent-vs-trait specialization as the JsonSchema probe), the def traits carry it via defaulted message_name / message_description methods into HandlerMetadata, and build_spec:

- prefers Message::NAME as the message component name (a manual impl can keep the wire contract stable across Rust type renames),
- uses Message::DESCRIPTION as the message description,
- moves the handler doc comment to the operation's own description field, keeping it as the message-description fallback so plain payload types produce the same output as before.

A second commit makes documented payload types feed the component without a manual Message impl: the JsonSchema derive already captures the type's doc comment (and a schemars title / rename) into the payload schema, so build_spec resolves the component name as Message::NAME -> schema title -> type name, and the description as Message::DESCRIPTION -> the type's doc comment -> the handler doc.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc here; the docs site lands in #31)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
