### PR TITLE
docs: catch the guides up with the 0.3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ the framework.
 
 ```toml
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <a href="https://docs.rs/ruststream"><img src="https://img.shields.io/docsrs/ruststream" alt="docs.rs"></a>
   <img src="https://img.shields.io/badge/MSRV-1.85-blue.svg" alt="MSRV 1.85">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License">
+  <a href="https://t.me/ruststream_community"><img src="https://img.shields.io/badge/-Telegram-blue?logo=telegram&label=News" alt="Telegram news channel"></a>
+  <a href="https://t.me/ruststream_communuty_ru_chat"><img src="https://img.shields.io/badge/-Telegram-blue?logo=telegram&label=RU" alt="Telegram RU chat"></a>
   <a href="https://context7.com/powersemmi/ruststream"><img src="https://img.shields.io/badge/Context7-Ask_AI-ff5722" alt="Ask AI"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the framework.
 [dependencies]
 ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
-schemars = "0.8"
+schemars = "1"
 ```
 
 The CLI ships with the crate behind the `cli` feature:

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -11,7 +11,7 @@ subscribe -> publish -> ack -> `shutdown` works on the real transport.
 
 ```toml
 [dev-dependencies]
-ruststream = { version = "0.2", features = ["conformance"] }
+ruststream = { version = "0.3", features = ["conformance"] }
 ```
 
 Enable your crate's own `testing` feature alongside it, since `run_suite` drives the `TestClient` you

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -21,7 +21,7 @@ default = []
 testing = ["ruststream/conformance"]
 
 [dependencies]
-ruststream = { version = "0.2", default-features = false }
+ruststream = { version = "0.3", default-features = false }
 async-nats = "0.46"
 bytes = "1"
 futures = "0.3"

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -6,7 +6,7 @@ any other broker:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.2", default-features = false }
+ruststream = { version = "0.3", default-features = false }
 ```
 
 This page is the contract. Implement the required traits, expose your own `Config`, add capability

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -5,7 +5,7 @@ which makes it ideal for examples, unit tests, and prototypes; the CLI scaffold 
 so a fresh project runs with zero dependencies.
 
 ```toml
-ruststream = { version = "0.2", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
 ```
 
 ```rust

--- a/docs/brokers/nats.md
+++ b/docs/brokers/nats.md
@@ -5,8 +5,8 @@ Core NATS subjects and JetStream durable consumers, and ships an in-memory test 
 `testing` feature.
 
 ```toml
-ruststream = { version = "0.2", features = ["macros"] }
-ruststream-nats = "0.2"
+ruststream = { version = "0.3", features = ["macros"] }
+ruststream-nats = "0.3"
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -32,8 +32,8 @@ Wire it onto the broker; the `with_broker` / `include` part is identical to the 
 
 To consume from JetStream instead, override the handler's by-name source with `SubscribeOptions`,
 naming the stream and a durable consumer so progress survives restarts. The handler's
-`HandlerResult::Ack` acks back to JetStream. `include_on` is the source-override form, so it takes
-the codec explicitly.
+`HandlerResult::Ack` acks back to JetStream. `include_on` is the source-override form; the codec
+resolves the same way as for `include`.
 
 ```rust
 --8<-- "examples/nats_jetstream.rs:include_on"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ features. Add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -40,7 +40,7 @@ Codec features are mutually compatible; enable as many as you need (see
 
 ```toml
 [dependencies]
-ruststream = { version = "0.2", default-features = false }
+ruststream = { version = "0.3", default-features = false }
 ```
 
 ## The CLI
@@ -61,11 +61,11 @@ which re-exports what it needs from `ruststream`:
 
 ```toml
 [dependencies]
-ruststream-nats = "0.2"
+ruststream-nats = "0.3"
 
 [dev-dependencies]
 # the broker's in-memory test client, for handler tests
-ruststream-nats = { version = "0.2", features = ["testing"] }
+ruststream-nats = { version = "0.3", features = ["testing"] }
 ```
 
 Each broker crate documents its own `Config` and capabilities; the available brokers are listed

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -18,7 +18,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.2", features = ["macros", "memory", "json", "asyncapi"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json", "asyncapi"] }
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -5,7 +5,7 @@ document from the application's handlers: each subscriber becomes a channel and 
 operation, and payload types contribute schemas.
 
 ```toml
-ruststream = { version = "0.2", features = ["macros", "memory", "asyncapi"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "asyncapi"] }
 ```
 
 ## Generating the document
@@ -39,6 +39,27 @@ A handler's payload type appears as a schema when it derives `JsonSchema`. RustS
 
 A type without `JsonSchema` still works as a handler payload; it just contributes no schema to the
 document.
+
+## Message names and descriptions
+
+By default a message component is named after the payload type, and its description falls back to
+the handler's doc comment (which also documents the `receive` operation). To name and describe the
+message itself, implement the `Message` trait - or derive it, which uses the type's name and doc
+comment:
+
+```rust
+use ruststream::Message;
+
+/// An order placed by a customer.
+#[derive(Message, serde::Deserialize)]
+struct Order {
+    id: u64,
+}
+// In the document: components.messages.Order with that description.
+```
+
+A manual `impl Message` can name the component differently from the Rust type
+(`const NAME: &'static str = "CustomOrder";`), which keeps the wire contract stable across renames.
 
 ## Servers
 

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -42,10 +42,15 @@ document.
 
 ## Message names and descriptions
 
-By default a message component is named after the payload type, and its description falls back to
-the handler's doc comment (which also documents the `receive` operation). To name and describe the
-message itself, implement the `Message` trait - or derive it, which uses the type's name and doc
-comment:
+A documented payload type feeds the message component on its own: with the `JsonSchema` derive,
+the type's doc comment becomes the message description, and a `#[schemars(title = "...")]` (or
+rename) names the component. Without a schema, the component is named after the payload type and
+the description falls back to the handler's doc comment (which also documents the `receive`
+operation).
+
+To control the metadata explicitly - including for types without `JsonSchema` - implement the
+`Message` trait, which takes precedence over the schema; or derive it, which uses the type's name
+and doc comment:
 
 ```rust
 use ruststream::Message;

--- a/docs/guides/codecs.md
+++ b/docs/guides/codecs.md
@@ -62,8 +62,9 @@ When nothing above names a codec, `include` uses [`DefaultCodec`](#the-default-c
 Publishers mirror the same rules: `TypedPublisher::new(publisher)` encodes replies with the default
 codec, and `TypedPublisher::with_codec(publisher, codec)` names one. `include_publishing(def,
 publisher)` reuses the publisher's codec to decode the incoming request, so one mounting names one
-codec. The request and reply formats can still differ: mount with `include_publishing_on` and name
-the decode codec explicitly.
+codec. The request and reply formats can still differ: set the decode codec on the scope
+(`with_broker_codec`) or on the router chain (`Router::with_codec`) and keep the reply codec on the
+`TypedPublisher`.
 
 There is no per-message-type codec (no associated codec on a message trait): the codec is a
 property of the mounting, not of the type.
@@ -88,5 +89,5 @@ dead-letter or max-deliveries policy. The codec examples above are
 ## Custom codecs
 
 A codec is any type implementing the `Codec` trait, so you can supply your own (a schema-registry
-envelope, an encrypting wrapper) and pass it anywhere a built-in codec goes: `include_on`,
+envelope, an encrypting wrapper) and pass it anywhere a built-in codec goes:
 `with_broker_codec`, `Router::with_codec`, or `TypedPublisher::with_codec`.

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -15,7 +15,7 @@ When the `logging` feature is enabled, the `#[ruststream::app]` CLI calls the lo
 `run` command, so a scaffolded service logs out of the box:
 
 ```toml
-ruststream = { version = "0.2", features = ["macros", "memory", "json", "logging"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "json", "logging"] }
 ```
 
 ```bash

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -4,7 +4,7 @@ The `metrics` feature collects Prometheus metrics for consumed and published mes
 the `prometheus` crate directly and exposes the data in the Prometheus exposition format.
 
 ```toml
-ruststream = { version = "0.2", features = ["macros", "memory", "metrics"] }
+ruststream = { version = "0.3", features = ["macros", "memory", "metrics"] }
 ```
 
 ## Wiring it up

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -6,19 +6,19 @@ dispatch path.
 
 ## Middleware scopes
 
-Today the two scopes are independent: a layer lives either on the **application** or on a
-**router**, and one does not see the other's handlers.
+The two scopes compose: the application stack is the outer one, a router's own stack sits inside
+it.
 
 **Application scope.** Add a layer to the whole application with `RustStream::layer`, before
-`with_broker`. Every handler registered directly on a broker scope is wrapped with it - but not the
-handlers a router brings in, because a router is finalized independently:
+`with_broker`. Every handler registered after it is wrapped - both handlers registered directly on
+a broker scope and handlers a router brings in via `include_router`:
 
 ```rust
 --8<-- "examples/middleware_app_scope.rs:app_scope"
 ```
 
 **Router scope.** Give a router its own middleware with `Router::layer`, which wraps every handler
-registered on it after the call (see [Routing](routing.md#router-middleware)). Handlers mounted
+on that router when it is mounted (see [Routing](routing.md#router-middleware)). Handlers mounted
 directly on the broker scope stay outside it:
 
 ```rust
@@ -32,14 +32,14 @@ and
 `LogLayer` is the hand-written layer from the next section, and the built-in
 `layers::TracingLayer` mounts the same way.
 
-!!! warning "Planned for 0.3: routers inherit the application scope"
-    The separation above is the 0.2 behaviour. In 0.3 a router will inherit the application's
-    stack, so app-level layers will wrap router handlers too (composing outside the router's own
-    `Router::layer` stack). Until then, a layer that must cover everything has to be added in both
-    places explicitly.
-
 The first layer added is the outermost. Both stacks are static: zero runtime dispatch cost, and
 the type grows as you call `layer`.
+
+!!! note "Reaching router handlers requires a `BlanketLayer`"
+    A router hides its handlers' concrete types, so a layer that wraps them (the app stack at
+    `include_router`, or `Router::layer`) must implement `BlanketLayer` - one generic method that
+    wraps any handler. The bundled layers implement it; for a custom layer it is a few lines next
+    to its `Layer` impl (see `LogLayer` in the examples above).
 
 ## Writing a layer
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -28,8 +28,28 @@ RustStream::new(info).with_broker(broker, |b| {
 ```
 
 The `TypedPublisher`'s codec encodes the reply, and `include_publishing` reuses it to decode the
-incoming request. To decode the request with a different codec, mount with `include_publishing_on`
-and name it explicitly; see [Codecs](codecs.md#the-publish-side).
+incoming request. To decode the request with a different codec, set a scope default with
+`with_broker_codec` (or `Router::with_codec` on a router chain); see
+[Codecs](codecs.md#the-publish-side).
+
+## Controlling the acknowledgement
+
+A plain reply form always publishes and acks. Return `Result<Reply, HandlerResult>` instead to
+take control: `Ok(reply)` publishes and acks, `Err(result)` publishes nothing and the dispatcher
+acts on the returned `HandlerResult` (`HandlerResult::drop()` to dead-letter,
+`HandlerResult::retry()` to ask for redelivery):
+
+```rust
+--8<-- "examples/publishing.rs:reply_result"
+```
+
+The `Result` form is detected from the written signature, so spell it out (a type alias hiding the
+`Result` is treated as a plain reply type). Like any handler, a publishing handler may declare an
+optional second `&mut Context` parameter to read app state or publish manually.
+
+If the reply publish itself fails (broker rejected it, connection lost), the incoming message is
+nacked with `requeue = true`: the broker redelivers it instead of the reply being silently lost.
+Make publishing handlers idempotent under redelivery.
 
 ## Publishing from inside a handler
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -6,9 +6,10 @@ scope.
 
 ## Building a router
 
-A `Router` mirrors the broker scope: alongside `include` and `include_publishing` it has
-`with_codec` (a per-handler codec, see [Codecs](codecs.md#per-handler)) and the manual `handle` /
-`subscribe` registrations:
+A `Router` mirrors the broker scope: alongside `include` / `include_on` and `include_publishing` /
+`include_publishing_on` it has `with_codec` (switches the chain's decode codec, see
+[Codecs](codecs.md#per-handler)) and the manual `handle` / `subscribe` registrations. Every call
+consumes the router and returns a new one, so registrations chain:
 
 ```rust title="routes.rs"
 use ruststream::runtime::Router;
@@ -31,27 +32,25 @@ Handlers that publish a reply register on the router the same way as on the scop
 
 ## Router middleware
 
-The application's global middleware (added with `RustStream::layer`) does not wrap router handlers,
-since a router is finalized independently. Give the router its own stack with `Router::layer`,
-applied to every handler registered after it (the same composition as `RustStream::layer`). It
-changes the router's type, so let the builder function's return type follow from it:
+The application's global middleware (added with `RustStream::layer`) wraps router handlers too:
+`include_router` applies the app stack around each handler when the router is mounted. A layer used
+this way must be a `BlanketLayer` - the router hides its handlers' concrete types, so the wrap
+happens through one generic method; every bundled layer qualifies.
+
+```rust title="main.rs"
+--8<-- "examples/logging_middleware.rs:layered_router"
+```
+
+A router can also carry its own stack: `Router::layer` wraps every handler in that router when it
+is mounted, inside the app's global stack (scopes nest, app outermost):
 
 ```rust title="routes.rs"
-use ruststream::runtime::{Identity, Router, Stack};
-use ruststream::runtime::layers::TracingLayer;
-
---8<-- "examples/logging_middleware.rs:layered_router"
+--8<-- "examples/middleware_router_scope.rs:router_scope"
 ```
 
 See [Middleware](middleware.md) for what a layer is and how to write one, and
 [`examples/logging_middleware.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/logging_middleware.rs)
-for this router in a running service.
-
-!!! warning "Planned for 0.3: routers inherit the application scope"
-    In 0.2 the router stack and the application stack are separate (`RustStream::layer` does not
-    wrap router handlers). In 0.3 routers will inherit the application scope, so app-level layers
-    will wrap router handlers too, composing outside the router's own stack. See
-    [middleware scopes](middleware.md#middleware-scopes).
+for the app-scope side in a running service.
 
 ## Composing and mounting
 
@@ -72,8 +71,9 @@ Or merge groups into one router before mounting (the whole program is
 --8<-- "examples/routing.rs:merge"
 ```
 
-`merge` appends another router's registrations in order; the merged router's own layer was already
-baked into its handlers, so the two need not share a middleware stack.
+`merge` appends another router's registrations in order. Each router keeps its own codec and layer
+stack; when the result is mounted, the outer router's layers (and the app's global stack) wrap
+around the merged router's own.
 
 ## Next
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -86,7 +86,7 @@ dev-dependencies:
 
 ```toml title="Cargo.toml"
 [dev-dependencies]
-ruststream-nats = { version = "0.2", features = ["testing"] }
+ruststream-nats = { version = "0.3", features = ["testing"] }
 ```
 
 The same pattern as above, with a wildcard subscriber that audits every order event (this file
@@ -105,14 +105,13 @@ A descriptor like `SubscribeOptions::new("orders.*").jetstream("ORDERS").durable
 a real JetStream consumer; it implements `SubscriptionSource` for the real `NatsBroker` only,
 because durable names and ack waits have no in-process meaning. To unit-test that handler's logic,
 mount the same definition on the test broker with an explicit by-name source - `include_on`
-overrides the macro's source and takes the codec explicitly:
+overrides the macro's source (the codec resolves the same way as for `include`):
 
 ```rust
 use ruststream::Name;
-use ruststream::codec::JsonCodec;
 
 .with_broker(client.broker().clone(), |b| {
-    b.include_on(Name::new("orders.created"), handle, JsonCodec);
+    b.include_on(Name::new("orders.created"), handle);
 })
 ```
 

--- a/examples/nats_jetstream.rs
+++ b/examples/nats_jetstream.rs
@@ -6,7 +6,8 @@
 //! durable consumer so progress survives restarts. The handler's [`HandlerResult::Ack`] acks the
 //! message back to `JetStream`; returning [`HandlerResult::Nack`] schedules redelivery.
 //!
-//! `include_on` is the source-override form, so it takes the codec explicitly (here [`JsonCodec`]).
+//! `include_on` is the source-override form; the codec resolves the same way as for `include`
+//! (the default, or a scope codec set with `with_broker_codec`).
 //! `NatsBroker::new` is synchronous, so this still fits `#[ruststream::app]`; the runtime connects
 //! the broker at startup and then opens the consumer. Create the stream once, then run:
 //!
@@ -23,7 +24,6 @@
 //!
 //! [`include_on`]: ruststream::runtime::BrokerScope::include_on
 
-use ruststream::codec::JsonCodec;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
 use ruststream::subscriber;
 use ruststream_nats::{NatsBroker, SubscribeOptions};
@@ -61,7 +61,6 @@ fn app() -> RustStream {
                     .jetstream("ORDERS")
                     .durable("orders-worker"),
                 handle,
-                JsonCodec,
             );
             // --8<-- [end:include_on]
             b.include(audit);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -36,6 +36,7 @@
 //! ```
 
 use std::fmt;
+use std::fmt::Write as _;
 use std::io::IsTerminal as _;
 
 use thiserror::Error;
@@ -268,7 +269,6 @@ struct EventVisitor {
 
 impl Visit for EventVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        use std::fmt::Write as _;
         if field.name() == "message" {
             let _ = write!(self.message, "{value:?}");
         } else {

--- a/src/runtime/app.rs
+++ b/src/runtime/app.rs
@@ -9,6 +9,9 @@ use std::{
     time::Duration,
 };
 
+#[cfg(unix)]
+use tokio::signal::unix::{SignalKind, signal};
+
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -948,7 +951,6 @@ async fn drain_handles(
 async fn wait_for_signal() {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{SignalKind, signal};
         let Ok(mut term) = signal(SignalKind::terminate()) else {
             let _ = tokio::signal::ctrl_c().await;
             return;


### PR DESCRIPTION
# Description

Final PR of the 0.3 stack, stacked on #32. Draft on purpose: merge only after BOTH ruststream 0.3 and ruststream-nats 0.3 are released - merging it triggers docs-deploy, which reads major.minor from Cargo.toml and publishes the site under "0.3" with the "latest" alias.

- include family without per-call codecs; with_broker_codec / Router::with_codec as the way to change the default (codecs, subscribers, testing, brokers/nats + the nats_jetstream snippet source).
- middleware scopes compose now; the "planned for 0.3" admonitions are removed; the BlanketLayer requirement is documented (middleware, routing).
- publishing: the Result<Reply, HandlerResult> ack-control form, the optional &mut Context parameter, and the nack-on-failed-reply semantics.
- asyncapi: Message naming/description of components, with the manual-impl rename case.
- version snippets bumped to 0.3 across installation, brokers, and broker-authors pages.

mkdocs build --strict passes locally against this tree; all --8<-- snippet references resolve.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
