### PR TITLE
ci: add cargo-deny to the security gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,17 @@ jobs:
       # examples trips its checksum.
       - name: cargo publish dry-run (no upload)
         run: cargo publish --dry-run -p ruststream-macros -p ruststream --all-features
+
+  security:
+    name: Security scans
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Dependency-graph gate: RustSec advisories, license allow-list, duplicate
+      # versions, and registry sources, per the checked-in deny.toml. Not path-
+      # gated: advisories arrive over time, not only with manifest changes.
+      - name: cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+# cargo-deny configuration: the dependency-graph half of the security gate.
+# Checks RustSec advisories, license compatibility, duplicate versions, and
+# registry sources. Run locally with `just deny`.
+
+[graph]
+all-features = true
+
+[advisories]
+yanked = "deny"
+
+[licenses]
+# Apache-2.0/MIT-compatible permissive licenses only.
+allow = [
+    "Apache-2.0",
+    "MIT",
+    # unicode-ident is (MIT OR Apache-2.0) AND Unicode-3.0; the Unicode license
+    # only covers the embedded character tables and is permissive.
+    "Unicode-3.0",
+]
+
+[bans]
+# clippy::cargo warns on duplicates; this is the enforcing counterpart. Known
+# unavoidable duplicates get a targeted skip with the chain that pulls them in.
+multiple-versions = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/justfile
+++ b/justfile
@@ -17,6 +17,11 @@ test:
 fmt:
     cargo fmt --all
 
+# Dependency-graph checks (advisories, licenses, duplicates, sources).
+# Needs cargo-deny: cargo install cargo-deny --locked
+deny:
+    cargo deny check
+
 build:
     cargo build --workspace --release
 


### PR DESCRIPTION
# Description

Adds the dependency-graph half of the security gate: a `security` CI job running cargo-deny
(`EmbarkStudios/cargo-deny-action@v2`) against a checked-in `deny.toml`, plus a local `just deny`
recipe.

The config covers:

- `advisories` - the RustSec database (yanked crates are denied as well),
- `licenses` - permissive allow-list: Apache-2.0, MIT, and Unicode-3.0 (unicode-ident embeds
  Unicode character tables under that license),
- `bans` - duplicate-version detection, the enforcing counterpart of the `clippy::cargo` warning;
  the graph is currently duplicate-free, so no skips were needed,
- `sources` - crates.io only.

The job is deliberately not path-gated: advisories arrive over time, not only with manifest
changes, so every PR and push gets a fresh advisory pass. `cargo deny check` passes locally
against the current lockfile (advisories ok, bans ok, licenses ok, sources ok).

Fixes #35

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
