### PR TITLE
runtime: per-subscriber worker pools via workers(n), with by_key lanes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,10 @@ required-features = ["macros", "memory", "json"]
 name = "metrics"
 required-features = ["metrics", "memory", "json"]
 
+[[test]]
+name = "workers"
+required-features = ["macros", "memory", "json"]
+
 # [[test]]
 # name = "doc_testing_nats"
 # required-features = ["macros", "json"]

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -15,12 +15,18 @@ use syn::{
 
 /// Arguments to `#[subscriber(..)]`: the subscription source (a string literal name, or a
 /// descriptor constructor `Type::new(..)` / `Type { .. }`), optionally wrapped in `batch(..)`
-/// to consume whole batches, and an optional `publish("topic")` clause naming the reply
-/// destination.
+/// to consume whole batches, plus optional `publish("topic")` (the reply destination) and
+/// `workers(n[, by_key])` (the dispatch concurrency) clauses, in any order.
 struct SubscriberArgs {
     source: Expr,
     batch: bool,
     publish: Option<LitStr>,
+    workers: Option<WorkersArg>,
+}
+
+struct WorkersArg {
+    count: syn::LitInt,
+    by_key: Option<Ident>,
 }
 
 impl Parse for SubscriberArgs {
@@ -48,23 +54,49 @@ impl Parse for SubscriberArgs {
             }
         }
         let mut publish = None;
-        if input.peek(Token![,]) {
+        let mut workers = None;
+        while input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
             let keyword: Ident = input.parse()?;
-            if keyword != "publish" {
+            if keyword == "publish" {
+                if publish.is_some() {
+                    return Err(syn::Error::new(keyword.span(), "duplicate publish(..)"));
+                }
+                let content;
+                parenthesized!(content in input);
+                publish = Some(content.parse()?);
+            } else if keyword == "workers" {
+                if workers.is_some() {
+                    return Err(syn::Error::new(keyword.span(), "duplicate workers(..)"));
+                }
+                let content;
+                parenthesized!(content in input);
+                let count: syn::LitInt = content.parse()?;
+                let mut by_key = None;
+                if content.peek(Token![,]) {
+                    content.parse::<Token![,]>()?;
+                    let marker: Ident = content.parse()?;
+                    if marker != "by_key" {
+                        return Err(syn::Error::new(
+                            marker.span(),
+                            "expected `by_key`: workers(n) or workers(n, by_key)",
+                        ));
+                    }
+                    by_key = Some(marker);
+                }
+                workers = Some(WorkersArg { count, by_key });
+            } else {
                 return Err(syn::Error::new(
                     keyword.span(),
-                    "expected `publish(\"reply-topic\")`",
+                    "expected `publish(\"reply-topic\")` or `workers(n[, by_key])`",
                 ));
             }
-            let content;
-            parenthesized!(content in input);
-            publish = Some(content.parse()?);
         }
         Ok(Self {
             source,
             batch,
             publish,
+            workers,
         })
     }
 }
@@ -219,6 +251,12 @@ fn unsupported_source(expr: &Expr) -> syn::Error {
 /// the whole batch is acked after. Hand the mount a `TypedPublisher` for independent reply
 /// publishes, or `.transactional()` for one transaction per batch.
 ///
+/// A `workers(n)` clause processes up to `n` deliveries (or batches) of this subscriber
+/// concurrently, each in its own task; global processing order is lost by design, and
+/// back-pressure holds at `n` in-flight deliveries. `workers(n, by_key)` switches to `n`
+/// sequential lanes keyed by the message's partition key, preserving per-key ordering
+/// (single-message forms only). The default is the sequential loop.
+///
 /// In both forms the handler may declare an optional second parameter, the per-delivery
 /// `&mut Context`, to read app state or publish manually.
 #[proc_macro_attribute]
@@ -290,6 +328,40 @@ struct HandlerParts<'a> {
     input_schema: TokenStream2,
     message_meta: TokenStream2,
     ctx_param: TokenStream2,
+    workers_method: TokenStream2,
+}
+
+/// Renders the `workers(..)` clause as an override of the def's defaulted `workers` method, or
+/// nothing when the clause is absent.
+fn workers_method(args: &SubscriberArgs) -> syn::Result<TokenStream2> {
+    let Some(WorkersArg { count, by_key }) = &args.workers else {
+        return Ok(quote!());
+    };
+    if count.base10_parse::<usize>()? == 0 {
+        return Err(syn::Error::new(
+            count.span(),
+            "workers(0) is not a policy; the minimum is 1",
+        ));
+    }
+    if let Some(marker) = by_key {
+        if args.batch {
+            return Err(syn::Error::new(
+                marker.span(),
+                "by_key lanes order single messages per key; they do not apply to batch(..) \
+                 forms",
+            ));
+        }
+        return Ok(quote! {
+            fn workers(&self) -> ::ruststream::runtime::Workers {
+                ::ruststream::runtime::Workers::keyed(#count)
+            }
+        });
+    }
+    Ok(quote! {
+        fn workers(&self) -> ::ruststream::runtime::Workers {
+            ::ruststream::runtime::Workers::pool(#count)
+        }
+    })
 }
 
 fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<HandlerParts<'a>> {
@@ -370,6 +442,8 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         quote!(_ctx)
     };
 
+    let workers_method = workers_method(args)?;
+
     Ok(HandlerParts {
         vis: &func.vis,
         name: &func.sig.ident,
@@ -382,6 +456,7 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         input_schema,
         message_meta,
         ctx_param,
+        workers_method,
     })
 }
 
@@ -432,6 +507,7 @@ fn expand_batch_publishing(
         input_schema,
         message_meta,
         ctx_param,
+        workers_method,
     } = parts;
 
     let declared_ty = match &func.sig.output {
@@ -481,6 +557,8 @@ fn expand_batch_publishing(
             fn source(&self) -> Self::Source { #source_expr }
             fn reply_name(&self) -> &str { #reply_topic }
 
+            #workers_method
+
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
             }
@@ -516,6 +594,7 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
         input_schema,
         message_meta,
         ctx_param,
+        workers_method,
     } = parts;
 
     // Pin the body's type to the declared return type before the `IntoBatchResult` conversion:
@@ -549,6 +628,8 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
 
                 fn source(&self) -> Self::Source { #source_expr }
 
+                #workers_method
+
                 fn description(&self) -> ::core::option::Option<&str> {
                     #description
                 }
@@ -579,6 +660,7 @@ fn expand_publishing(
         input_schema,
         message_meta,
         ctx_param,
+        workers_method,
     } = parts;
 
     let declared_ty = match &func.sig.output {
@@ -612,6 +694,8 @@ fn expand_publishing(
             fn source(&self) -> Self::Source { #source_expr }
             fn reply_name(&self) -> &str { #reply_topic }
 
+            #workers_method
+
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
             }
@@ -644,6 +728,7 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
         input_schema,
         message_meta,
         ctx_param,
+        workers_method,
     } = parts;
 
     quote! {
@@ -669,6 +754,8 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
                 type Source = #source_ty;
 
                 fn source(&self) -> Self::Source { #source_expr }
+
+                #workers_method
 
                 fn description(&self) -> ::core::option::Option<&str> {
                     #description

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -153,6 +153,35 @@ way it does for a single-message nack (the crate of that broker documents it). R
 vector whose length does not match the batch is a bug in the handler: the unmatched remainder is
 retried (an extra redelivery beats a silently lost message) and the mismatch is logged.
 
+## Worker pools
+
+The dispatch loop is sequential per subscriber: one delivery is handled and settled before the
+next is pulled, so one slow handler stalls the whole subscription. A `workers(n)` clause
+processes up to `n` deliveries of this subscriber concurrently, each in its own task on the
+multi-thread runtime:
+
+```rust
+--8<-- "examples/subscribers.rs:workers"
+```
+
+Back-pressure holds: the stream is not polled while `n` deliveries are in flight, which plays
+well with broker-side limits like JetStream `max_ack_pending`. **Global processing order is lost
+by design** - if any ordering matters, either stay sequential or use keyed lanes:
+
+```rust
+--8<-- "examples/subscribers.rs:workers_by_key"
+```
+
+`workers(n, by_key)` runs `n` sequential lanes. A delivery goes to the lane its partition key
+hashes to, so messages sharing a key never overlap or reorder - the in-process analogue of
+Kafka partition semantics. The key comes from the broker message's `partition_key()` (brokers
+whose messages implement the `Partitioned` capability expose it; the in-memory broker reads the
+`partition-key` header). Messages without a key rotate over the lanes. `by_key` applies to
+single-message subscribers; batch forms take a plain `workers(n)` pool of batches.
+
+On shutdown, the subscriber stops pulling new deliveries and in-flight workers drain under the
+app's `shutdown_timeout`.
+
 ## Macro or manual
 
 `#[subscriber]` is sugar over a generic API. The macro generates a typed handler and its metadata;

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -46,6 +46,24 @@ async fn settle(orders: &[Order]) -> HandlerResult {
 }
 // --8<-- [end:batch]
 
+// --8<-- [start:workers]
+/// Up to 16 orders processed concurrently; global order is lost by design.
+#[subscriber("orders", workers(16))]
+async fn fan_out(order: &Order) -> HandlerResult {
+    println!("processing order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:workers]
+
+// --8<-- [start:workers_by_key]
+/// 16 lanes keyed by the message's partition key: per-key order is preserved.
+#[subscriber("orders", workers(16, by_key))]
+async fn per_customer(order: &Order) -> HandlerResult {
+    println!("processing order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:workers_by_key]
+
 // --8<-- [start:batch_selective]
 /// Retries only the entries that are not ready yet; the rest of the page settles.
 #[subscriber(batch("orders"))]
@@ -86,6 +104,8 @@ fn app() -> RustStream {
         // --8<-- [end:batch_mount]
         b.include_batch(reconcile);
         b.include_batch(drain);
+        b.include(fan_out);
+        b.include(per_customer);
         // --8<-- [start:manual]
         b.subscribe(
             Name::new("orders"),

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -454,11 +454,19 @@ mod tests {
 
         let mut stream = std::pin::pin!(sub.stream());
         let keyed = stream.next().await.unwrap().unwrap();
-        assert_eq!(keyed.partition_key(), Some(b"user-42".as_slice()));
+        assert_eq!(
+            Partitioned::partition_key(&keyed),
+            Some(b"user-42".as_slice())
+        );
+        // The IncomingMessage hook must agree with the capability trait.
+        assert_eq!(
+            IncomingMessage::partition_key(&keyed),
+            Some(b"user-42".as_slice())
+        );
         keyed.ack().await.unwrap();
 
         let unkeyed = stream.next().await.unwrap().unwrap();
-        assert_eq!(unkeyed.partition_key(), None);
+        assert_eq!(Partitioned::partition_key(&unkeyed), None);
         unkeyed.ack().await.unwrap();
     }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -362,6 +362,10 @@ impl IncomingMessage for MemoryMessage {
             .unwrap_or_default()
     }
 
+    fn partition_key(&self) -> Option<&[u8]> {
+        crate::Partitioned::partition_key(self)
+    }
+
     fn headers(&self) -> &Headers {
         static EMPTY: OnceLock<Headers> = OnceLock::new();
         self.delivery

--- a/src/message.rs
+++ b/src/message.rs
@@ -151,6 +151,17 @@ pub trait IncomingMessage: Send + Sync {
     /// Returns the headers attached to the message.
     fn headers(&self) -> &Headers;
 
+    /// Returns the routing key the broker partitioned this message by, or `None` when the
+    /// message carries no key.
+    ///
+    /// Defaulted to `None` so existing implementations keep compiling. Brokers whose messages
+    /// implement the [`Partitioned`](crate::Partitioned) capability override this to return the
+    /// same key, which lets the runtime preserve per-key ordering in keyed worker lanes
+    /// (`workers(n, by_key)`) without a `Partitioned` bound on every dispatch path.
+    fn partition_key(&self) -> Option<&[u8]> {
+        None
+    }
+
     /// Acknowledges successful processing. Consumes the message handle.
     ///
     /// # Errors

--- a/src/runtime/app.rs
+++ b/src/runtime/app.rs
@@ -1017,8 +1017,10 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
     {
         let meta = subscriber_metadata(source.name().to_owned(), &def);
-        let handler = typed(codec, def.into_handler());
-        self.subscribe(source, handler, meta);
+        let workers = def.workers();
+        let handler = self.global.layer(typed(codec, def.into_handler()));
+        self.sink
+            .push_subscribe_workers(source, handler, meta, workers);
     }
 
     /// Mounts a batch definition on `source`, decoding each element with `codec`. The shared
@@ -1034,8 +1036,10 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         C: Codec + 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let handler = typed_batch(codec, def.into_handler());
-        self.sink.push_subscribe_batch(source, handler, meta);
+        self.sink
+            .push_subscribe_batch(source, handler, meta, workers);
     }
 
     /// Mounts a batch publishing definition on `source`, decoding each element with `codec` and
@@ -1052,13 +1056,15 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         RP: ReplyPublisher + 'static,
     {
         let meta = batch_publishing_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let handler = BatchPublishingHandler {
             def,
             codec,
             publisher,
             pipeline: self.pipeline.clone(),
         };
-        self.sink.push_subscribe_batch(source, handler, meta);
+        self.sink
+            .push_subscribe_batch(source, handler, meta, workers);
     }
 
     /// Mounts a publishing definition on `source`, decoding with `codec` and replying through
@@ -1084,13 +1090,15 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
     {
         let meta = publishing_metadata(source.name().to_owned(), &def);
-        let handler = PublishingHandler {
+        let workers = def.workers();
+        let handler = self.global.layer(PublishingHandler {
             def,
             codec,
             publisher,
             pipeline: self.pipeline.clone(),
-        };
-        self.subscribe(source, handler, meta);
+        });
+        self.sink
+            .push_subscribe_workers(source, handler, meta, workers);
     }
 }
 

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -17,6 +17,7 @@ use crate::IncomingMessage;
 use crate::codec::Codec;
 
 use super::context::Context;
+use super::dispatch::Workers;
 use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
 use super::typed::DecodeFailure;
@@ -170,6 +171,13 @@ pub trait BatchDef: Sized {
 
     /// Builds the subscription source (fresh each call).
     fn source(&self) -> Self::Source;
+
+    /// The concurrency policy for this subscriber's dispatch loop (how many batches are in
+    /// flight at once). The macro fills this in from the `workers(..)` argument; the default is
+    /// sequential dispatch.
+    fn workers(&self) -> Workers {
+        Workers::sequential()
+    }
 
     /// An optional human description (from the handler's doc comment), for `AsyncAPI`.
     fn description(&self) -> Option<&str> {

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -17,6 +17,7 @@ use crate::codec::Codec;
 
 use super::batch::BatchHandler;
 use super::context::Context;
+use super::dispatch::Workers;
 use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
 use super::publish::{PublishMiddleware, ReplyPublisher};
@@ -44,6 +45,13 @@ pub trait BatchPublishingDef: Send + Sync {
 
     /// The name (subject / channel) the replies are published to.
     fn reply_name(&self) -> &str;
+
+    /// The concurrency policy for this subscriber's dispatch loop (how many batches are in
+    /// flight at once). The macro fills this in from the `workers(..)` argument; the default is
+    /// sequential dispatch.
+    fn workers(&self) -> Workers {
+        Workers::sequential()
+    }
 
     /// An optional human description (from the handler's doc comment), for `AsyncAPI`.
     fn description(&self) -> Option<&str> {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -3,10 +3,12 @@
 //! [`RustStream`](super::RustStream) can own task spawning directly.
 
 use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
 use futures::StreamExt;
-use tokio::task::JoinHandle;
+use tokio::sync::mpsc;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
@@ -20,6 +22,65 @@ use super::publisher_registry::ErasedPublisher;
 
 /// Named publishers registered on the application, resolvable from a [`Context`] by name.
 pub(crate) type Publishers = HashMap<String, Arc<dyn ErasedPublisher>>;
+
+/// Concurrency policy for one subscriber's dispatch loop, declared with the `workers(..)` macro
+/// argument (or [`Workers::sequential`] by default).
+///
+/// - `workers(n)`: up to `n` deliveries of the subscriber processed concurrently, each in its
+///   own task on the multi-thread runtime. Back-pressure holds: the stream is not polled while
+///   `n` deliveries are in flight. Global processing order is lost by design.
+/// - `workers(n, by_key)`: `n` lanes; a delivery goes to the lane picked by hashing its
+///   [`partition_key`](crate::IncomingMessage::partition_key), and each lane is sequential, so
+///   per-key ordering is preserved. Messages without a key rotate over the lanes.
+///
+/// The default is sequential dispatch (`workers(1)`), the pre-pool behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Workers {
+    count: usize,
+    by_key: bool,
+}
+
+impl Workers {
+    /// Sequential dispatch: one delivery at a time, in stream order. The default.
+    #[must_use]
+    pub const fn sequential() -> Self {
+        Self {
+            count: 1,
+            by_key: false,
+        }
+    }
+
+    /// A pool of up to `count` concurrent deliveries. Zero behaves like one (sequential).
+    #[must_use]
+    pub const fn pool(count: usize) -> Self {
+        Self {
+            count: if count == 0 { 1 } else { count },
+            by_key: false,
+        }
+    }
+
+    /// `count` sequential lanes keyed by the message
+    /// [`partition_key`](crate::IncomingMessage::partition_key): per-key ordering is preserved.
+    /// Zero or one lane behaves like sequential dispatch.
+    #[must_use]
+    pub const fn keyed(count: usize) -> Self {
+        Self {
+            count: if count == 0 { 1 } else { count },
+            by_key: true,
+        }
+    }
+
+    /// One worker is indistinguishable from the sequential loop.
+    pub(crate) const fn is_sequential(&self) -> bool {
+        self.count <= 1
+    }
+}
+
+impl Default for Workers {
+    fn default() -> Self {
+        Self::sequential()
+    }
+}
 
 /// Per-scope publish context threaded into every delivery's [`Context`]: the named-publisher
 /// registry and the scope's publish middleware pipeline. A handler resolves a publisher with
@@ -92,34 +153,74 @@ where
     })
 }
 
-/// Spawns a task that drives `subscriber` through a batch `handler`, one
-/// [`BatchSubscriber::batches`] item per invocation, until `shutdown` is triggered or the stream
-/// terminates. The handler owns the batch's deliveries and settles each of them.
-pub(crate) fn spawn_batch_dispatch<S, H>(
+/// Spawns a task that drives `subscriber` through `handler` with a bounded worker pool: up to
+/// `workers.count` deliveries in flight, each handled (and settled) in its own task. With
+/// `by_key`, the pool becomes per-key sequential lanes instead.
+///
+/// Sequential policies delegate to [`spawn_dispatch`]. On shutdown the stream stops being
+/// polled and in-flight workers drain; if the app's `shutdown_timeout` aborts this task, the
+/// owned worker tasks abort with it.
+pub(crate) fn spawn_dispatch_workers<S, H>(
+    subscriber: S,
+    handler: Arc<H>,
+    shutdown: CancellationToken,
+    name: Arc<str>,
+    state: Arc<State>,
+    delivery: Arc<Delivery>,
+    workers: Workers,
+) -> JoinHandle<()>
+where
+    S: Subscriber + Send + 'static,
+    S::Message: Send + Sync + 'static,
+    H: Handler<S::Message> + 'static,
+{
+    if workers.is_sequential() {
+        return spawn_dispatch(subscriber, handler, shutdown, name, state, delivery);
+    }
+    if workers.by_key {
+        spawn_dispatch_lanes(
+            subscriber, handler, shutdown, name, state, delivery, workers,
+        )
+    } else {
+        spawn_dispatch_pool(
+            subscriber, handler, shutdown, name, state, delivery, workers,
+        )
+    }
+}
+
+fn spawn_dispatch_pool<S, H>(
     mut subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
     state: Arc<State>,
     delivery: Arc<Delivery>,
+    workers: Workers,
 ) -> JoinHandle<()>
 where
-    S: BatchSubscriber + Send + 'static,
-    H: BatchHandler<S::Message> + 'static,
+    S: Subscriber + Send + 'static,
+    S::Message: Send + Sync + 'static,
+    H: Handler<S::Message> + 'static,
 {
     tokio::spawn(async move {
-        let mut stream = std::pin::pin!(subscriber.batches());
+        let mut stream = std::pin::pin!(subscriber.stream());
+        let mut tasks = JoinSet::new();
         loop {
             tokio::select! {
                 () = shutdown.cancelled() => break,
-                next = stream.next() => match next {
-                    Some(Ok(batch)) => {
-                        // A batch has no single working copy of headers, so the context starts
-                        // with an empty set; per-message headers stay on the broker deliveries.
-                        let mut ctx = Context::new(&name, Headers::new(), &state, &delivery);
-                        handler
-                            .handle_batch(batch.into_iter().collect(), &mut ctx)
-                            .await;
+                // The pool is full: reap a finished worker before polling for more.
+                Some(joined) = tasks.join_next(), if tasks.len() >= workers.count => {
+                    log_worker_exit(joined);
+                }
+                next = stream.next(), if tasks.len() < workers.count => match next {
+                    Some(Ok(msg)) => {
+                        let handler = Arc::clone(&handler);
+                        let name = Arc::clone(&name);
+                        let state = Arc::clone(&state);
+                        let delivery = Arc::clone(&delivery);
+                        tasks.spawn(async move {
+                            dispatch(&*handler, msg, &name, &state, &delivery).await;
+                        });
                     }
                     Some(Err(err)) => {
                         error!(
@@ -138,6 +239,188 @@ where
                     }
                 }
             }
+        }
+        while let Some(joined) = tasks.join_next().await {
+            log_worker_exit(joined);
+        }
+    })
+}
+
+fn spawn_dispatch_lanes<S, H>(
+    mut subscriber: S,
+    handler: Arc<H>,
+    shutdown: CancellationToken,
+    name: Arc<str>,
+    state: Arc<State>,
+    delivery: Arc<Delivery>,
+    workers: Workers,
+) -> JoinHandle<()>
+where
+    S: Subscriber + Send + 'static,
+    S::Message: Send + Sync + 'static,
+    H: Handler<S::Message> + 'static,
+{
+    tokio::spawn(async move {
+        // One sequential worker per lane, fed by a capacity-1 channel: a keyed delivery always
+        // lands in the lane its key hashes to, so per-key order is preserved. In-flight cap is
+        // one processing plus one queued delivery per lane.
+        let mut lanes = Vec::with_capacity(workers.count);
+        let mut tasks = JoinSet::new();
+        for _ in 0..workers.count {
+            let (tx, mut rx) = mpsc::channel::<S::Message>(1);
+            let handler = Arc::clone(&handler);
+            let name = Arc::clone(&name);
+            let state = Arc::clone(&state);
+            let delivery = Arc::clone(&delivery);
+            tasks.spawn(async move {
+                while let Some(msg) = rx.recv().await {
+                    dispatch(&*handler, msg, &name, &state, &delivery).await;
+                }
+            });
+            lanes.push(tx);
+        }
+
+        let mut stream = std::pin::pin!(subscriber.stream());
+        let mut unkeyed_rotation = 0usize;
+        loop {
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                next = stream.next() => match next {
+                    Some(Ok(msg)) => {
+                        // No key: any lane will do; rotate to spread the load.
+                        let lane = msg.partition_key().map_or_else(
+                            || {
+                                unkeyed_rotation = (unkeyed_rotation + 1) % workers.count;
+                                unkeyed_rotation
+                            },
+                            |key| lane_of(key, workers.count),
+                        );
+                        if lanes[lane].send(msg).await.is_err() {
+                            // A lane only disappears if its task panicked; stop pulling rather
+                            // than silently dropping deliveries for that key range.
+                            error!(
+                                target: "ruststream::dispatch",
+                                subscriber = %name,
+                                lane,
+                                "worker lane terminated; stopping dispatch",
+                            );
+                            break;
+                        }
+                    }
+                    Some(Err(err)) => {
+                        error!(
+                            target: "ruststream::dispatch",
+                            error = %err,
+                            "subscriber stream error",
+                        );
+                    }
+                    None => {
+                        debug!(
+                            target: "ruststream::dispatch",
+                            subscriber = %name,
+                            "subscriber stream ended",
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+        // Closing the channels lets each lane drain its queued delivery and exit.
+        drop(lanes);
+        while let Some(joined) = tasks.join_next().await {
+            log_worker_exit(joined);
+        }
+    })
+}
+
+fn lane_of(key: &[u8], lanes: usize) -> usize {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    // The modulo keeps the value below `lanes`, which is a usize.
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        (hasher.finish() % lanes as u64) as usize
+    }
+}
+
+fn log_worker_exit(joined: Result<(), tokio::task::JoinError>) {
+    if let Err(err) = joined {
+        error!(target: "ruststream::dispatch", error = %err, "worker task failed");
+    }
+}
+
+/// Spawns a task that drives `subscriber` through a batch `handler`, one
+/// [`BatchSubscriber::batches`] item per invocation, until `shutdown` is triggered or the stream
+/// terminates. The handler owns the batch's deliveries and settles each of them.
+///
+/// With a non-sequential `workers` policy, up to `workers.count` batches are in flight at once,
+/// each in its own task; keyed lanes do not apply at batch granularity (the macro rejects
+/// `by_key` on batch forms), so a keyed policy degrades to the plain pool.
+pub(crate) fn spawn_batch_dispatch<S, H>(
+    mut subscriber: S,
+    handler: Arc<H>,
+    shutdown: CancellationToken,
+    name: Arc<str>,
+    state: Arc<State>,
+    delivery: Arc<Delivery>,
+    workers: Workers,
+) -> JoinHandle<()>
+where
+    S: BatchSubscriber + Send + 'static,
+    S::Message: Send + 'static,
+    H: BatchHandler<S::Message> + 'static,
+{
+    tokio::spawn(async move {
+        let mut stream = std::pin::pin!(subscriber.batches());
+        let mut tasks = JoinSet::new();
+        loop {
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                // The pool is full: reap a finished worker before polling for more.
+                Some(joined) = tasks.join_next(), if tasks.len() >= workers.count => {
+                    log_worker_exit(joined);
+                }
+                next = stream.next(), if tasks.len() < workers.count => match next {
+                    Some(Ok(batch)) => {
+                        let batch: Vec<S::Message> = batch.into_iter().collect();
+                        if workers.is_sequential() {
+                            // A batch has no single working copy of headers, so the context
+                            // starts with an empty set; per-message headers stay on the broker
+                            // deliveries.
+                            let mut ctx = Context::new(&name, Headers::new(), &state, &delivery);
+                            handler.handle_batch(batch, &mut ctx).await;
+                        } else {
+                            let handler = Arc::clone(&handler);
+                            let name = Arc::clone(&name);
+                            let state = Arc::clone(&state);
+                            let delivery = Arc::clone(&delivery);
+                            tasks.spawn(async move {
+                                let mut ctx =
+                                    Context::new(&name, Headers::new(), &state, &delivery);
+                                handler.handle_batch(batch, &mut ctx).await;
+                            });
+                        }
+                    }
+                    Some(Err(err)) => {
+                        error!(
+                            target: "ruststream::dispatch",
+                            error = %err,
+                            "subscriber stream error",
+                        );
+                    }
+                    None => {
+                        debug!(
+                            target: "ruststream::dispatch",
+                            subscriber = %name,
+                            "subscriber stream ended",
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+        while let Some(joined) = tasks.join_next().await {
+            log_worker_exit(joined);
         }
     })
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -22,6 +22,7 @@ pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
 pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};
 pub use context::{Context, State};
+pub use dispatch::Workers;
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
 pub use handler::{Handler, HandlerResult, IntoHandlerResult};
 pub use metadata::HandlerMetadata;

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -14,6 +14,7 @@ use crate::codec::Codec;
 use crate::{IncomingMessage, Publisher};
 
 use super::context::Context;
+use super::dispatch::Workers;
 use super::handler::{Handler, HandlerResult};
 use super::metadata::HandlerMetadata;
 use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
@@ -39,6 +40,12 @@ pub trait PublishingDef: Send + Sync {
 
     /// The name (subject / channel) the reply is published to.
     fn reply_name(&self) -> &str;
+
+    /// The concurrency policy for this subscriber's dispatch loop. The macro fills this in from
+    /// the `workers(..)` argument; the default is sequential dispatch.
+    fn workers(&self) -> Workers {
+        Workers::sequential()
+    }
 
     /// An optional human description (from the handler's doc comment), for `AsyncAPI`.
     fn description(&self) -> Option<&str> {

--- a/src/runtime/router.rs
+++ b/src/runtime/router.rs
@@ -30,7 +30,9 @@ use super::batch_publishing::{
     BatchPublishingDef, BatchPublishingHandler, batch_publishing_metadata,
 };
 use super::context::State;
-use super::dispatch::{Delivery, spawn_batch_dispatch, spawn_dispatch};
+use super::dispatch::{
+    Delivery, Workers, spawn_batch_dispatch, spawn_dispatch, spawn_dispatch_workers,
+};
 use super::handler::Handler;
 use super::lifecycle::{BoxError, BoxFuture};
 use super::metadata::HandlerMetadata;
@@ -145,9 +147,11 @@ impl<B: Broker + 'static> RouterSink<B> {
         source: S,
         handler: H,
         meta: HandlerMetadata,
+        workers: Workers,
     ) where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
+        SourceMessage<B, S>: Send + 'static,
         H: BatchHandler<SourceMessage<B, S>> + 'static,
     {
         let handler = Arc::new(handler);
@@ -160,7 +164,38 @@ impl<B: Broker + 'static> RouterSink<B> {
                         .await
                         .map_err(|e| Box::new(e) as BoxError)?;
                     Ok(spawn_batch_dispatch(
-                        subscriber, handler, token, name, state, delivery,
+                        subscriber, handler, token, name, state, delivery, workers,
+                    ))
+                })
+            }));
+        self.handlers.push(meta);
+    }
+
+    /// Erases a source and its handler into a starter dispatching under the `workers` policy;
+    /// the subscription opens after connect.
+    pub(crate) fn push_subscribe_workers<S, H>(
+        &mut self,
+        source: S,
+        handler: H,
+        meta: HandlerMetadata,
+        workers: Workers,
+    ) where
+        S: SubscriptionSource<B> + Send + 'static,
+        S::Subscriber: Send + 'static,
+        SourceMessage<B, S>: Send + Sync + 'static,
+        H: Handler<SourceMessage<B, S>> + 'static,
+    {
+        let handler = Arc::new(handler);
+        let name: Arc<str> = Arc::from(meta.name.as_ref());
+        self.starters
+            .push(Box::new(move |broker: Arc<B>, state, delivery, token| {
+                Box::pin(async move {
+                    let subscriber = source
+                        .subscribe(broker.as_ref())
+                        .await
+                        .map_err(|e| Box::new(e) as BoxError)?;
+                    Ok(spawn_dispatch_workers(
+                        subscriber, handler, token, name, state, delivery, workers,
                     ))
                 })
             }));
@@ -204,6 +239,7 @@ pub struct SubscribeRoute<S, H> {
     source: S,
     handler: H,
     meta: HandlerMetadata,
+    workers: Workers,
 }
 
 /// One registration bound to an already-created subscriber. An implementation detail of [`Router`].
@@ -223,6 +259,7 @@ pub struct BatchRoute<S, H> {
     source: S,
     handler: H,
     meta: HandlerMetadata,
+    workers: Workers,
 }
 
 /// One mountable registration: applies the global blanket layer to its handler and registers it.
@@ -241,7 +278,7 @@ where
 {
     fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
         let handler = global.apply::<SourceMessage<B, S>, H>(self.handler);
-        sink.push_subscribe(self.source, handler, self.meta);
+        sink.push_subscribe_workers(self.source, handler, self.meta, self.workers);
     }
 
     fn collect(&self, out: &mut Vec<HandlerMetadata>) {
@@ -254,12 +291,13 @@ where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: BatchSubscriber + Send + 'static,
+    SourceMessage<B, S>: Send + 'static,
     H: BatchHandler<SourceMessage<B, S>> + 'static,
 {
     fn mount_one<G: BlanketLayer>(self, _global: &G, sink: &mut RouterSink<B>) {
         // Per-message layers cannot wrap a whole-batch handler, so neither the app-global stack
         // nor the router's own layers apply to batch registrations.
-        sink.push_subscribe_batch(self.source, self.handler, self.meta);
+        sink.push_subscribe_batch(self.source, self.handler, self.meta, self.workers);
     }
 
     fn collect(&self, out: &mut Vec<HandlerMetadata>) {
@@ -494,6 +532,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
                     source,
                     handler,
                     meta,
+                    workers: Workers::sequential(),
                 },
                 self.routes,
             ),
@@ -520,8 +559,22 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         C: Codec + 'static,
     {
         let meta = subscriber_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let handler = typed(codec, def.into_handler());
-        self.subscribe(source, handler, meta)
+        Router {
+            routes: (
+                SubscribeRoute {
+                    source,
+                    handler,
+                    meta,
+                    workers,
+                },
+                self.routes,
+            ),
+            codec: self.codec,
+            layers: self.layers,
+            _broker: PhantomData,
+        }
     }
 
     /// Mounts a batch definition on `source`, decoding with `codec`. The shared tail of the
@@ -541,6 +594,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         C: Codec + 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let handler = typed_batch(codec, def.into_handler());
         Router {
             routes: (
@@ -548,6 +602,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
                     source,
                     handler,
                     meta,
+                    workers,
                 },
                 self.routes,
             ),
@@ -577,6 +632,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         RP: ReplyPublisher + 'static,
     {
         let meta = batch_publishing_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let pipeline: Arc<[Arc<dyn PublishMiddleware>]> = Arc::from([]);
         let handler = BatchPublishingHandler {
             def,
@@ -590,6 +646,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
                     source,
                     handler,
                     meta,
+                    workers,
                 },
                 self.routes,
             ),
@@ -620,6 +677,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         PL: PublishLayer + 'static,
     {
         let meta = publishing_metadata(source.name().to_owned(), &def);
+        let workers = def.workers();
         let pipeline: Arc<[Arc<dyn PublishMiddleware>]> = Arc::from([]);
         let handler = PublishingHandler {
             def,
@@ -627,7 +685,20 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
             publisher,
             pipeline,
         };
-        self.subscribe(source, handler, meta)
+        Router {
+            routes: (
+                SubscribeRoute {
+                    source,
+                    handler,
+                    meta,
+                    workers,
+                },
+                self.routes,
+            ),
+            codec: self.codec,
+            layers: self.layers,
+            _broker: PhantomData,
+        }
     }
 }
 

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -1,6 +1,7 @@
 //! The contract a `#[subscriber]`-generated type implements so it can be mounted with
 //! [`BrokerScope::include`](super::BrokerScope::include).
 
+use super::dispatch::Workers;
 use super::handler::Handler;
 use super::metadata::HandlerMetadata;
 
@@ -47,6 +48,12 @@ pub trait SubscriberDef: Sized {
     /// The macro fills this in; the default omits it.
     fn message_description(&self) -> Option<&'static str> {
         None
+    }
+
+    /// The concurrency policy for this subscriber's dispatch loop. The macro fills this in from
+    /// the `workers(..)` argument; the default is sequential dispatch.
+    fn workers(&self) -> Workers {
+        Workers::sequential()
     }
 
     /// Consumes the definition, returning the handler.

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -1,0 +1,224 @@
+//! Integration tests for the workers(..) dispatch policies: concurrent pools, per-key lanes,
+//! and batch pools.
+#![cfg(feature = "macros")]
+
+use std::{
+    sync::{
+        Arc, LazyLock, Mutex,
+        atomic::{AtomicU32, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::{Headers, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Barrier, Notify};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+static WARMED: AtomicU32 = AtomicU32::new(0);
+static CRUNCHED: AtomicU32 = AtomicU32::new(0);
+static GATE: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(4));
+
+/// Four deliveries must be in flight at once to pass the barrier; a sequential loop would
+/// deadlock on the first one.
+#[subscriber("jobs", workers(4))]
+async fn crunch(job: &Order) -> HandlerResult {
+    if job.id == 0 {
+        WARMED.fetch_add(1, Ordering::SeqCst);
+        return HandlerResult::Ack;
+    }
+    GATE.wait().await;
+    CRUNCHED.fetch_add(1, Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pool_processes_deliveries_concurrently() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app =
+        RustStream::new(AppInfo::new("jobs", "0.1.0")).with_broker(broker, |b| b.include(crunch));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // Warm up until the subscription is live, then submit exactly the barrier's worth of jobs.
+    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("jobs", &order_bytes(0)))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if WARMED.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(warmup.is_ok(), "subscription did not come up");
+
+    for id in 1..=4u32 {
+        publisher
+            .publish(OutgoingMessage::new("jobs", &order_bytes(id)))
+            .await
+            .unwrap();
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        while CRUNCHED.load(Ordering::SeqCst) < 4 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "4 deliveries never ran concurrently (sequential dispatch would deadlock the barrier)",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static KEYED_SEEN: Mutex<Vec<(String, u32)>> = Mutex::new(Vec::new());
+
+/// Records (key, id) pairs; per-key arrival order must match publish order.
+#[subscriber("keyed", workers(4, by_key))]
+async fn keyed(order: &Order, ctx: &mut ruststream::runtime::Context<'_>) -> HandlerResult {
+    let key = ctx
+        .headers()
+        .get_str("partition-key")
+        .unwrap_or_default()
+        .to_owned();
+    // Encourage interleaving between lanes; each lane itself stays sequential.
+    tokio::task::yield_now().await;
+    KEYED_SEEN.lock().unwrap().push((key, order.id));
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn by_key_lanes_preserve_per_key_order() {
+    const PER_KEY: u32 = 10;
+
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app =
+        RustStream::new(AppInfo::new("keyed", "0.1.0")).with_broker(broker, |b| b.include(keyed));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let keyed_publish = |key: &'static str, id: u32| {
+        let publisher = publisher.clone();
+        async move {
+            let mut headers = Headers::new();
+            headers.insert("partition-key", key);
+            publisher
+                .publish(OutgoingMessage::new("keyed", &order_bytes(id)).with_headers(headers))
+                .await
+        }
+    };
+
+    // Warm up until the subscription is live (warmup deliveries carry their own key).
+    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = keyed_publish("warmup", 0).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if !KEYED_SEEN.lock().unwrap().is_empty() {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(warmup.is_ok(), "subscription did not come up");
+
+    for id in 1..=PER_KEY {
+        keyed_publish("alpha", id).await.unwrap();
+        keyed_publish("beta", id + 100).await.unwrap();
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let counted = KEYED_SEEN
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(key, _)| key == "alpha" || key == "beta")
+                .count();
+            if counted >= (PER_KEY as usize) * 2 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "keyed deliveries did not all arrive");
+
+    let seen = KEYED_SEEN.lock().unwrap().clone();
+    for key in ["alpha", "beta"] {
+        let ids: Vec<u32> = seen
+            .iter()
+            .filter(|(k, _)| k == key)
+            .map(|(_, id)| *id)
+            .collect();
+        assert!(
+            ids.windows(2).all(|w| w[0] < w[1]),
+            "per-key order lost for {key}: {ids:?}",
+        );
+    }
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static PAGES: AtomicUsize = AtomicUsize::new(0);
+
+/// Batch form composing with a pool: up to two pages in flight.
+#[subscriber(batch("pages"), workers(2))]
+async fn settle(orders: &[Order]) -> HandlerResult {
+    PAGES.fetch_add(orders.len(), Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_pool_dispatches_batches() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("pages", "0.1.0"))
+        .with_broker(broker, |b| b.include_batch(settle));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("pages", &order_bytes(1)))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if PAGES.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "no batch was dispatched through the pool");
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
# Description

Stacked on #41.

The dispatch loop is strictly sequential per subscriber, so one slow handler stalls the whole
subscription. This adds per-subscriber worker pools.

What changed:

- **`workers(n)` macro clause** on every subscriber form: up to `n` deliveries (or batches, for
  the `batch(..)` forms) of this subscriber processed concurrently, each spawned into a bounded
  `JoinSet` - true parallelism on the multi-thread runtime, not just concurrent awaiting. The
  stream is not polled while `n` deliveries are in flight, so back-pressure holds (plays well
  with JetStream `max_ack_pending` / Kafka `max.poll.interval`). Global processing order is lost
  by design, documented loudly; the conformance `ordering` scenario remains a sequential
  (`workers(1)`) guarantee.
- **`workers(n, by_key)`**: `n` sequential lanes, each fed by a capacity-1 channel; a delivery
  goes to the lane its partition key hashes to, so per-key ordering is preserved - the
  in-process analogue of Kafka partition semantics. Keyless messages rotate over the lanes.
  Single-message forms only (a batch has no single key); the macro rejects `by_key` on
  `batch(..)`.
- **The key hook**: a defaulted `IncomingMessage::partition_key` (returning `None`) that brokers
  whose messages implement the `Partitioned` capability override - the memory broker does, via
  its `partition-key` header. The issue proposed requiring `S::Message: Partitioned` at the
  mount site, but that needs an associated type on the released `SubscriberDef` (associated-type
  defaults are not stable), which would be a breaking change; the defaulted method is additive,
  gives `Partitioned` its runtime role through an explicit bridge, and degrades keyless brokers
  to lane rotation instead of refusing to compile. This is the same defaulted-hook pattern #25
  proposes for `nack_after`.
- **Plumbing**: a `Workers` policy type; a defaulted `workers()` method on all four def traits
  (additive on the released `SubscriberDef` / `PublishingDef`), which the macro overrides; the
  routes carry the policy to dispatch. Manual `subscribe` / `handle` registrations stay
  sequential - giving them a workers option requires either tightening their public bounds
  (breaking) or new methods, deferred until someone needs it.
- **Shutdown**: the cancellation token stops pulling new deliveries; in-flight workers drain
  under the existing `shutdown_timeout` (aborting the dispatch task aborts its owned workers).
- Docs: a "Worker pools" section in the subscribers guide with embedded example snippets.

Not included: the `ruststream_workers_busy{name}` gauge suggested in the issue's additional
context - the metrics module is middleware-based and a dispatch-level gauge is a separate wiring
exercise; happy to file it as a follow-up.

Fixes #24

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
