### PR TITLE
ci: build every stable toolchain from the 1.85 floor and write down the MSRV policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,36 @@ jobs:
               - 'Cargo.lock'
               - '.github/workflows/ci.yml'
 
+  toolchains:
+    name: Resolve toolchain range
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ steps.range.outputs.list }}
+    steps:
+      # Multi-MSRV: the crate keeps rust-version = 1.85 and CI proves the build on
+      # every stable toolchain from that floor up to current stable, so broker
+      # crates can adopt any MSRV in the range without waiting for a core release.
+      # The list is resolved from the release manifest, so a new stable joins the
+      # matrix on its release day with no workflow edit.
+      - name: Build the 1.85..stable toolchain list
+        id: range
+        run: |
+          stable_minor=$(curl -sSf https://static.rust-lang.org/dist/channel-rust-stable.toml \
+            | grep -A1 '^\[pkg\.rust\]' | grep -m1 'version' | sed -E 's/.*"1\.([0-9]+)\..*/\1/')
+          versions=$(seq 85 "$((stable_minor - 1))" | sed 's/^/"1./; s/$/"/' | paste -sd, -)
+          echo "list=[\"stable\",${versions}]" >> "$GITHUB_OUTPUT"
+
   rust:
     name: Rust ${{ matrix.toolchain }}
-    needs: changes
+    needs: [changes, toolchains]
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, "1.85"]
+        toolchain: ${{ fromJSON(needs.toolchains.outputs.list) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,7 +105,10 @@ jobs:
       - name: cargo check (all features)
         run: cargo check --workspace --all-targets --all-features
 
+      # The intermediate toolchains exist to prove the build (the two checks
+      # above); the full suite runs at the edges of the range only.
       - name: cargo test
+        if: matrix.toolchain == 'stable' || matrix.toolchain == '1.85'
         run: cargo test --workspace --all-features
 
   package:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ only, so you assert on handler behaviour, middleware, and decoding exactly as in
 
 Concrete brokers live in their own crates and pull `ruststream` from crates.io.
 
+## Minimum supported Rust version
+
+The MSRV is **1.85** (edition 2024, native `async fn in trait`). CI builds the crate on every
+stable toolchain from 1.85 up to current stable, so any floor in that range works.
+
+The policy:
+
+- The published `rust-version` stays at the floor. Raising it is a breaking change (a minor
+  version bump pre-1.0) and is reviewed against the broker crates' client requirements at each
+  minor release.
+- Broker crates (`ruststream-nats`, ...) may require a newer toolchain than the core when their
+  underlying clients do; cargo allows a dependent crate to have a stricter floor than its
+  dependency. Check the broker crate's own `rust-version` for its floor.
+
 ## Contributing
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,10 @@ serde = { version = "1", features = ["derive"] }
 
 !!! note "Edition and MSRV"
     RustStream targets **edition 2024** and a minimum supported Rust version of **1.85** (native
-    `async fn in trait`). Set `edition = "2024"` in your `Cargo.toml`.
+    `async fn in trait`). Set `edition = "2024"` in your `Cargo.toml`. CI builds the crate on
+    every stable toolchain from 1.85 up to current stable, so any floor in that range works.
+    Broker crates may require a newer toolchain than the core when their underlying clients do;
+    check the broker crate's own `rust-version`.
 
 ## Features
 


### PR DESCRIPTION
# Description

Resolves the MSRV squeeze without raising the floor: instead of bumping `rust-version` (a breaking
change that would have to wait for 0.4), CI now proves the build on every stable toolchain from
the 1.85 floor up to current stable - a multi-MSRV matrix. With that guarantee in place, a broker
crate may adopt any MSRV in the range (cargo permits a dependent crate to have a stricter floor
than its dependency), so `ruststream-nats` can move to async-nats 0.49 (rust-version 1.88) right
away, on ruststream 0.3.

What changed:

- A `toolchains` job resolves the current stable minor from the official release manifest and
  emits the matrix list (`stable`, `1.85` .. stable-minus-one). A new stable joins the matrix on
  its release day with no workflow edit, so the list cannot go stale.
- The `rust` matrix consumes that list. Intermediate toolchains prove the build (`cargo check`
  with `--no-default-features` and with `--all-features`); the full test suite keeps running at
  the edges of the range (`stable` and `1.85`), exactly as before.
- The MSRV policy is written down in the README and the installation guide: the published
  `rust-version` stays at the floor, raising it remains a breaking change reviewed against the
  broker crates' client requirements at each minor release, and broker crates may require a newer
  toolchain than the core when their underlying clients do.

`rust-version` in the workspace manifest is intentionally untouched, and `rust-toolchain.toml`
already tracks `stable`. Follow-up in ruststream-nats: bump async-nats to 0.49 and set its own
`rust-version = "1.88"`.

Fixes #34

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
