### PR TITLE
deps: bump prometheus to 0.14 and schemars to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,16 +683,16 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -717,6 +717,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -786,7 +806,7 @@ dependencies = [
  "serde_json",
  "serde_norway",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -810,11 +830,12 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -822,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1013,31 +1034,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,8 +180,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }
 ciborium = { version = "0.2", optional = true }
-prometheus = { version = "0.13", default-features = false, optional = true }
-schemars = { version = "0.8", optional = true }
+prometheus = { version = "0.14", default-features = false, optional = true }
+schemars = { version = "1", optional = true }
 serde_norway = { version = "0.9", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }

--- a/src/bin/ruststream/templates/memory/Cargo.toml.in
+++ b/src/bin/ruststream/templates/memory/Cargo.toml.in
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 ruststream = { version = "0.3", features = ["macros", "memory", "json", "asyncapi", "logging"] }
-schemars = "0.8"
+schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/bin/ruststream/templates/nats-js/Cargo.toml.in
+++ b/src/bin/ruststream/templates/nats-js/Cargo.toml.in
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 ruststream = { version = "0.3", features = ["macros", "json", "asyncapi", "logging"] }
 ruststream-nats = "0.3"
-schemars = "0.8"
+schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/bin/ruststream/templates/nats/Cargo.toml.in
+++ b/src/bin/ruststream/templates/nats/Cargo.toml.in
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 ruststream = { version = "0.3", features = ["macros", "json", "asyncapi", "logging"] }
 ruststream-nats = "0.3"
-schemars = "0.8"
+schemars = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
# Description

Stacked on #30.

Bumps prometheus 0.13 -> 0.14 and schemars 0.8 -> 1 (latest majors). Both are drop-in for this crate's surface: the metrics module uses the stable counter/histogram/registry API, and the AsyncAPI schema probe goes through schema_for! + Serialize, which schemars 1.x keeps. Payload schemas in the generated document now follow the JSON Schema dialect schemars 1.x emits (draft 2020-12), which AsyncAPI 3.0 accepts.

The CLI scaffold templates (ruststream new) pin schemars = "1" accordingly.

Consumer-visible: the schemars re-export (ruststream::schemars) now surfaces schemars 1.x, so JsonSchema derives compile against the new major - riding in the 0.3 breaking release on purpose.

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
