### PR TITLE
tests: replace timed polling with notify-driven synchronization

### DIFF
--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -120,7 +120,7 @@ async fn app_dispatches_typed_messages() {
 
     wait_for(
         || received.load(Ordering::SeqCst) == 10,
-        Duration::from_secs(1),
+        Duration::from_secs(5),
     )
     .await;
 
@@ -155,7 +155,7 @@ async fn app_subscribes_via_descriptor_after_connect() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     // The descriptor subscribes inside run(); retry publishing until the subscription is live.
-    wait_for_published(&publisher, &seen, Duration::from_secs(1)).await;
+    wait_for_published(&publisher, &seen, Duration::from_secs(5)).await;
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();
@@ -189,7 +189,7 @@ async fn included_router_handlers_dispatch() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    wait_for_published(&publisher, &seen, Duration::from_secs(1)).await;
+    wait_for_published(&publisher, &seen, Duration::from_secs(5)).await;
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();
@@ -225,7 +225,7 @@ async fn global_layer_reaches_router_handlers() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    wait_for_published(&publisher, &handler_hits, Duration::from_secs(1)).await;
+    wait_for_published(&publisher, &handler_hits, Duration::from_secs(5)).await;
 
     assert!(
         layer_hits.load(Ordering::SeqCst) >= 1,
@@ -273,7 +273,7 @@ async fn global_layer_wraps_handlers() {
 
     wait_for(
         || handler_hits.load(Ordering::SeqCst) == 1 && layer_hits.load(Ordering::SeqCst) == 1,
-        Duration::from_secs(1),
+        Duration::from_secs(5),
     )
     .await;
 
@@ -326,12 +326,12 @@ async fn cross_broker_publish_via_named_publisher() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     // ingress "orders" subscribes inside run() (deferred); retry until the bridge fires.
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress_pub
                 .publish(OutgoingMessage::new("orders", b"x"))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::task::yield_now().await;
             if received.load(Ordering::SeqCst) >= 1 {
                 break;
             }
@@ -394,7 +394,7 @@ async fn handler_reads_context_topic_and_state() {
 
     wait_for(
         || seen.lock().expect("poisoned").is_some(),
-        Duration::from_secs(1),
+        Duration::from_secs(5),
     )
     .await;
     assert_eq!(
@@ -459,7 +459,7 @@ async fn lifespan_hooks_run_in_order() {
 
     wait_for(
         || order.lock().expect("poisoned").contains(&"after_startup"),
-        Duration::from_secs(1),
+        Duration::from_secs(5),
     )
     .await;
     shutdown.notify_one();
@@ -502,7 +502,9 @@ fn app_records_handler_metadata() {
 async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
     let result = tokio::time::timeout(timeout, async {
         while !cond() {
-            tokio::time::sleep(Duration::from_millis(5)).await;
+            // Yield to the scheduler; in multi-thread mode the handler runs in a different
+            // thread and updates the atomic independently - no sleep needed for correctness.
+            tokio::task::yield_now().await;
         }
     })
     .await;
@@ -515,7 +517,8 @@ async fn wait_for_published(publisher: &impl Publisher, seen: &AtomicU32, timeou
             let _ = publisher
                 .publish(OutgoingMessage::new("events", b"ping"))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            // Yield once so the handler task has a chance to run before checking.
+            tokio::task::yield_now().await;
             if seen.load(Ordering::SeqCst) >= 1 {
                 break;
             }
@@ -598,12 +601,12 @@ async fn ctx_publisher_runs_through_pipeline() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress_pub
                 .publish(OutgoingMessage::new("orders", b"x"))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::task::yield_now().await;
             if tagged.load(Ordering::SeqCst) >= 1 {
                 break;
             }

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -2,14 +2,17 @@
 //! `include_batch` mounting, per-element decode failures, and the `Buffered` adapter.
 #![cfg(feature = "macros")]
 
+mod common;
+
 use std::{
     sync::{
-        Arc, Mutex,
+        Arc, LazyLock, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
+use common::handler_signal;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, TypedPublisher};
 use ruststream::testing::TestClient;
@@ -27,6 +30,7 @@ fn order_bytes(id: u32) -> Vec<u8> {
 }
 
 static BATCHES: Mutex<Vec<Vec<u32>>> = Mutex::new(Vec::new());
+static BILL_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Settles a whole page of orders at once.
 #[subscriber(batch("orders"))]
@@ -35,6 +39,7 @@ async fn bill(orders: &[Order]) -> HandlerResult {
         .lock()
         .unwrap()
         .push(orders.iter().map(|o| o.id).collect());
+    BILL_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -50,15 +55,15 @@ async fn batch_macro_def_receives_batches() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    // The subscription opens inside run(); retry until deliveries land.
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    // The subscription opens inside run(); retry publishing until deliveries land.
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             for id in 0..3u32 {
                 let _ = publisher
                     .publish(OutgoingMessage::new("orders", &order_bytes(id)))
                     .await;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&BILL_NOTIFY).await;
             let received: usize = BATCHES.lock().unwrap().iter().map(Vec::len).sum();
             if received >= 3 {
                 break;
@@ -85,11 +90,13 @@ async fn batch_macro_def_receives_batches() {
 }
 
 static GOOD_IDS: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+static SIFT_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Records the ids that survived decoding.
 #[subscriber(batch("mixed"))]
 async fn sift(orders: &[Order]) -> HandlerResult {
     GOOD_IDS.lock().unwrap().extend(orders.iter().map(|o| o.id));
+    SIFT_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -105,7 +112,7 @@ async fn undecodable_elements_never_reach_the_handler() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("mixed", &order_bytes(1)))
@@ -116,7 +123,7 @@ async fn undecodable_elements_never_reach_the_handler() {
             let _ = publisher
                 .publish(OutgoingMessage::new("mixed", &order_bytes(2)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&SIFT_NOTIFY).await;
             if GOOD_IDS.lock().unwrap().len() >= 2 {
                 break;
             }
@@ -134,6 +141,7 @@ async fn undecodable_elements_never_reach_the_handler() {
 }
 
 static BUFFERED_SEEN: AtomicUsize = AtomicUsize::new(0);
+static DRAIN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// A handler mounted on a `Buffered`-wrapped source directly in the macro. The macro recovers
 /// the source type from the constructor path, so a generic source spells its parameter
@@ -141,6 +149,7 @@ static BUFFERED_SEEN: AtomicUsize = AtomicUsize::new(0);
 #[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(2)))]
 async fn drain(events: &[Order]) -> HandlerResult {
     BUFFERED_SEEN.fetch_add(events.len(), Ordering::SeqCst);
+    DRAIN_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -158,12 +167,12 @@ async fn buffered_adapter_batches_plain_subscribers_via_router() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("events", &order_bytes(7)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&DRAIN_NOTIFY).await;
             if BUFFERED_SEEN.load(Ordering::SeqCst) >= 1 {
                 break;
             }
@@ -177,12 +186,13 @@ async fn buffered_adapter_batches_plain_subscribers_via_router() {
 }
 
 static SETTLED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+static RECONCILE_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static RETRIED_ONCE: AtomicBool = AtomicBool::new(false);
 
 /// Retries order 11 on first sight; settles everything else, per element.
 #[subscriber(batch("pages"))]
 async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
-    orders
+    let results = orders
         .iter()
         .map(|o| {
             if o.id == 11 && !RETRIED_ONCE.swap(true, Ordering::SeqCst) {
@@ -192,7 +202,9 @@ async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
                 HandlerResult::Ack
             }
         })
-        .collect()
+        .collect();
+    RECONCILE_NOTIFY.notify_one();
+    results
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -209,12 +221,12 @@ async fn per_element_outcomes_retry_individually() {
 
     // Warm up until the subscription is live, then publish the real page exactly once, so the
     // retry accounting below is deterministic.
-    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("pages", &order_bytes(0)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&RECONCILE_NOTIFY).await;
             if SETTLED.lock().unwrap().contains(&0) {
                 break;
             }
@@ -230,9 +242,9 @@ async fn per_element_outcomes_retry_individually() {
             .unwrap();
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&RECONCILE_NOTIFY).await;
             let settled = SETTLED.lock().unwrap().clone();
             if [10, 11, 12].iter().all(|id| settled.contains(id)) {
                 break;
@@ -263,10 +275,13 @@ struct Confirmation {
     accepted: bool,
 }
 
+static BATCH_CONFIRM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
 /// Confirms a page of orders. The Result form gives explicit ack control; the whole-batch
 /// rejection path is covered by the runtime unit tests.
 #[subscriber(batch("requests"), publish("confirmations"))]
 async fn confirm(orders: &[Order]) -> Result<Vec<Confirmation>, HandlerResult> {
+    BATCH_CONFIRM_NOTIFY.notify_one();
     Ok(orders
         .iter()
         .map(|o| Confirmation {
@@ -302,14 +317,16 @@ async fn batch_replies_publish_transactionally() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    // Retry publishing until the subscription is live, waking as soon as the handler fires;
+    // the published confirmations are then awaited with expect_published's own deadline.
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("requests", &order_bytes(7)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&BATCH_CONFIRM_NOTIFY).await;
             let confirmed = observer
-                .expect_published("confirmations", 1, Duration::from_millis(1))
+                .expect_published("confirmations", 1, Duration::from_millis(200))
                 .await
                 .unwrap();
             if !confirmed.is_empty() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,14 @@
+//! Shared helpers for the integration tests.
+
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+/// Waits until a handler signals `notify`, but no longer than one retry interval.
+///
+/// Used in publish-retry loops: subscriptions open inside `run()`, so a message published too
+/// early is lost and the signal never comes. The bounded wait lets the caller publish again
+/// instead of deadlocking, while still waking immediately on the happy path.
+pub(crate) async fn handler_signal(notify: &Notify) {
+    let _ = tokio::time::timeout(Duration::from_millis(10), notify.notified()).await;
+}

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -1,11 +1,17 @@
 //! Integration test for the `#[subscriber]` attribute macro.
 #![cfg(feature = "macros")]
 
+mod common;
+
 use std::{
-    sync::atomic::{AtomicU32, Ordering},
+    sync::{
+        LazyLock,
+        atomic::{AtomicU32, Ordering},
+    },
     time::Duration,
 };
 
+use common::handler_signal;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemorySubscriber};
 use ruststream::runtime::{
@@ -27,10 +33,12 @@ struct Order {
 }
 
 static HANDLED: AtomicU32 = AtomicU32::new(0);
+static HANDLED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("orders")]
 async fn handle(order: &Order) -> HandlerResult {
     HANDLED.fetch_add(order.id, Ordering::SeqCst);
+    HANDLED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -68,10 +76,12 @@ impl SubscriptionSource<MemoryBroker> for StreamSource {
 }
 
 static HANDLED_ON_STREAM: AtomicU32 = AtomicU32::new(0);
+static HANDLED_ON_STREAM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ignored-on-the-include_on-path")]
 async fn on_stream(order: &Order) -> HandlerResult {
     HANDLED_ON_STREAM.fetch_add(order.id, Ordering::SeqCst);
+    HANDLED_ON_STREAM_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -94,13 +104,13 @@ async fn macro_def_mounts_on_arbitrary_source() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Order { id: 4, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             // The source subscribed to "events.stream", not the macro's name.
             let _ = publisher
                 .publish(OutgoingMessage::new("events.stream", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&HANDLED_ON_STREAM_NOTIFY).await;
             if HANDLED_ON_STREAM.load(Ordering::SeqCst) >= 4 {
                 break;
             }
@@ -114,12 +124,14 @@ async fn macro_def_mounts_on_arbitrary_source() {
 }
 
 static HANDLED_CTOR: AtomicU32 = AtomicU32::new(0);
+static HANDLED_CTOR_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 // The descriptor lives in the decorator: the macro pulls the `StreamSource` type out of the
 // constructor path and `include` mounts on `def.source()`, with the broker checked at compile time.
 #[subscriber(StreamSource::new("ctor.stream"))]
 async fn on_ctor(order: &Order) -> HandlerResult {
     HANDLED_CTOR.fetch_add(order.id, Ordering::SeqCst);
+    HANDLED_CTOR_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -137,12 +149,12 @@ async fn macro_descriptor_in_decorator() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Order { id: 6, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("ctor.stream", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&HANDLED_CTOR_NOTIFY).await;
             if HANDLED_CTOR.load(Ordering::SeqCst) >= 6 {
                 break;
             }
@@ -159,12 +171,14 @@ async fn macro_descriptor_in_decorator() {
 }
 
 static HANDLED_CHAIN: AtomicU32 = AtomicU32::new(0);
+static HANDLED_CHAIN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 // A builder chain in the decorator: the macro follows the receivers down to `StreamSource::new`
 // for the type, and emits the whole chain as the source constructor.
 #[subscriber(StreamSource::new("placeholder").at("chain.stream"))]
 async fn on_chain(order: &Order) -> HandlerResult {
     HANDLED_CHAIN.fetch_add(order.id, Ordering::SeqCst);
+    HANDLED_CHAIN_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -181,13 +195,13 @@ async fn macro_builder_chain_in_decorator() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Order { id: 7, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             // The `at(..)` option won: the subscription binds to "chain.stream".
             let _ = publisher
                 .publish(OutgoingMessage::new("chain.stream", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&HANDLED_CHAIN_NOTIFY).await;
             if HANDLED_CHAIN.load(Ordering::SeqCst) >= 7 {
                 break;
             }
@@ -233,12 +247,12 @@ async fn macro_subscriber_dispatches() {
 
     let payload = serde_json::to_vec(&Order { id: 5, total: 1.0 }).unwrap();
     // include subscribes inside run() (after connect); retry until the subscription is live.
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("orders", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&HANDLED_NOTIFY).await;
             if HANDLED.load(Ordering::SeqCst) >= 5 {
                 break;
             }
@@ -252,10 +266,12 @@ async fn macro_subscriber_dispatches() {
 }
 
 static HANDLED_DEFAULT: AtomicU32 = AtomicU32::new(0);
+static HANDLED_DEFAULT_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("orders-default")]
 async fn handle_default(order: &Order) -> HandlerResult {
     HANDLED_DEFAULT.fetch_add(order.id, Ordering::SeqCst);
+    HANDLED_DEFAULT_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -274,12 +290,12 @@ async fn scope_default_codec_drops_per_call_codec() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Order { id: 9, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("orders-default", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&HANDLED_DEFAULT_NOTIFY).await;
             if HANDLED_DEFAULT.load(Ordering::SeqCst) >= 9 {
                 break;
             }
@@ -307,6 +323,7 @@ struct Ping {
 }
 
 static STATIC_SEEN: AtomicU32 = AtomicU32::new(0);
+static STATIC_SEEN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ping-in", publish("ping-out"))]
 async fn relay(p: &Ping) -> Ping {
@@ -318,6 +335,7 @@ async fn check(p: &Ping, ctx: &mut Context) -> HandlerResult {
     if ctx.headers().get("x-static").is_some() {
         STATIC_SEEN.store(p.n, Ordering::SeqCst);
     }
+    STATIC_SEEN_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -341,12 +359,12 @@ async fn static_publish_layer_transforms_reply() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Ping { n: 7 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress_pub
                 .publish(OutgoingMessage::new("ping-in", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&STATIC_SEEN_NOTIFY).await;
             if STATIC_SEEN.load(Ordering::SeqCst) == 7 {
                 break;
             }
@@ -373,6 +391,7 @@ struct Response {
 }
 
 static REPLY_DOUBLED: AtomicU32 = AtomicU32::new(0);
+static REPLY_DOUBLED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static REPLY_TAGGED: AtomicU32 = AtomicU32::new(0);
 
 /// A publish middleware that tags every outgoing reply with a header (envelope-style).
@@ -404,6 +423,7 @@ async fn capture(resp: &Response, ctx: &mut Context) -> HandlerResult {
         REPLY_TAGGED.store(1, Ordering::SeqCst);
     }
     REPLY_DOUBLED.store(resp.doubled, Ordering::SeqCst);
+    REPLY_DOUBLED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -428,12 +448,12 @@ async fn macro_publisher_replies_cross_broker() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Request { n: 21 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress_pub
                 .publish(OutgoingMessage::new("requests", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&REPLY_DOUBLED_NOTIFY).await;
             if REPLY_DOUBLED.load(Ordering::SeqCst) == 42 {
                 break;
             }
@@ -458,12 +478,15 @@ struct Confirmation {
 }
 
 static CONFIRM_REJECTED: AtomicU32 = AtomicU32::new(0);
+static CONFIRM_REJECTED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static CONFIRM_ACCEPTED: AtomicU32 = AtomicU32::new(0);
+static CONFIRM_ACCEPTED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("confirm-in", publish("confirm-out"))]
 async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
     if order.id == 0 {
         CONFIRM_REJECTED.fetch_add(1, Ordering::SeqCst);
+        CONFIRM_REJECTED_NOTIFY.notify_one();
         return Err(HandlerResult::drop());
     }
     Ok(Confirmation {
@@ -476,6 +499,7 @@ async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
 async fn confirm_sink(c: &Confirmation) -> HandlerResult {
     if c.accepted {
         CONFIRM_ACCEPTED.store(c.id, Ordering::SeqCst);
+        CONFIRM_ACCEPTED_NOTIFY.notify_one();
     }
     HandlerResult::Ack
 }
@@ -497,12 +521,12 @@ async fn publishing_result_form_controls_ack_and_publish() {
 
     // Err(HandlerResult) skips the publish entirely.
     let rejected = serde_json::to_vec(&Order { id: 0, total: 0.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress
                 .publish(OutgoingMessage::new("confirm-in", &rejected))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&CONFIRM_REJECTED_NOTIFY).await;
             if CONFIRM_REJECTED.load(Ordering::SeqCst) >= 3 {
                 break;
             }
@@ -521,12 +545,12 @@ async fn publishing_result_form_controls_ack_and_publish() {
 
     // Ok(reply) publishes and acks.
     let accepted = serde_json::to_vec(&Order { id: 6, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress
                 .publish(OutgoingMessage::new("confirm-in", &accepted))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&CONFIRM_ACCEPTED_NOTIFY).await;
             if CONFIRM_ACCEPTED.load(Ordering::SeqCst) == 6 {
                 break;
             }
@@ -544,6 +568,7 @@ async fn publishing_result_form_controls_ack_and_publish() {
 struct Bump(u32);
 
 static CTX_REPLY: AtomicU32 = AtomicU32::new(0);
+static CTX_REPLY_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ctx-in", publish("ctx-out"))]
 async fn ctx_reply(req: &Request, ctx: &mut Context) -> Response {
@@ -556,6 +581,7 @@ async fn ctx_reply(req: &Request, ctx: &mut Context) -> Response {
 #[subscriber("ctx-out")]
 async fn ctx_sink(resp: &Response) -> HandlerResult {
     CTX_REPLY.store(resp.doubled, Ordering::SeqCst);
+    CTX_REPLY_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -577,12 +603,12 @@ async fn publishing_handler_reads_context_state() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     let payload = serde_json::to_vec(&Request { n: 1 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = ingress
                 .publish(OutgoingMessage::new("ctx-in", &payload))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&CTX_REPLY_NOTIFY).await;
             if CTX_REPLY.load(Ordering::SeqCst) == 101 {
                 break;
             }
@@ -599,12 +625,15 @@ async fn publishing_handler_reads_context_state() {
 }
 
 static ATTEMPTS: AtomicU32 = AtomicU32::new(0);
+static ATTEMPTS_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Asks for a delayed redelivery on first sight, then acks: the not-ready-yet pattern.
 #[subscriber("deferred")]
 async fn eventually(order: &Order) -> HandlerResult {
     let _ = order;
-    if ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 0 {
+    let prev = ATTEMPTS.fetch_add(1, Ordering::SeqCst);
+    ATTEMPTS_NOTIFY.notify_one();
+    if prev == 0 {
         return HandlerResult::retry_after(Duration::from_millis(10));
     }
     HandlerResult::Ack
@@ -624,14 +653,14 @@ async fn retry_after_redelivers_through_the_dispatcher() {
 
     // One publish is enough: the second attempt must come from the delayed redelivery.
     let payload = serde_json::to_vec(&Order { id: 5, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             if ATTEMPTS.load(Ordering::SeqCst) == 0 {
                 let _ = publisher
                     .publish(OutgoingMessage::new("deferred", &payload))
                     .await;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&ATTEMPTS_NOTIFY).await;
             if ATTEMPTS.load(Ordering::SeqCst) >= 2 {
                 break;
             }

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -2,6 +2,8 @@
 //! and batch pools.
 #![cfg(feature = "macros")]
 
+mod common;
+
 use std::{
     sync::{
         Arc, LazyLock, Mutex,
@@ -10,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use common::handler_signal;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
 use ruststream::{Headers, OutgoingMessage, Publisher, subscriber};
@@ -26,7 +29,9 @@ fn order_bytes(id: u32) -> Vec<u8> {
 }
 
 static WARMED: AtomicU32 = AtomicU32::new(0);
+static WARMED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static CRUNCHED: AtomicU32 = AtomicU32::new(0);
+static CRUNCHED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static GATE: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(4));
 
 /// Four deliveries must be in flight at once to pass the barrier; a sequential loop would
@@ -35,10 +40,12 @@ static GATE: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(4));
 async fn crunch(job: &Order) -> HandlerResult {
     if job.id == 0 {
         WARMED.fetch_add(1, Ordering::SeqCst);
+        WARMED_NOTIFY.notify_one();
         return HandlerResult::Ack;
     }
     GATE.wait().await;
     CRUNCHED.fetch_add(1, Ordering::SeqCst);
+    CRUNCHED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -55,12 +62,12 @@ async fn pool_processes_deliveries_concurrently() {
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
     // Warm up until the subscription is live, then submit exactly the barrier's worth of jobs.
-    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("jobs", &order_bytes(0)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&WARMED_NOTIFY).await;
             if WARMED.load(Ordering::SeqCst) >= 1 {
                 break;
             }
@@ -76,9 +83,9 @@ async fn pool_processes_deliveries_concurrently() {
             .unwrap();
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(2), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         while CRUNCHED.load(Ordering::SeqCst) < 4 {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            CRUNCHED_NOTIFY.notified().await;
         }
     })
     .await;
@@ -92,6 +99,7 @@ async fn pool_processes_deliveries_concurrently() {
 }
 
 static KEYED_SEEN: Mutex<Vec<(String, u32)>> = Mutex::new(Vec::new());
+static KEYED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Records (key, id) pairs; per-key arrival order must match publish order.
 #[subscriber("keyed", workers(4, by_key))]
@@ -104,6 +112,7 @@ async fn keyed(order: &Order, ctx: &mut ruststream::runtime::Context<'_>) -> Han
     // Encourage interleaving between lanes; each lane itself stays sequential.
     tokio::task::yield_now().await;
     KEYED_SEEN.lock().unwrap().push((key, order.id));
+    KEYED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -133,10 +142,10 @@ async fn by_key_lanes_preserve_per_key_order() {
     };
 
     // Warm up until the subscription is live (warmup deliveries carry their own key).
-    let warmup = tokio::time::timeout(Duration::from_secs(1), async {
+    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = keyed_publish("warmup", 0).await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&KEYED_NOTIFY).await;
             if !KEYED_SEEN.lock().unwrap().is_empty() {
                 break;
             }
@@ -150,9 +159,9 @@ async fn by_key_lanes_preserve_per_key_order() {
         keyed_publish("beta", id + 100).await.unwrap();
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(2), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            KEYED_NOTIFY.notified().await;
             let counted = KEYED_SEEN
                 .lock()
                 .unwrap()
@@ -185,11 +194,13 @@ async fn by_key_lanes_preserve_per_key_order() {
 }
 
 static PAGES: AtomicUsize = AtomicUsize::new(0);
+static PAGES_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Batch form composing with a pool: up to two pages in flight.
 #[subscriber(batch("pages"), workers(2))]
 async fn settle(orders: &[Order]) -> HandlerResult {
     PAGES.fetch_add(orders.len(), Ordering::SeqCst);
+    PAGES_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -205,12 +216,12 @@ async fn batch_pool_dispatches_batches() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher
                 .publish(OutgoingMessage::new("pages", &order_bytes(1)))
                 .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            handler_signal(&PAGES_NOTIFY).await;
             if PAGES.load(Ordering::SeqCst) >= 1 {
                 break;
             }


### PR DESCRIPTION
## Problem

The integration suites synchronized on handler progress with 10ms sleep polling under a 1s deadline - a pattern the project's own guidelines forbid ("do not sleep for synchronization"). Under slow builds the deadline is too tight: `batch_macro_def_receives_batches` reproducibly failed under `cargo llvm-cov` instrumentation while passing in a normal build. 52 polling sites across 4 test files shared the pattern.

## Change

- Handlers signal a `tokio::sync::Notify`; tests wake immediately on delivery instead of sleeping in 10ms quanta.
- Publish-retry loops use a bounded wait (`handler_signal` in the new shared `tests/common` module): subscriptions open inside `run()`, so a message published too early is lost - the bounded wait lets the loop publish again instead of deadlocking on a signal that never comes.
- Post-warmup waits (subscription known live, no republish needed) use plain `notified()`.
- Outer deadlines are pure hang guards now and were raised 1s -> 5s; the suites finish in well under a second of wall time.
- `app_dispatch.rs` closure-handler waits use `yield_now()` spinning instead of sleep quanta (the helpers there poll `Arc<AtomicU32>` state that closures update).

## Verification

- `cargo test --all-features`: 126 passed.
- `cargo llvm-cov --all-features` (the instrumented build that exposed the flake): 0 failures.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.

Found during the 0.3.1 cleanup audit (coverage baseline run).