### PR TITLE
runtime: selective batch acknowledgement via Vec<HandlerResult>

### DIFF
--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -206,9 +206,11 @@ fn unsupported_source(expr: &Expr) -> syn::Error {
 ///
 /// Wrapping the source in `batch(..)` switches the definition to a `BatchDef`: the handler takes
 /// `&[T]` and runs once per batch pulled from the broker's `BatchSubscriber` (use the `Buffered`
-/// adapter for brokers without native batching). `batch(..)` cannot be combined with
-/// `publish(..)`. The source type is recovered from the constructor path, so a generic source
-/// spells its parameters: `batch(Buffered::<Name>::new(Name::new("orders")))`.
+/// adapter for brokers without native batching). It returns any `IntoBatchResult` - one outcome
+/// for the whole batch (`HandlerResult`, `()`, `Result<_, E>`), or `Vec<HandlerResult>` to settle
+/// element `i` of the slice with outcome `i`. `batch(..)` cannot be combined with `publish(..)`.
+/// The source type is recovered from the constructor path, so a generic source spells its
+/// parameters: `batch(Buffered::<Name>::new(Name::new("orders")))`.
 ///
 /// In both forms the handler may declare an optional second parameter, the per-delivery
 /// `&mut Context`, to read app state or publish manually.
@@ -385,7 +387,7 @@ fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
                 "batch(..) cannot be combined with publish(..)",
             ));
         }
-        expand_batch(&parts)
+        expand_batch(&parts, func)
     } else if let Some(reply_topic) = &args.publish {
         expand_publishing(&parts, func, reply_topic)?
     } else {
@@ -394,7 +396,7 @@ fn expand(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
     Ok(body.into())
 }
 
-fn expand_batch(parts: &HandlerParts<'_>) -> TokenStream2 {
+fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
     let HandlerParts {
         vis,
         name,
@@ -409,6 +411,14 @@ fn expand_batch(parts: &HandlerParts<'_>) -> TokenStream2 {
         ctx_param,
     } = parts;
 
+    // Pin the body's type to the declared return type before the `IntoBatchResult` conversion:
+    // the trait has several impls, so an open-ended tail like `.collect()` cannot infer through
+    // the conversion alone.
+    let outcome_ty = match &func.sig.output {
+        ReturnType::Type(_, ty) => quote!(#ty),
+        ReturnType::Default => quote!(()),
+    };
+
     quote! {
             #[derive(Clone, Copy)]
             #[allow(non_camel_case_types)]
@@ -419,10 +429,9 @@ fn expand_batch(parts: &HandlerParts<'_>) -> TokenStream2 {
                     &self,
                     #pat: &[#input_ty],
                     #ctx_param: &mut ::ruststream::runtime::Context<'_>,
-                ) -> ::ruststream::runtime::HandlerResult {
-                    ::ruststream::runtime::IntoHandlerResult::into_handler_result(
-                        (async move #block).await,
-                    )
+                ) -> ::ruststream::runtime::BatchResult {
+                    let outcome: #outcome_ty = (async move #block).await;
+                    ::ruststream::runtime::IntoBatchResult::into_batch_result(outcome)
                 }
             }
 

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -130,12 +130,28 @@ The semantics differ from single-message handlers in a few ways:
 
 - Elements that fail to decode are nacked individually (per the decode-failure policy) and never
   reach the handler; the rest arrive as one slice.
-- The returned `HandlerResult` settles **every** message of the batch: `Ack` acks them all,
-  `retry()` requeues them all.
+- The returned value settles the batch. A single `HandlerResult` (or `()` / `Result<_, E>`)
+  settles **every** message uniformly: `Ack` acks them all, `retry()` requeues them all.
 - Per-message headers are not accessible in the `&[T]` form, and the context starts with empty
   headers.
 - App-global and router middleware wrap per-message handlers and do not apply to batch
   registrations.
+
+### Selective acknowledgement
+
+A common case is partial readiness: some messages of the page are processed, others are not
+ready yet and should be redelivered without retrying the ones that succeeded. Return
+`Vec<HandlerResult>` to settle element `i` of the slice with outcome `i`:
+
+```rust
+--8<-- "examples/subscribers.rs:batch_selective"
+```
+
+Broker semantics are exactly those of per-message `nack(requeue = true)`: brokers with
+per-message redelivery honour selective retry natively; a positional broker degrades the same
+way it does for a single-message nack (the crate of that broker documents it). Returning a
+vector whose length does not match the batch is a bug in the handler: the unmatched remainder is
+retried (an extra redelivery beats a silently lost message) and the mismatch is logged.
 
 ## Macro or manual
 

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -46,6 +46,23 @@ async fn settle(orders: &[Order]) -> HandlerResult {
 }
 // --8<-- [end:batch]
 
+// --8<-- [start:batch_selective]
+/// Retries only the entries that are not ready yet; the rest of the page settles.
+#[subscriber(batch("orders"))]
+async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
+    orders
+        .iter()
+        .map(|order| {
+            if order.id == 0 {
+                HandlerResult::retry()
+            } else {
+                HandlerResult::Ack
+            }
+        })
+        .collect()
+}
+// --8<-- [end:batch_selective]
+
 // --8<-- [start:batch_buffered]
 // Client-side batching for sources without native batches: close a batch at 128 deliveries or
 // 20 ms after its first one. The macro recovers the source type from the constructor path, so
@@ -67,6 +84,7 @@ fn app() -> RustStream {
         // --8<-- [start:batch_mount]
         b.include_batch(settle);
         // --8<-- [end:batch_mount]
+        b.include_batch(reconcile);
         b.include_batch(drain);
         // --8<-- [start:manual]
         b.subscribe(

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -11,7 +11,7 @@
 use std::{future::Future, marker::PhantomData};
 
 use serde::de::DeserializeOwned;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::IncomingMessage;
 use crate::codec::Codec;
@@ -21,24 +21,106 @@ use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
 use super::typed::DecodeFailure;
 
+/// The settlement of one dispatched batch.
+///
+/// Returned by batch handlers (usually through [`IntoBatchResult`]) and applied by the
+/// dispatcher to each message's own `ack` / `nack`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BatchResult {
+    /// One outcome settles every message of the batch.
+    Uniform(HandlerResult),
+    /// Outcome `i` settles slice element `i`. A length mismatch with the dispatched batch is a
+    /// bug in the handler: the unmatched remainder is retried (an extra redelivery beats a
+    /// silently lost message) and the mismatch is logged.
+    PerElement(Vec<HandlerResult>),
+}
+
+/// Conversion into a [`BatchResult`], so `#[subscriber(batch(..))]` handlers can return a plain
+/// value.
+///
+/// Implemented for [`BatchResult`] (identity), [`HandlerResult`] / `()` / `Result<(), E>` /
+/// `Result<HandlerResult, E>` (one outcome for the whole batch, with the same conventions as
+/// [`IntoHandlerResult`](super::IntoHandlerResult)), and `Vec<HandlerResult>` (element `i`
+/// settles slice element `i`).
+pub trait IntoBatchResult {
+    /// Converts `self` into the settlement the dispatcher applies.
+    fn into_batch_result(self) -> BatchResult;
+}
+
+impl IntoBatchResult for BatchResult {
+    fn into_batch_result(self) -> BatchResult {
+        self
+    }
+}
+
+impl IntoBatchResult for HandlerResult {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::Uniform(self)
+    }
+}
+
+impl IntoBatchResult for () {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::Uniform(HandlerResult::Ack)
+    }
+}
+
+impl<E> IntoBatchResult for Result<(), E> {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::Uniform(match self {
+            Ok(()) => HandlerResult::Ack,
+            Err(_) => HandlerResult::drop(),
+        })
+    }
+}
+
+impl<E> IntoBatchResult for Result<HandlerResult, E> {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::Uniform(self.unwrap_or_else(|_| HandlerResult::drop()))
+    }
+}
+
+impl IntoBatchResult for Vec<HandlerResult> {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::PerElement(self)
+    }
+}
+
 /// A handler invoked with one whole decoded batch.
 ///
 /// The batch parameter is a slice: per-message broker handles stay with the dispatcher, which
-/// acknowledges every message of the batch according to the returned [`HandlerResult`].
+/// settles every message of the batch according to the returned [`BatchResult`] - one uniform
+/// outcome, or one outcome per element.
 ///
 /// # Examples
 ///
-/// Closures implement `SliceHandler` automatically:
+/// Closures returning any [`IntoBatchResult`] implement `SliceHandler` automatically:
 ///
 /// ```
 /// use ruststream::runtime::{Context, HandlerResult, SliceHandler};
 ///
 /// fn assert_slice_handler<T, H: SliceHandler<T>>(_: H) {}
 ///
-/// fn use_closure() {
+/// fn use_closures() {
+///     // One outcome for the whole batch.
 ///     assert_slice_handler::<u32, _>(|batch: &[u32], _ctx: &mut Context| {
 ///         let _ = batch.len();
 ///         async { HandlerResult::Ack }
+///     });
+///     // One outcome per element: entries that are not ready yet retry individually.
+///     assert_slice_handler::<u32, _>(|batch: &[u32], _ctx: &mut Context| {
+///         let outcomes: Vec<HandlerResult> = batch
+///             .iter()
+///             .map(|n| {
+///                 if *n == 0 {
+///                     HandlerResult::retry()
+///                 } else {
+///                     HandlerResult::Ack
+///                 }
+///             })
+///             .collect();
+///         async move { outcomes }
 ///     });
 /// }
 /// ```
@@ -48,20 +130,24 @@ pub trait SliceHandler<T>: Send + Sync {
         &self,
         batch: &[T],
         ctx: &mut Context,
-    ) -> impl Future<Output = HandlerResult> + Send;
+    ) -> impl Future<Output = BatchResult> + Send;
 }
 
 impl<T, F, Fut> SliceHandler<T> for F
 where
     F: Fn(&[T], &mut Context) -> Fut + Send + Sync,
-    Fut: Future<Output = HandlerResult> + Send,
+    Fut: Future + Send,
+    Fut::Output: IntoBatchResult,
 {
     fn handle_slice(
         &self,
         batch: &[T],
         ctx: &mut Context,
-    ) -> impl Future<Output = HandlerResult> + Send {
-        (self)(batch, ctx)
+    ) -> impl Future<Output = BatchResult> + Send {
+        // Build the inner future before the async block so the returned future does not hold
+        // `&[T]` (which would demand `T: Sync` for it to be `Send`).
+        let fut = (self)(batch, ctx);
+        async move { fut.await.into_batch_result() }
     }
 }
 
@@ -158,7 +244,8 @@ where
 ///
 /// Each element decodes independently: failures are settled individually per the
 /// [`DecodeFailure`] policy and never reach the handler; the rest are passed on as one slice.
-/// The [`HandlerResult`] the handler returns is applied to every delivery behind that slice.
+/// The [`BatchResult`] the handler returns settles the deliveries behind that slice - uniformly,
+/// or element by element.
 pub struct TypedBatch<M, T, C, H> {
     codec: C,
     inner: H,
@@ -216,15 +303,152 @@ where
         if accepted.is_empty() {
             return;
         }
-        let outcome = self.inner.handle_slice(&values, ctx).await;
-        for msg in accepted {
-            let ack_result = match outcome {
-                HandlerResult::Ack => msg.ack().await,
-                HandlerResult::Nack { requeue } => msg.nack(requeue).await,
-            };
-            if let Err(err) = ack_result {
-                warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");
+        match self.inner.handle_slice(&values, ctx).await {
+            BatchResult::Uniform(result) => {
+                for msg in accepted {
+                    settle(msg, result).await;
+                }
             }
+            BatchResult::PerElement(results) => {
+                if results.len() != accepted.len() {
+                    error!(
+                        target: "ruststream::dispatch",
+                        expected = accepted.len(),
+                        returned = results.len(),
+                        "per-element outcome count does not match the batch; \
+                         retrying the unmatched remainder",
+                    );
+                }
+                let mut results = results.into_iter();
+                for msg in accepted {
+                    // An unmatched message gets retried: an extra redelivery beats losing it.
+                    let result = results.next().unwrap_or_else(HandlerResult::retry);
+                    settle(msg, result).await;
+                }
+            }
+        }
+    }
+}
+
+async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult) {
+    let ack_result = match result {
+        HandlerResult::Ack => msg.ack().await,
+        HandlerResult::Nack { requeue } => msg.nack(requeue).await,
+    };
+    if let Err(err) = ack_result {
+        warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");
+    }
+}
+
+#[cfg(all(test, feature = "memory", feature = "json"))]
+mod tests {
+    use futures::StreamExt;
+
+    use super::super::context::State;
+    use super::super::dispatch::Delivery;
+    use super::*;
+    use crate::codec::JsonCodec;
+    use crate::memory::{MemoryBroker, MemoryMessage, MemorySubscriber};
+    use crate::{BatchSubscriber, Headers, OutgoingMessage, Publisher, Subscriber};
+
+    async fn publish_numbers(broker: &MemoryBroker, name: &str, numbers: &[u32]) {
+        let publisher = broker.publisher();
+        for n in numbers {
+            publisher
+                .publish(OutgoingMessage::new(name, &serde_json::to_vec(n).unwrap()))
+                .await
+                .unwrap();
+        }
+    }
+
+    async fn pull_batch(sub: &mut MemorySubscriber) -> Vec<MemoryMessage> {
+        let mut stream = std::pin::pin!(sub.batches());
+        stream.next().await.unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn per_element_outcomes_settle_individually() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("selective");
+        publish_numbers(&broker, "selective", &[0, 1, 2]).await;
+
+        // 0 acks, 1 retries, 2 drops: only 1 may come back.
+        let handler = typed_batch(JsonCodec, |batch: &[u32], _ctx: &mut Context| {
+            let outcomes: Vec<HandlerResult> = batch
+                .iter()
+                .map(|n| match n {
+                    1 => HandlerResult::retry(),
+                    2 => HandlerResult::drop(),
+                    _ => HandlerResult::Ack,
+                })
+                .collect();
+            async move { outcomes }
+        });
+
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("selective", Headers::new(), &state, &delivery);
+        let batch = pull_batch(&mut sub).await;
+        assert_eq!(batch.len(), 3);
+        handler.handle_batch(batch, &mut ctx).await;
+
+        let redelivered = pull_batch(&mut sub).await;
+        let payloads: Vec<&[u8]> = redelivered.iter().map(IncomingMessage::payload).collect();
+        assert_eq!(payloads, [b"1"]);
+        for msg in redelivered {
+            msg.ack().await.unwrap();
+        }
+        let mut stream = std::pin::pin!(sub.stream());
+        assert!(futures::poll!(stream.next()).is_pending());
+    }
+
+    #[tokio::test]
+    async fn unmatched_remainder_is_retried() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("short");
+        publish_numbers(&broker, "short", &[0, 1, 2]).await;
+
+        // A buggy handler returning one outcome for a batch of three: the unmatched two retry.
+        let handler = typed_batch(JsonCodec, |_batch: &[u32], _ctx: &mut Context| async {
+            vec![HandlerResult::Ack]
+        });
+
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("short", Headers::new(), &state, &delivery);
+        let batch = pull_batch(&mut sub).await;
+        assert_eq!(batch.len(), 3);
+        handler.handle_batch(batch, &mut ctx).await;
+
+        let redelivered = pull_batch(&mut sub).await;
+        let payloads: Vec<&[u8]> = redelivered.iter().map(IncomingMessage::payload).collect();
+        assert_eq!(payloads, [b"1", b"2"]);
+        for msg in redelivered {
+            msg.ack().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn uniform_outcome_settles_the_whole_batch() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("uniform");
+        publish_numbers(&broker, "uniform", &[0, 1]).await;
+
+        let handler = typed_batch(JsonCodec, |_batch: &[u32], _ctx: &mut Context| async {
+            HandlerResult::retry()
+        });
+
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("uniform", Headers::new(), &state, &delivery);
+        let batch = pull_batch(&mut sub).await;
+        assert_eq!(batch.len(), 2);
+        handler.handle_batch(batch, &mut ctx).await;
+
+        let redelivered = pull_batch(&mut sub).await;
+        assert_eq!(redelivered.len(), 2);
+        for msg in redelivered {
+            msg.ack().await.unwrap();
         }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,7 +18,7 @@ mod subscriber_def;
 mod typed;
 
 pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
-pub use batch::{BatchDef, SliceHandler, TypedBatch};
+pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
 pub use context::{Context, State};
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
 pub use handler::{Handler, HandlerResult, IntoHandlerResult};

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -5,7 +5,7 @@
 use std::{
     sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -170,6 +170,87 @@ async fn buffered_adapter_batches_plain_subscribers_via_router() {
     })
     .await;
     assert!(result.is_ok(), "buffered batch did not arrive");
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static SETTLED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+static RETRIED_ONCE: AtomicBool = AtomicBool::new(false);
+
+/// Retries order 11 on first sight; settles everything else, per element.
+#[subscriber(batch("pages"))]
+async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
+    orders
+        .iter()
+        .map(|o| {
+            if o.id == 11 && !RETRIED_ONCE.swap(true, Ordering::SeqCst) {
+                HandlerResult::retry()
+            } else {
+                SETTLED.lock().unwrap().push(o.id);
+                HandlerResult::Ack
+            }
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn per_element_outcomes_retry_individually() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("pages", "0.1.0"))
+        .with_broker(broker, |b| b.include_batch(reconcile));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // Warm up until the subscription is live, then publish the real page exactly once, so the
+    // retry accounting below is deterministic.
+    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("pages", &order_bytes(0)))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if SETTLED.lock().unwrap().contains(&0) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(warmup.is_ok(), "subscription did not come up");
+
+    for id in [10u32, 11, 12] {
+        publisher
+            .publish(OutgoingMessage::new("pages", &order_bytes(id)))
+            .await
+            .unwrap();
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let settled = SETTLED.lock().unwrap().clone();
+            if [10, 11, 12].iter().all(|id| settled.contains(id)) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "retried element was not redelivered");
+
+    // 11 was retried exactly once and settled only on redelivery; 10 and 12 settled first try.
+    assert!(RETRIED_ONCE.load(Ordering::SeqCst));
+    let settled = SETTLED.lock().unwrap().clone();
+    for id in [10u32, 11, 12] {
+        assert_eq!(
+            settled.iter().filter(|s| **s == id).count(),
+            1,
+            "{id} must settle exactly once; settled: {settled:?}",
+        );
+    }
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();


### PR DESCRIPTION
# Description

Stacked on #39.

With batch subscribers a single `HandlerResult` settles the whole batch; the common
partial-readiness case (some messages processed, others not ready yet) needs per-element
outcomes, without retrying the ones that succeeded.

What changed:

- **`BatchResult`** (`#[non_exhaustive]`): `Uniform(HandlerResult)` settles every message of the
  batch; `PerElement(Vec<HandlerResult>)` settles slice element `i` with outcome `i`.
- **`IntoBatchResult`** mirrors `IntoHandlerResult`: implemented for `HandlerResult` / `()` /
  `Result<(), E>` / `Result<HandlerResult, E>` (uniform, same conventions as the single-message
  form), and for `Vec<HandlerResult>` (per element). `SliceHandler::handle_slice` now returns
  `BatchResult`; closures returning any `IntoBatchResult` still implement it automatically.
- **Outcome application**: the dispatcher already keeps the decoded-index -> original-message
  mapping (decode failures are settled before the handler runs), so applying outcomes is a zip
  over each message's own `ack()` / `nack()` - no new broker contract. A length mismatch between
  outcomes and the batch is a handler bug: the unmatched remainder is retried (an extra
  redelivery beats a silently lost message) and the mismatch is logged; surplus outcomes are
  ignored.
- The macro pins the handler body's type to the declared return type before the conversion, so
  an open-ended tail like `.collect()` infers cleanly through the multi-impl trait.
- Docs: a "Selective acknowledgement" subsection in the subscribers guide with an embedded
  example snippet.

Broker semantics are exactly those of per-message `nack(requeue = true)`; brokers with
per-message redelivery honour selective retry natively, positional brokers degrade the same way
they do for a single-message nack. Fully additive on top of #39.

Fixes #22

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
