### PR TITLE
memory: make MemorySubscriber::stream re-enterable; drop tokio-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -1085,17 +1084,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ autotests = false
 
 [features]
 default = ["json"]
-memory = ["dep:tokio-stream"]
+memory = []
 conformance = []
 json = ["dep:serde_json"]
 msgpack = ["dep:rmp-serde"]
@@ -183,7 +183,6 @@ ciborium = { version = "0.2", optional = true }
 prometheus = { version = "0.13", default-features = false, optional = true }
 schemars = { version = "0.8", optional = true }
 serde_norway = { version = "0.9", optional = true }
-tokio-stream = { version = "0.1", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }
 
@@ -191,7 +190,6 @@ anyhow = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
-tokio-stream = "0.1"
 tempfile = "3"
 axum = "0.8"
 # `testing` pulls the in-memory NATS test broker used by tests/doc_testing_nats.rs (the snippet

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -27,7 +27,6 @@ use tokio::{
     sync::{Notify, mpsc},
     time::timeout,
 };
-use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 
 type Sender = mpsc::UnboundedSender<MemoryDelivery>;
 
@@ -97,7 +96,7 @@ impl MemoryBroker {
         self.state.register(name.clone(), tx.clone());
         MemorySubscriber {
             name,
-            rx: Some(rx),
+            rx,
             requeue: tx,
         }
     }
@@ -181,7 +180,7 @@ impl SubscriptionSource<MemoryBroker> for MemorySource {
 /// delivery; consumers must call `ack` or `nack` on each.
 pub struct MemorySubscriber {
     name: String,
-    rx: Option<mpsc::UnboundedReceiver<MemoryDelivery>>,
+    rx: mpsc::UnboundedReceiver<MemoryDelivery>,
     requeue: Sender,
 }
 
@@ -198,15 +197,17 @@ impl Subscriber for MemorySubscriber {
     type Error = Infallible;
 
     fn stream(&mut self) -> impl Stream<Item = Result<Self::Message, Self::Error>> + Send + '_ {
-        let rx = self
-            .rx
-            .take()
-            .expect("MemorySubscriber::stream called more than once");
         let requeue = self.requeue.clone();
-        UnboundedReceiverStream::new(rx).map(move |delivery| {
-            Ok(MemoryMessage {
-                delivery: Some(delivery),
-                requeue: requeue.clone(),
+        // Poll the receiver in place rather than wrapping it in an owning stream, so `stream` can
+        // be called again after the returned stream is dropped (helpers re-enter it per call).
+        futures::stream::poll_fn(move |cx| {
+            self.rx.poll_recv(cx).map(|next| {
+                next.map(|delivery| {
+                    Ok(MemoryMessage {
+                        delivery: Some(delivery),
+                        requeue: requeue.clone(),
+                    })
+                })
             })
         })
     }
@@ -379,5 +380,41 @@ impl TestClient for MemoryBroker {
 
     async fn shutdown(self) -> Result<(), Self::Error> {
         <Self as Broker>::shutdown(&self).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn stream_can_be_reentered() {
+        let broker = MemoryBroker::new();
+        let mut sub = MemoryBroker::subscribe(&broker, "test");
+        let publisher = broker.publisher();
+
+        publisher
+            .publish(OutgoingMessage::new("test", b"one".as_slice()))
+            .await
+            .unwrap();
+        {
+            let mut stream = std::pin::pin!(sub.stream());
+            let msg = stream.next().await.unwrap().unwrap();
+            assert_eq!(msg.payload(), b"one");
+            msg.ack().await.unwrap();
+        }
+
+        // Helpers like `conformance::helpers::next_message` re-enter `stream` per call; the
+        // subscriber must keep yielding after the first stream is dropped.
+        publisher
+            .publish(OutgoingMessage::new("test", b"two".as_slice()))
+            .await
+            .unwrap();
+        let mut stream = std::pin::pin!(sub.stream());
+        let msg = stream.next().await.unwrap().unwrap();
+        assert_eq!(msg.payload(), b"two");
+        msg.ack().await.unwrap();
     }
 }


### PR DESCRIPTION
# Description

Stacked on #29.

MemorySubscriber::stream() took the receiver out of an Option and panicked on a second call, while the Subscriber contract (and the conformance helpers, which re-enter stream() per call) allow it. The receiver is now polled in place, so dropping the returned stream between polls and calling stream() again just works; a regression test covers the re-entry.

The owning UnboundedReceiverStream wrapper was the only tokio-stream use, so the dependency is removed entirely (the memory feature no longer pulls anything extra).

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)