### PR TITLE
runtime: delayed retry via HandlerResult::retry_after and IncomingMessage::nack_after

### DIFF
--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -40,12 +40,20 @@ The return type is anything that converts into a [`HandlerResult`]:
 |---|---|
 | `HandlerResult::Ack` | acknowledge; the broker removes the message |
 | `HandlerResult::retry()` | nack with requeue (redeliver later) |
+| `HandlerResult::retry_after(delay)` | nack asking for redelivery no sooner than `delay` |
 | `HandlerResult::drop()` | nack without requeue (discard or dead-letter) |
 | `()` | always `Ack` |
 | `Result<(), E>` | `Ack` on `Ok`, `drop` on `Err` |
 | `Result<HandlerResult, E>` | the inner result on `Ok`, `drop` on `Err` |
 
 On the message itself, ack consumes `self`, so the type system prevents acking twice.
+
+`retry_after` covers the not-ready-yet case (a dependency has not arrived, an upstream is
+rate-limited), where an immediate redelivery would just spin. The delay is a hint: brokers with
+native delayed redelivery (JetStream `NAK` with delay, the in-memory broker) honour it, others
+fall back to an immediate requeue. It composes with
+[selective batch outcomes](#selective-acknowledgement): a `Vec<HandlerResult>` can carry
+per-element delays.
 
 ## Choosing the subscription source
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -385,6 +385,19 @@ impl IncomingMessage for MemoryMessage {
         }
         Ok(())
     }
+
+    /// Native delayed redelivery: the message returns to the same subscriber's queue once
+    /// `delay` has elapsed, not immediately.
+    async fn nack_after(mut self, delay: Duration) -> Result<(), AckError> {
+        let delivery = self.delivery.take().expect("delivery already consumed");
+        let requeue = self.requeue.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            // The subscriber may be gone by then; a dropped receiver is not an error.
+            let _ = requeue.send(delivery);
+        });
+        Ok(())
+    }
 }
 
 impl TestClient for MemoryBroker {
@@ -464,6 +477,34 @@ mod tests {
     use futures::StreamExt;
 
     use super::*;
+
+    // Paused time needs the current-thread runtime; the redelivery timer auto-advances instead
+    // of sleeping for real.
+    #[tokio::test(start_paused = true)]
+    async fn nack_after_redelivers_after_the_delay() {
+        let broker = MemoryBroker::new();
+        let mut sub = MemoryBroker::subscribe(&broker, "delayed");
+        let publisher = broker.publisher();
+
+        publisher
+            .publish(OutgoingMessage::new("delayed", b"later".as_slice()))
+            .await
+            .unwrap();
+
+        let mut stream = std::pin::pin!(sub.stream());
+        let msg = stream.next().await.unwrap().unwrap();
+        msg.nack_after(Duration::from_secs(5)).await.unwrap();
+
+        // Nothing is redelivered while the delay has not elapsed.
+        assert!(futures::poll!(stream.next()).is_pending());
+        tokio::time::advance(Duration::from_secs(5)).await;
+        // The timer task needs a tick to run before the redelivery is visible.
+        tokio::task::yield_now().await;
+
+        let redelivered = stream.next().await.unwrap().unwrap();
+        assert_eq!(redelivered.payload(), b"later");
+        redelivered.ack().await.unwrap();
+    }
 
     #[tokio::test]
     async fn stream_can_be_reentered() {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 //! Message types and the [`IncomingMessage`] trait.
 
-use std::future::Future;
+use std::{future::Future, time::Duration};
 
 use bytes::Bytes;
 
@@ -180,6 +180,25 @@ pub trait IncomingMessage: Send + Sync {
     ///
     /// [`ack`]: Self::ack
     fn nack(self, requeue: bool) -> impl Future<Output = Result<(), AckError>> + Send;
+
+    /// Negatively acknowledges the message, asking the broker to redeliver it no sooner than
+    /// `delay` from now.
+    ///
+    /// Defaulted to a plain `nack(true)` (immediate requeue), so existing implementations keep
+    /// compiling and the delay degrades to a hint. Brokers with native delayed redelivery
+    /// (`JetStream` `NAK` with delay) override it; the in-memory broker re-delivers after the
+    /// delay via a timer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AckError`] under the same conditions as [`nack`](Self::nack).
+    fn nack_after(self, delay: Duration) -> impl Future<Output = Result<(), AckError>> + Send
+    where
+        Self: Sized,
+    {
+        let _ = delay;
+        self.nack(true)
+    }
 }
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -160,7 +160,8 @@ impl Metrics {
 const fn consume_status(result: HandlerResult) -> &'static str {
     match result {
         HandlerResult::Ack => "ack",
-        HandlerResult::Nack { .. } => "nack",
+        // A delayed nack is still a nack for counting purposes.
+        HandlerResult::Nack { .. } | HandlerResult::NackAfter { .. } => "nack",
     }
 }
 

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -342,6 +342,7 @@ async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult) {
     let ack_result = match result {
         HandlerResult::Ack => msg.ack().await,
         HandlerResult::Nack { requeue } => msg.nack(requeue).await,
+        HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
     };
     if let Err(err) = ack_result {
         warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");
@@ -434,6 +435,41 @@ mod tests {
         for msg in redelivered {
             msg.ack().await.unwrap();
         }
+    }
+
+    // Paused time (current-thread runtime): the per-element delay auto-advances.
+    #[tokio::test(start_paused = true)]
+    async fn per_element_outcomes_carry_delays() {
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("delayed");
+        publish_numbers(&broker, "delayed", &[0, 1]).await;
+
+        // 0 acks; 1 retries no sooner than five seconds from now.
+        let handler = typed_batch(JsonCodec, |batch: &[u32], _ctx: &mut Context| {
+            let outcomes: Vec<HandlerResult> = batch
+                .iter()
+                .map(|n| match n {
+                    1 => HandlerResult::retry_after(std::time::Duration::from_secs(5)),
+                    _ => HandlerResult::Ack,
+                })
+                .collect();
+            async move { outcomes }
+        });
+
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("delayed", Headers::new(), &state, &delivery);
+        let batch = pull_batch(&mut sub).await;
+        handler.handle_batch(batch, &mut ctx).await;
+
+        let mut stream = std::pin::pin!(sub.stream());
+        assert!(futures::poll!(stream.next()).is_pending());
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+
+        let redelivered = stream.next().await.unwrap().unwrap();
+        assert_eq!(redelivered.payload(), b"1");
+        redelivered.ack().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -189,6 +189,7 @@ where
             let ack_result = match outcome {
                 HandlerResult::Ack => msg.ack().await,
                 HandlerResult::Nack { requeue } => msg.nack(requeue).await,
+                HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
             };
             if let Err(err) = ack_result {
                 warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -435,6 +435,7 @@ where
     let ack_result = match outcome {
         HandlerResult::Ack => msg.ack().await,
         HandlerResult::Nack { requeue } => msg.nack(requeue).await,
+        HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
     };
     if let Err(err) = ack_result {
         warn!(

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -1,6 +1,6 @@
 //! Handler abstraction and the [`HandlerResult`] enum returned to the router.
 
-use std::{future::Future, sync::Arc};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use super::context::Context;
 
@@ -15,6 +15,16 @@ pub enum HandlerResult {
         /// Whether the broker should redeliver the message.
         requeue: bool,
     },
+    /// Negatively acknowledge the message, asking the broker to redeliver it no sooner than
+    /// `delay` from now.
+    ///
+    /// The delay is a hint, honoured by brokers with native delayed redelivery (`JetStream`
+    /// `NAK` with delay); brokers without it fall back to an immediate requeue (see
+    /// [`IncomingMessage::nack_after`](crate::IncomingMessage::nack_after)).
+    NackAfter {
+        /// How long the broker should wait before redelivering.
+        delay: Duration,
+    },
 }
 
 impl HandlerResult {
@@ -22,6 +32,14 @@ impl HandlerResult {
     #[must_use]
     pub const fn retry() -> Self {
         Self::Nack { requeue: true }
+    }
+
+    /// Convenience constructor for [`NackAfter`](Self::NackAfter): redeliver, but not before
+    /// `delay` has passed - the not-ready-yet case (a dependency has not arrived, an upstream is
+    /// rate-limited), where an immediate redelivery would just spin.
+    #[must_use]
+    pub const fn retry_after(delay: Duration) -> Self {
+        Self::NackAfter { delay }
     }
 
     /// Convenience constructor for `Nack { requeue: false }`.

--- a/src/runtime/middleware.rs
+++ b/src/runtime/middleware.rs
@@ -197,6 +197,9 @@ pub mod layers {
                     HandlerResult::Nack { requeue } => {
                         warn!(target: "ruststream::dispatch", requeue, "handler nack");
                     }
+                    HandlerResult::NackAfter { delay } => {
+                        warn!(target: "ruststream::dispatch", ?delay, "handler delayed nack");
+                    }
                 }
                 result
             }

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -597,3 +597,52 @@ async fn publishing_handler_reads_context_state() {
     shutdown.notify_one();
     run.await.unwrap().unwrap();
 }
+
+static ATTEMPTS: AtomicU32 = AtomicU32::new(0);
+
+/// Asks for a delayed redelivery on first sight, then acks: the not-ready-yet pattern.
+#[subscriber("deferred")]
+async fn eventually(order: &Order) -> HandlerResult {
+    let _ = order;
+    if ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 0 {
+        return HandlerResult::retry_after(Duration::from_millis(10));
+    }
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retry_after_redelivers_through_the_dispatcher() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(broker, |b| b.include(eventually));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // One publish is enough: the second attempt must come from the delayed redelivery.
+    let payload = serde_json::to_vec(&Order { id: 5, total: 1.0 }).unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if ATTEMPTS.load(Ordering::SeqCst) == 0 {
+                let _ = publisher
+                    .publish(OutgoingMessage::new("deferred", &payload))
+                    .await;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if ATTEMPTS.load(Ordering::SeqCst) >= 2 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "the delayed nack never came back through the dispatcher",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
# Description

Stacked on #42.

`HandlerResult::Nack { requeue: true }` asks for immediate redelivery, but the not-ready-yet
case (a dependency has not arrived, an upstream is rate-limited) really means "retry in N
seconds". This lets the core contract carry that hint.

What changed:

- **`HandlerResult::NackAfter { delay }`** - a new variant on the `#[non_exhaustive]` enum, plus
  the `HandlerResult::retry_after(duration)` constructor. Additive; the enum stays `Copy`.
- **`IncomingMessage::nack_after(self, delay)`** - a defaulted trait method falling back to a
  plain `nack(true)`, so existing broker implementations keep compiling and the delay degrades
  to a hint. Brokers with native delayed NAK (JetStream) override it. The in-memory broker
  overrides it natively: the delivery returns to the subscriber's queue once the delay elapses,
  via a timer task.
- **Dispatch**: every settle path (single-message, batch, batch publishing) maps `NackAfter` to
  `nack_after`. It composes with selective batch outcomes (#22): a `Vec<HandlerResult>` carries
  per-element delays, covered by a paused-clock test. The metrics consume counter and the
  tracing layer count a delayed nack as a nack.
- The dispatcher never sleeps holding the delivery: the broker owns the delay, so no worker slot
  (#24) is blocked and no `ack_wait` expiry is faked - sleeping in the dispatcher was considered
  and rejected in the issue.
- Docs: the acking table and a not-ready-yet note in the subscribers guide.

Uniform retry policy stays where it belongs (JetStream `backoff`, delayed exchanges); this is
for per-message hints only expressible from the handler. Fully additive.

Fixes #25

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
