### PR TITLE
memory: native implementations of every capability trait, plus conformance suites

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ anyhow = { version = "1", optional = true }
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "test-util"] }
 tempfile = "3"
 axum = "0.8"
 # `testing` pulls the in-memory NATS test broker used by tests/doc_testing_nats.rs (the snippet

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -82,6 +82,40 @@ the check accepts that as well as a successful ack. Because `lifecycle` performs
 run it against a live server (gate it behind an env var like `NATS_TEST_URL`); the in-memory broker
 can run it in-process.
 
+## Capability suites
+
+If your broker implements a capability trait, run the matching suite from
+`conformance::capabilities` to prove the implementation honours the trait contract; brokers
+without the capability simply do not call it. Each suite takes the same factory shape as
+`lifecycle` and performs a real `connect`, so gate it the same way:
+
+| Suite | Requires | Asserts |
+|---|---|---|
+| `capabilities::request_reply` | `RequestReply` | the request reaches a responder with a usable `reply-to` header, the correlated reply resolves the request, an unanswered request fails after its timeout |
+| `capabilities::batches` | `BatchSubscriber` | every published message arrives in publish order, distributed over non-empty batches |
+| `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it |
+
+```rust
+use ruststream::conformance::capabilities;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
+async fn passes_request_reply() {
+    let url = std::env::var("NATS_TEST_URL").unwrap();
+    capabilities::request_reply(
+        || NatsBroker::new(url.clone()),
+        |subject| SubscribeOptions::new(subject),
+        |broker| broker.publisher(),   // the RequestReply publisher under test
+        |broker| broker.publisher(),   // the plain publisher the responder replies through
+    )
+    .await;
+}
+```
+
+The in-memory broker implements every capability natively and passes all three suites in-process
+(see [Memory](../brokers/memory.md#capabilities)); it is the executable reference for what each
+suite expects.
+
 ## Author checklist
 
 Before publishing a broker crate:
@@ -91,7 +125,8 @@ Before publishing a broker crate:
 - [ ] `shutdown` performs all fallible teardown and never blocks or panics.
 - [ ] Ack consumes `self`; nack honours the `requeue` flag.
 - [ ] The crate owns its `Config`; fields without a sane default do not get a `Default`.
-- [ ] Capability traits are implemented only where the broker genuinely supports them.
+- [ ] Capability traits are implemented only where the broker genuinely supports them, and each
+      implemented capability passes its `conformance::capabilities` suite.
 - [ ] A `TestClient` is shipped under a `testing` feature, doing core routing only.
 - [ ] `harness::run_suite` passes (the routing surface).
 - [ ] `harness::lifecycle` passes against a real server, gated behind an environment variable (the

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -28,6 +28,27 @@ let broker = MemoryBroker::new();
 It does core routing only and does not emulate any real broker's delivery semantics (durable
 cursors, redelivery timers, partitions, dead-letter routing).
 
+## Capabilities
+
+Every capability trait has a native implementation - a first-class feature of the broker's own
+in-process semantics, not a simulation of another broker's:
+
+- **Request / reply.** `broker.requester()` returns a `MemoryRequester` whose `request` publishes
+  with a unique in-process inbox in the `reply-to` header and resolves on the first message
+  delivered there. A responder reads `reply-to` from the request and publishes its reply to that
+  name. Requests nobody answers fail with `RequestError::Timeout`.
+- **Batches.** `MemorySubscriber` implements `BatchSubscriber`: a batch is the first awaited
+  delivery plus everything already buffered, capped by `set_batch_limit` (default 64). Partial
+  batches ship immediately, so no deadline timer is involved.
+- **Transactions.** `MemoryPublisher` implements `TransactionalPublisher`: publishes between
+  `begin_transaction` and `commit` are buffered and fan out together in publish order; `abort`
+  discards them. Clones of a publisher handle do not share its transaction.
+- **Partition keys.** `MemoryMessage` implements `Partitioned`, reading the key from the
+  well-known `partition-key` header (`memory::PARTITION_KEY_HEADER`).
+
+`DescribeServer` stays deliberately unimplemented: the in-memory broker has no network
+coordinates, and that asymmetry is part of the contract documentation.
+
 ## Subscription source
 
 `MemoryBroker` implements `Subscribe`, so `#[subscriber("orders")]` works directly. Its descriptor

--- a/src/conformance/capabilities.rs
+++ b/src/conformance/capabilities.rs
@@ -1,0 +1,323 @@
+//! Optional conformance suites, one per capability trait.
+//!
+//! A broker crate that implements a capability ([`RequestReply`], [`BatchSubscriber`],
+//! [`TransactionalPublisher`]) runs the matching suite to prove the implementation honours the
+//! trait contract; brokers without the capability simply do not call it. Like
+//! [`harness::lifecycle`](super::harness::lifecycle), every suite is built from caller-supplied
+//! factories so it stays broker-agnostic, and the in-memory broker is the executable reference
+//! that passes all of them.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use super::harness::{expect_next, expect_no_more};
+use crate::{
+    AckError, BatchSubscriber, Broker, Headers, IncomingMessage, OutgoingMessage, Publisher,
+    RequestReply, Subscriber, SubscriptionSource, TransactionalPublisher,
+};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+const MISS_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Verifies the [`RequestReply`] contract.
+///
+/// A request reaches a responder with a usable `reply-to` header, the correlated reply resolves
+/// the request, and a request nobody answers fails once its timeout elapses.
+///
+/// The factories mirror [`harness::lifecycle`](super::harness::lifecycle): `make_source` opens
+/// the responder's subscription, `make_requester` produces the [`RequestReply`] publisher under
+/// test, and `make_publisher` produces the plain publisher the responder replies through.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() {
+/// use ruststream::conformance::capabilities;
+/// use ruststream::memory::{MemoryBroker, MemorySource};
+///
+/// capabilities::request_reply(
+///     MemoryBroker::new,
+///     |name| MemorySource::new(name),
+///     |broker| broker.requester(),
+///     |broker| broker.publisher(),
+/// )
+/// .await;
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics with a descriptive message if any step violates the contract.
+pub async fn request_reply<B, MkBroker, Src, MkSrc, Req, MkReq, Pub, MkPub>(
+    make_broker: MkBroker,
+    make_source: MkSrc,
+    make_requester: MkReq,
+    make_publisher: MkPub,
+) where
+    B: Broker,
+    MkBroker: Fn() -> B,
+    Src: SubscriptionSource<B> + Send,
+    Src::Subscriber: Send,
+    MkSrc: Fn(&str) -> Src,
+    Req: RequestReply,
+    MkReq: Fn(&B) -> Req,
+    Pub: Publisher,
+    MkPub: Fn(&B) -> Pub,
+{
+    const SUBJECT: &str = "conformance.request_reply";
+
+    let broker = make_broker();
+    Broker::connect(&broker).await.expect("broker must connect");
+
+    let mut responder = make_source(SUBJECT)
+        .subscribe(&broker)
+        .await
+        .expect("responder subscription must open after connect");
+    let publisher = make_publisher(&broker);
+    let requester = make_requester(&broker);
+
+    let respond = async {
+        let mut stream = std::pin::pin!(responder.stream());
+        let msg = expect_next(&mut stream, "request_reply responder").await;
+        assert_eq!(
+            msg.payload(),
+            b"ping",
+            "responder must receive the request payload"
+        );
+        let reply_to = msg
+            .headers()
+            .reply_to()
+            .expect("a request must carry a usable reply-to header")
+            .to_owned();
+
+        // Echo the correlation id when the requester set one; replies must at minimum go to
+        // the reply-to destination.
+        let mut headers = Headers::new();
+        if let Some(correlation_id) = msg.headers().correlation_id() {
+            headers.insert("correlation-id", correlation_id.to_owned());
+        }
+        publisher
+            .publish(OutgoingMessage::new(&reply_to, b"pong".as_slice()).with_headers(headers))
+            .await
+            .expect("reply publish failed");
+        match msg.ack().await {
+            Ok(()) | Err(AckError::Unsupported) => {}
+            Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+        }
+    };
+    let request = requester.request(
+        OutgoingMessage::new(SUBJECT, b"ping".as_slice()),
+        DEFAULT_TIMEOUT,
+    );
+
+    let (reply, ()) = futures::join!(request, respond);
+    let reply = reply.expect("request must resolve once the responder replies");
+    assert_eq!(
+        reply.payload(),
+        b"pong",
+        "the correlated reply must carry the responder payload"
+    );
+
+    let unanswered = requester
+        .request(
+            OutgoingMessage::new("conformance.request_reply.void", b"ping".as_slice()),
+            MISS_TIMEOUT,
+        )
+        .await;
+    assert!(
+        unanswered.is_err(),
+        "a request nobody answers must fail once its timeout elapses",
+    );
+
+    Broker::shutdown(&broker)
+        .await
+        .expect("broker must shut down cleanly");
+}
+
+/// Verifies the [`BatchSubscriber`] contract.
+///
+/// Every published message arrives, in publish order, distributed over one or more non-empty
+/// batches.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() {
+/// use ruststream::conformance::capabilities;
+/// use ruststream::memory::{MemoryBroker, MemorySource};
+///
+/// capabilities::batches(
+///     MemoryBroker::new,
+///     |name| MemorySource::new(name),
+///     |broker| broker.publisher(),
+/// )
+/// .await;
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics with a descriptive message if any step violates the contract.
+pub async fn batches<B, MkBroker, Src, MkSrc, Pub, MkPub>(
+    make_broker: MkBroker,
+    make_source: MkSrc,
+    make_publisher: MkPub,
+) where
+    B: Broker,
+    MkBroker: Fn() -> B,
+    Src: SubscriptionSource<B> + Send,
+    Src::Subscriber: BatchSubscriber + Send,
+    MkSrc: Fn(&str) -> Src,
+    Pub: Publisher,
+    MkPub: Fn(&B) -> Pub,
+{
+    const SUBJECT: &str = "conformance.batches";
+    const COUNT: u32 = 10;
+
+    let broker = make_broker();
+    Broker::connect(&broker).await.expect("broker must connect");
+
+    let mut subscriber = make_source(SUBJECT)
+        .subscribe(&broker)
+        .await
+        .expect("subscription must open after connect");
+    let publisher = make_publisher(&broker);
+
+    for i in 0..COUNT {
+        publisher
+            .publish(OutgoingMessage::new(SUBJECT, i.to_be_bytes().as_slice()))
+            .await
+            .expect("publish failed");
+    }
+
+    let mut received = Vec::new();
+    let mut stream = std::pin::pin!(subscriber.batches());
+    while received.len() < COUNT as usize {
+        let batch = tokio::time::timeout(DEFAULT_TIMEOUT, stream.next())
+            .await
+            .expect("batches: stream timed out")
+            .expect("batches: stream ended unexpectedly")
+            .unwrap_or_else(|err| panic!("batches: stream yielded error: {err:?}"));
+
+        let batch: Vec<_> = batch.into_iter().collect();
+        assert!(!batch.is_empty(), "a yielded batch must not be empty");
+        for msg in batch {
+            received.push(msg.payload().to_vec());
+            match msg.ack().await {
+                Ok(()) | Err(AckError::Unsupported) => {}
+                Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+            }
+        }
+    }
+
+    let expected: Vec<Vec<u8>> = (0..COUNT).map(|i| i.to_be_bytes().to_vec()).collect();
+    assert_eq!(
+        received, expected,
+        "batched deliveries must preserve publish order across batches",
+    );
+
+    Broker::shutdown(&broker)
+        .await
+        .expect("broker must shut down cleanly");
+}
+
+/// Verifies the [`TransactionalPublisher`] contract.
+///
+/// Nothing published inside a transaction is visible before `commit`, a commit makes every
+/// buffered message visible in publish order, and an abort discards the buffer.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() {
+/// use ruststream::conformance::capabilities;
+/// use ruststream::memory::{MemoryBroker, MemorySource};
+///
+/// capabilities::transactions(
+///     MemoryBroker::new,
+///     |name| MemorySource::new(name),
+///     |broker| broker.publisher(),
+/// )
+/// .await;
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics with a descriptive message if any step violates the contract.
+pub async fn transactions<B, MkBroker, Src, MkSrc, Pub, MkPub>(
+    make_broker: MkBroker,
+    make_source: MkSrc,
+    make_publisher: MkPub,
+) where
+    B: Broker,
+    MkBroker: Fn() -> B,
+    Src: SubscriptionSource<B> + Send,
+    Src::Subscriber: Send,
+    MkSrc: Fn(&str) -> Src,
+    Pub: TransactionalPublisher,
+    MkPub: Fn(&B) -> Pub,
+{
+    const SUBJECT: &str = "conformance.transactions";
+
+    let broker = make_broker();
+    Broker::connect(&broker).await.expect("broker must connect");
+
+    let mut subscriber = make_source(SUBJECT)
+        .subscribe(&broker)
+        .await
+        .expect("subscription must open after connect");
+    let publisher = make_publisher(&broker);
+    let mut stream = std::pin::pin!(subscriber.stream());
+
+    publisher
+        .begin_transaction()
+        .await
+        .expect("begin_transaction failed");
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"first".as_slice()))
+        .await
+        .expect("publish inside transaction failed");
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"second".as_slice()))
+        .await
+        .expect("publish inside transaction failed");
+    expect_no_more(&mut stream, "transactions: before commit").await;
+
+    publisher.commit().await.expect("commit failed");
+    let first = expect_next(&mut stream, "transactions: first after commit").await;
+    assert_eq!(
+        first.payload(),
+        b"first",
+        "commit must make buffered messages visible in publish order",
+    );
+    match first.ack().await {
+        Ok(()) | Err(AckError::Unsupported) => {}
+        Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+    }
+    let second = expect_next(&mut stream, "transactions: second after commit").await;
+    assert_eq!(second.payload(), b"second");
+    match second.ack().await {
+        Ok(()) | Err(AckError::Unsupported) => {}
+        Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+    }
+
+    publisher
+        .begin_transaction()
+        .await
+        .expect("begin_transaction failed");
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"discarded".as_slice()))
+        .await
+        .expect("publish inside transaction failed");
+    publisher.abort().await.expect("abort failed");
+    expect_no_more(&mut stream, "transactions: after abort").await;
+
+    Broker::shutdown(&broker)
+        .await
+        .expect("broker must shut down cleanly");
+}

--- a/src/conformance/harness.rs
+++ b/src/conformance/harness.rs
@@ -336,7 +336,7 @@ async fn expect_published_observes_publishes<T: TestClient>(client: T) {
     client.shutdown().await.expect("shutdown failed");
 }
 
-async fn expect_next<S, M, E>(stream: &mut S, label: &str) -> M
+pub(crate) async fn expect_next<S, M, E>(stream: &mut S, label: &str) -> M
 where
     S: futures::Stream<Item = Result<M, E>> + Unpin,
     M: IncomingMessage,
@@ -349,7 +349,7 @@ where
     item.unwrap_or_else(|err| panic!("{label}: stream yielded error: {err:?}"))
 }
 
-async fn expect_no_more<S, M, E>(stream: &mut S, label: &str)
+pub(crate) async fn expect_no_more<S, M, E>(stream: &mut S, label: &str)
 where
     S: futures::Stream<Item = Result<M, E>> + Unpin,
     M: IncomingMessage,

--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -5,5 +5,6 @@
 //! reference [`crate::memory::MemoryBroker`], which lives in the always-available `memory`
 //! module so applications can use it without the conformance feature.
 
+pub mod capabilities;
 pub mod harness;
 pub mod helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,10 @@
 //! * `metrics`: Prometheus metrics middleware and exporter.
 //! * `logging`: colored, `RUST_LOG`-driven console logging via `tracing-subscriber`
 //!   ([`logging::init`]). The generated `cli` `run` command installs it automatically.
-//! * `conformance`: the [`conformance::harness`] contract suite and broker-agnostic
-//!   [`conformance::helpers`] for application tests. Generic over any broker's `TestClient`, so it
-//!   pulls in no concrete broker (enable `memory` too to run it against [`memory::MemoryBroker`]).
+//! * `conformance`: the [`conformance::harness`] contract suite, per-capability suites in
+//!   [`conformance::capabilities`], and broker-agnostic [`conformance::helpers`] for application
+//!   tests. Generic over any broker's `TestClient`, so it pulls in no concrete broker (enable
+//!   `memory` too to run it against [`memory::MemoryBroker`]).
 //! * `cli`: the `ruststream` binary (`run`, `asyncapi gen`, `new`).
 //!
 //! Disable defaults (`default-features = false`) to drop the bundled JSON codec; the core traits,

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -1,0 +1,464 @@
+//! Native capability-trait implementations for the in-memory broker.
+//!
+//! These are first-class features of the broker's own in-process semantics, not simulations of
+//! another broker: real buffered transactions, real greedy batching, real correlated request /
+//! reply over an in-process inbox. The conformance harness offers a suite per capability (see
+//! `conformance::capabilities`), and these implementations are the executable reference for
+//! them.
+
+use std::{
+    convert::Infallible,
+    sync::{Arc, atomic::Ordering},
+    task::Poll,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::Stream;
+use thiserror::Error;
+use tokio::{sync::mpsc, time::timeout};
+
+use super::{MemoryDelivery, MemoryMessage, MemoryPublisher, MemoryState, MemorySubscriber};
+use crate::{
+    BatchSubscriber, IncomingMessage, OutgoingMessage, Partitioned, Publisher, RequestReply,
+    Subscriber, TransactionalPublisher,
+};
+
+/// The well-known header the [`Partitioned`] implementation reads the partition key from.
+pub const PARTITION_KEY_HEADER: &str = "partition-key";
+
+/// Errors returned by [`MemoryRequester`] operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RequestError {
+    /// No reply arrived in the request inbox before the timeout elapsed.
+    #[error("no reply to \"{subject}\" within {timeout:?}")]
+    Timeout {
+        /// The subject the request was published to.
+        subject: String,
+        /// How long the requester waited for a reply.
+        timeout: Duration,
+    },
+}
+
+/// Publisher with native request / reply support, returned by
+/// [`MemoryBroker::requester`](super::MemoryBroker::requester).
+///
+/// [`request`](RequestReply::request) publishes the message with a unique in-process inbox in
+/// the `reply-to` header and resolves on the first message delivered to that inbox. A responder
+/// reads `reply-to` from the request headers and publishes its reply there. Plain
+/// [`publish`](Publisher::publish) is the usual fire-and-forget fanout.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use futures::StreamExt;
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::{IncomingMessage, OutgoingMessage, Publisher, RequestReply, Subscriber};
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let broker = MemoryBroker::new();
+/// let mut service = broker.subscribe("svc.echo");
+/// let publisher = broker.publisher();
+/// let requester = broker.requester();
+///
+/// let respond = async {
+///     let mut stream = std::pin::pin!(service.stream());
+///     if let Some(Ok(msg)) = stream.next().await {
+///         let reply_to = msg.headers().reply_to().ok_or("request must carry reply-to")?.to_owned();
+///         publisher.publish(OutgoingMessage::new(&reply_to, msg.payload())).await?;
+///         msg.ack().await?;
+///     }
+///     Ok::<_, Box<dyn std::error::Error>>(())
+/// };
+/// let request = requester.request(
+///     OutgoingMessage::new("svc.echo", b"ping"),
+///     Duration::from_secs(1),
+/// );
+///
+/// let (reply, responded) = futures::join!(request, respond);
+/// responded?;
+/// assert_eq!(reply?.payload(), b"ping");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct MemoryRequester {
+    state: Arc<MemoryState>,
+}
+
+impl MemoryRequester {
+    pub(super) fn new(state: Arc<MemoryState>) -> Self {
+        Self { state }
+    }
+}
+
+impl std::fmt::Debug for MemoryRequester {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryRequester").finish_non_exhaustive()
+    }
+}
+
+impl Publisher for MemoryRequester {
+    type Error = RequestError;
+
+    async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
+        let delivery = MemoryDelivery {
+            name: msg.name().to_owned(),
+            payload: Bytes::copy_from_slice(msg.payload()),
+            headers: msg.headers().clone(),
+        };
+        self.state.fanout(&delivery);
+        Ok(())
+    }
+}
+
+impl RequestReply for MemoryRequester {
+    type Reply = MemoryMessage;
+
+    async fn request(
+        &self,
+        msg: OutgoingMessage<'_>,
+        wait: Duration,
+    ) -> Result<Self::Reply, Self::Error> {
+        let id = self.state.inbox_seq.fetch_add(1, Ordering::Relaxed);
+        let inbox = format!("_inbox.{id}");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.state.register(inbox.clone(), tx.clone());
+
+        let mut headers = msg.headers().clone();
+        headers.insert("reply-to", inbox.clone());
+        let delivery = MemoryDelivery {
+            name: msg.name().to_owned(),
+            payload: Bytes::copy_from_slice(msg.payload()),
+            headers,
+        };
+        self.state.fanout(&delivery);
+
+        let outcome = timeout(wait, rx.recv()).await;
+        self.state.unregister(&inbox);
+        match outcome {
+            Ok(Some(reply)) => Ok(MemoryMessage {
+                delivery: Some(reply),
+                requeue: tx,
+            }),
+            // `tx` is held on this stack frame, so the channel cannot report closed.
+            Ok(None) => unreachable!("request inbox closed while its sender is held"),
+            Err(_) => Err(RequestError::Timeout {
+                subject: msg.name().to_owned(),
+                timeout: wait,
+            }),
+        }
+    }
+}
+
+/// Greedy batching: a batch is the first awaited delivery plus everything already buffered, up
+/// to the [`set_batch_limit`](MemorySubscriber::set_batch_limit) cap. Partial batches ship
+/// immediately, so no deadline timer is needed.
+impl BatchSubscriber for MemorySubscriber {
+    type Batch = Vec<MemoryMessage>;
+
+    fn batches(
+        &mut self,
+    ) -> impl Stream<Item = Result<Self::Batch, <Self as Subscriber>::Error>> + Send + '_ {
+        let limit = self.batch_limit.max(1);
+        let requeue = self.requeue.clone();
+        // The drain happens inside a single poll, so no batch state is buffered between polls
+        // and the stream stays cancel-safe, like `MemorySubscriber::stream`.
+        futures::stream::poll_fn(move |cx| {
+            let Some(first) = std::task::ready!(self.rx.poll_recv(cx)) else {
+                return Poll::Ready(None);
+            };
+            let mut batch = vec![MemoryMessage {
+                delivery: Some(first),
+                requeue: requeue.clone(),
+            }];
+            while batch.len() < limit {
+                match self.rx.poll_recv(cx) {
+                    Poll::Ready(Some(delivery)) => batch.push(MemoryMessage {
+                        delivery: Some(delivery),
+                        requeue: requeue.clone(),
+                    }),
+                    // Drained (pending) or closed: ship what we have; a closed channel ends
+                    // the stream on the next poll.
+                    Poll::Ready(None) | Poll::Pending => break,
+                }
+            }
+            Poll::Ready(Some(Ok(batch)))
+        })
+    }
+}
+
+/// In-process transactions: [`begin_transaction`](TransactionalPublisher::begin_transaction)
+/// switches this handle to buffering, [`commit`](TransactionalPublisher::commit) fans out the
+/// buffer in publish order, [`abort`](TransactionalPublisher::abort) discards it.
+///
+/// Every operation is total, matching the infallible publisher: `begin_transaction` inside an
+/// active transaction continues that transaction, and `commit` / `abort` without one are no-ops.
+/// Clones of the handle do not share the transaction (see [`MemoryPublisher`]).
+impl TransactionalPublisher for MemoryPublisher {
+    async fn begin_transaction(&self) -> Result<(), Infallible> {
+        let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
+        if txn.is_none() {
+            *txn = Some(Vec::new());
+        }
+        drop(txn);
+        Ok(())
+    }
+
+    async fn commit(&self) -> Result<(), Infallible> {
+        let buffered = self
+            .txn
+            .lock()
+            .expect("memory broker mutex poisoned")
+            .take();
+        for delivery in buffered.into_iter().flatten() {
+            self.state.fanout(&delivery);
+        }
+        Ok(())
+    }
+
+    async fn abort(&self) -> Result<(), Infallible> {
+        self.txn
+            .lock()
+            .expect("memory broker mutex poisoned")
+            .take();
+        Ok(())
+    }
+}
+
+/// The partition key is carried in the [`PARTITION_KEY_HEADER`] header; producers that want
+/// per-key ordering set it at publish time. Messages without the header return `None` (any
+/// partition will do).
+impl Partitioned for MemoryMessage {
+    fn partition_key(&self) -> Option<&[u8]> {
+        self.headers().get(PARTITION_KEY_HEADER)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+
+    use super::super::MemoryBroker;
+    use super::*;
+    use crate::Headers;
+
+    #[tokio::test]
+    async fn batches_drain_buffered_deliveries() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("batch");
+        let publisher = broker.publisher();
+        for i in 0..5u8 {
+            publisher
+                .publish(OutgoingMessage::new("batch", &[i]))
+                .await
+                .unwrap();
+        }
+
+        let mut stream = std::pin::pin!(sub.batches());
+        let batch = stream.next().await.unwrap().unwrap();
+        let payloads: Vec<u8> = batch.iter().map(|m| m.payload()[0]).collect();
+        assert_eq!(payloads, [0, 1, 2, 3, 4]);
+        for msg in batch {
+            msg.ack().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_limit_caps_each_batch() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("batch.capped");
+        sub.set_batch_limit(2);
+        let publisher = broker.publisher();
+        for i in 0..3u8 {
+            publisher
+                .publish(OutgoingMessage::new("batch.capped", &[i]))
+                .await
+                .unwrap();
+        }
+
+        let mut stream = std::pin::pin!(sub.batches());
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.len(), 2);
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.len(), 1);
+        for msg in first.into_iter().chain(second) {
+            msg.ack().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn transaction_buffers_until_commit() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("txn");
+        let publisher = broker.publisher();
+
+        publisher.begin_transaction().await.unwrap();
+        publisher
+            .publish(OutgoingMessage::new("txn", b"a".as_slice()))
+            .await
+            .unwrap();
+        publisher
+            .publish(OutgoingMessage::new("txn", b"b".as_slice()))
+            .await
+            .unwrap();
+
+        // Fanout is synchronous, so an empty queue here proves nothing was published yet.
+        let mut stream = std::pin::pin!(sub.stream());
+        assert!(futures::poll!(stream.next()).is_pending());
+
+        publisher.commit().await.unwrap();
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.payload(), b"a");
+        first.ack().await.unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.payload(), b"b");
+        second.ack().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn abort_discards_buffered_publishes() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("txn.abort");
+        let publisher = broker.publisher();
+
+        publisher.begin_transaction().await.unwrap();
+        publisher
+            .publish(OutgoingMessage::new("txn.abort", b"gone".as_slice()))
+            .await
+            .unwrap();
+        publisher.abort().await.unwrap();
+
+        let mut stream = std::pin::pin!(sub.stream());
+        assert!(futures::poll!(stream.next()).is_pending());
+
+        publisher
+            .publish(OutgoingMessage::new("txn.abort", b"kept".as_slice()))
+            .await
+            .unwrap();
+        let msg = stream.next().await.unwrap().unwrap();
+        assert_eq!(msg.payload(), b"kept");
+        msg.ack().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clone_does_not_join_transaction() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("txn.clone");
+        let transactional = broker.publisher();
+
+        transactional.begin_transaction().await.unwrap();
+        transactional
+            .publish(OutgoingMessage::new("txn.clone", b"buffered".as_slice()))
+            .await
+            .unwrap();
+
+        let independent = transactional.clone();
+        independent
+            .publish(OutgoingMessage::new("txn.clone", b"direct".as_slice()))
+            .await
+            .unwrap();
+
+        let mut stream = std::pin::pin!(sub.stream());
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.payload(), b"direct");
+        first.ack().await.unwrap();
+
+        transactional.commit().await.unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.payload(), b"buffered");
+        second.ack().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_resolves_on_reply() {
+        let broker = MemoryBroker::new();
+        let mut service = broker.subscribe("svc.echo");
+        let publisher = broker.publisher();
+        let requester = broker.requester();
+
+        let respond = async {
+            let mut stream = std::pin::pin!(service.stream());
+            let msg = stream.next().await.unwrap().unwrap();
+            assert_eq!(msg.payload(), b"ping");
+            let reply_to = msg.headers().reply_to().unwrap().to_owned();
+            publisher
+                .publish(OutgoingMessage::new(&reply_to, b"pong".as_slice()))
+                .await
+                .unwrap();
+            msg.ack().await.unwrap();
+        };
+        let request = requester.request(
+            OutgoingMessage::new("svc.echo", b"ping".as_slice()),
+            Duration::from_secs(1),
+        );
+
+        let (reply, ()) = futures::join!(request, respond);
+        assert_eq!(reply.unwrap().payload(), b"pong");
+
+        // The single-use inbox must be unregistered once the request resolves.
+        let inbox_leaked = broker
+            .state
+            .subscribers
+            .lock()
+            .unwrap()
+            .keys()
+            .any(|name| name.starts_with("_inbox."));
+        assert!(!inbox_leaked);
+    }
+
+    // Paused time needs the current-thread runtime; the test spawns nothing, so the timeout
+    // auto-advances instead of sleeping for real.
+    #[tokio::test(start_paused = true)]
+    async fn request_times_out_without_responder() {
+        let broker = MemoryBroker::new();
+        let requester = broker.requester();
+
+        let outcome = requester
+            .request(
+                OutgoingMessage::new("svc.void", b"ping".as_slice()),
+                Duration::from_millis(5),
+            )
+            .await;
+        assert!(matches!(outcome, Err(RequestError::Timeout { .. })));
+
+        let inbox_leaked = broker
+            .state
+            .subscribers
+            .lock()
+            .unwrap()
+            .keys()
+            .any(|name| name.starts_with("_inbox."));
+        assert!(!inbox_leaked);
+    }
+
+    #[tokio::test]
+    async fn partition_key_reads_well_known_header() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("keyed");
+        let publisher = broker.publisher();
+
+        let mut headers = Headers::new();
+        headers.insert(PARTITION_KEY_HEADER, b"user-42".as_slice());
+        publisher
+            .publish(OutgoingMessage::new("keyed", b"a".as_slice()).with_headers(headers))
+            .await
+            .unwrap();
+        publisher
+            .publish(OutgoingMessage::new("keyed", b"b".as_slice()))
+            .await
+            .unwrap();
+
+        let mut stream = std::pin::pin!(sub.stream());
+        let keyed = stream.next().await.unwrap().unwrap();
+        assert_eq!(keyed.partition_key(), Some(b"user-42".as_slice()));
+        keyed.ack().await.unwrap();
+
+        let unkeyed = stream.next().await.unwrap().unwrap();
+        assert_eq!(unkeyed.partition_key(), None);
+        unkeyed.ack().await.unwrap();
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -9,11 +9,20 @@
 //! harness runs against. It does not model any broker-specific semantics (`JetStream` ack
 //! timing, `Kafka` offsets, `RabbitMQ` exchanges); for those, use the corresponding broker
 //! crate.
+//!
+//! Every capability trait has a native implementation here, as a first-class feature of the
+//! broker's own in-process semantics (not a simulation of someone else's): request / reply via
+//! [`MemoryRequester`], batch consumption on [`MemorySubscriber`], transactions on
+//! [`MemoryPublisher`], and partition keys on [`MemoryMessage`].
+
+mod capability;
+
+pub use capability::{MemoryRequester, PARTITION_KEY_HEADER, RequestError};
 
 use std::{
     collections::HashMap,
     convert::Infallible,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex, OnceLock, atomic::AtomicU64},
     time::Duration,
 };
 
@@ -42,6 +51,7 @@ struct MemoryState {
     subscribers: Mutex<HashMap<String, Vec<Sender>>>,
     published: Mutex<HashMap<String, Vec<RawMessage>>>,
     notify: Notify,
+    inbox_seq: AtomicU64,
 }
 
 impl MemoryState {
@@ -51,6 +61,16 @@ impl MemoryState {
             .lock()
             .expect("memory broker mutex poisoned");
         subs.entry(name).or_default().push(tx);
+    }
+
+    // Request inboxes are single-use; dropping the whole entry keeps the subscriber map from
+    // accumulating one dead sender per completed request.
+    fn unregister(&self, name: &str) {
+        let mut subs = self
+            .subscribers
+            .lock()
+            .expect("memory broker mutex poisoned");
+        subs.remove(name);
     }
 
     fn fanout(&self, delivery: &MemoryDelivery) {
@@ -98,6 +118,7 @@ impl MemoryBroker {
             name,
             rx,
             requeue: tx,
+            batch_limit: DEFAULT_BATCH_LIMIT,
         }
     }
 
@@ -106,7 +127,18 @@ impl MemoryBroker {
     pub fn publisher(&self) -> MemoryPublisher {
         MemoryPublisher {
             state: Arc::clone(&self.state),
+            txn: Mutex::new(None),
         }
+    }
+
+    /// Returns a request / reply-capable publisher bound to this broker.
+    ///
+    /// Unlike [`MemoryBroker::publisher`], whose fire-and-forget operations cannot fail, a
+    /// requester awaits a correlated reply that may never arrive, so its operations report
+    /// [`RequestError`].
+    #[must_use]
+    pub fn requester(&self) -> MemoryRequester {
+        MemoryRequester::new(Arc::clone(&self.state))
     }
 }
 
@@ -176,12 +208,30 @@ impl SubscriptionSource<MemoryBroker> for MemorySource {
     }
 }
 
+/// Default cap on how many buffered deliveries one batch drains.
+const DEFAULT_BATCH_LIMIT: usize = 64;
+
 /// Subscriber returned by [`MemoryBroker::subscribe`]. Yields one [`MemoryMessage`] per
 /// delivery; consumers must call `ack` or `nack` on each.
+///
+/// Also consumable in batches through the
+/// [`BatchSubscriber`](crate::BatchSubscriber) capability; see
+/// [`set_batch_limit`](Self::set_batch_limit) for the batch size cap.
 pub struct MemorySubscriber {
     name: String,
     rx: mpsc::UnboundedReceiver<MemoryDelivery>,
     requeue: Sender,
+    batch_limit: usize,
+}
+
+impl MemorySubscriber {
+    /// Caps how many buffered deliveries one batch yielded by
+    /// [`BatchSubscriber::batches`](crate::BatchSubscriber::batches) may carry (default 64).
+    ///
+    /// A batch always carries at least one delivery, so a limit of zero behaves like one.
+    pub fn set_batch_limit(&mut self, limit: usize) {
+        self.batch_limit = limit;
+    }
 }
 
 impl std::fmt::Debug for MemorySubscriber {
@@ -215,9 +265,24 @@ impl Subscriber for MemorySubscriber {
 
 /// Publisher returned by [`MemoryBroker::publisher`]. Fanout copy to every subscriber of the
 /// target name at publish time.
-#[derive(Clone)]
+///
+/// Also implements [`TransactionalPublisher`](crate::TransactionalPublisher): while a
+/// transaction is active on this handle, publishes are buffered and fan out together on commit.
 pub struct MemoryPublisher {
     state: Arc<MemoryState>,
+    // Active transaction buffer of this handle. `None` outside a transaction.
+    txn: Mutex<Option<Vec<MemoryDelivery>>>,
+}
+
+impl Clone for MemoryPublisher {
+    /// A clone is an independent handle on the same broker: it does not join (or carry over)
+    /// this handle's active transaction.
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            txn: Mutex::new(None),
+        }
+    }
 }
 
 impl std::fmt::Debug for MemoryPublisher {
@@ -235,6 +300,13 @@ impl Publisher for MemoryPublisher {
             payload: Bytes::copy_from_slice(msg.payload()),
             headers: msg.headers().clone(),
         };
+        {
+            let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
+            if let Some(buffered) = txn.as_mut() {
+                buffered.push(delivery);
+                return Ok(());
+            }
+        }
         self.state.fanout(&delivery);
         Ok(())
     }

--- a/tests/conformance_self.rs
+++ b/tests/conformance_self.rs
@@ -6,7 +6,7 @@
 use std::convert::Infallible;
 
 use ruststream::{
-    conformance::harness,
+    conformance::{capabilities, harness},
     memory::{MemoryBroker, MemorySource},
 };
 
@@ -22,6 +22,40 @@ async fn memory_broker_passes_conformance_suite() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn memory_broker_passes_lifecycle() {
     harness::lifecycle(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+
+#[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_request_reply_suite() {
+    capabilities::request_reply(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.requester(),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+
+#[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_batches_suite() {
+    capabilities::batches(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+
+#[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_transactions_suite() {
+    capabilities::transactions(
         MemoryBroker::new,
         |name| MemorySource::new(name),
         |broker| broker.publisher(),


### PR DESCRIPTION
# Description

Implements every capability trait natively on the in-memory broker and gives the conformance
harness per-capability suites, so application code that depends on a capability can be tested
without a real server and broker authors implementing a capability get a contract check for it.
These are first-class features of the broker's own in-process semantics, not simulations of
another broker's (the no-simulation rule applies to `TestClient` implementations standing in for
other brokers; `MemoryBroker` owns its semantics).

What changed:

- **Request / reply**: `MemoryBroker::requester()` returns a new `MemoryRequester` whose
  `request` publishes with a unique in-process inbox in the `reply-to` header and resolves on the
  first message delivered there; unanswered requests fail with `RequestError::Timeout`. It is a
  separate publisher type because `MemoryPublisher::Error` is `Infallible` and a request can time
  out; changing that associated type would be breaking, a new type is additive. Single-use
  inboxes are unregistered after the request resolves, so the subscriber map does not grow.
- **Batches**: `MemorySubscriber` implements `BatchSubscriber` with greedy draining - a batch is
  the first awaited delivery plus everything already buffered, capped by `set_batch_limit`
  (default 64). Partial batches ship immediately, so no deadline timer is involved, and the drain
  happens inside a single poll, keeping the stream cancel-safe.
- **Transactions**: `MemoryPublisher` implements `TransactionalPublisher` - publishes between
  `begin_transaction` and `commit` are buffered on the handle and fan out together in publish
  order; `abort` discards them. All operations are total (matching the infallible error type):
  `begin` inside an active transaction continues it, `commit`/`abort` without one are no-ops.
  Clones of a handle deliberately do not share its transaction.
- **Partition keys**: `MemoryMessage` implements `Partitioned`, reading the key from the
  well-known `partition-key` header (`memory::PARTITION_KEY_HEADER`).
- **Conformance**: new `conformance::capabilities` module with `request_reply`, `batches`, and
  `transactions` suites, built from the same caller-supplied factory shape as
  `harness::lifecycle`. `MemoryBroker` passes all of them in `tests/conformance_self.rs` and is
  the executable reference.
- `DescribeServer` stays deliberately unimplemented: the in-memory broker has no network
  coordinates, and that asymmetry is part of the contract documentation.
- `memory.rs` grew past the 500-line cap and became `memory/` (`mod.rs` + `capability.rs`).
- Docs: capability sections in the Memory broker page and the conformance guide; `test-util`
  added to the dev tokio features for one paused-clock timeout test.

Reference implementation and test bed for #21, #22, #23, #24. Fully additive, no existing API
changes.

Fixes #33

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
