### PR TITLE
runtime: deduplicate the publishing-stack internals

### DIFF
--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -208,20 +208,12 @@ pub trait BatchDef: Sized {
 
 /// Builds the registration metadata for a batch definition mounted under `name`.
 pub(crate) fn batch_metadata<D: BatchDef>(name: String, def: &D) -> HandlerMetadata {
-    let mut meta = HandlerMetadata::typed::<D::Input>(name);
-    if let Some(description) = def.description() {
-        meta = meta.with_description(description.to_owned());
-    }
-    if let Some(schema) = def.input_schema() {
-        meta = meta.with_payload_schema(schema);
-    }
-    if let Some(message_name) = def.message_name() {
-        meta = meta.with_message_name(message_name);
-    }
-    if let Some(message_description) = def.message_description() {
-        meta = meta.with_message_description(message_description);
-    }
-    meta
+    HandlerMetadata::typed::<D::Input>(name).with_def_details(
+        def.description(),
+        def.input_schema(),
+        def.message_name(),
+        def.message_description(),
+    )
 }
 
 /// The dispatch-side consumer of one raw batch: decode, run the handler, settle every delivery.
@@ -287,27 +279,7 @@ where
     H: SliceHandler<T>,
 {
     async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_>) {
-        let mut values = Vec::with_capacity(batch.len());
-        let mut accepted = Vec::with_capacity(batch.len());
-        for msg in batch {
-            match self.codec.decode::<T>(msg.payload()) {
-                Ok(value) => {
-                    values.push(value);
-                    accepted.push(msg);
-                }
-                Err(err) => {
-                    warn!(
-                        target: "ruststream::dispatch",
-                        error = %err,
-                        "codec decode failed",
-                    );
-                    let requeue = matches!(self.on_decode_failure, DecodeFailure::Requeue);
-                    if let Err(err) = msg.nack(requeue).await {
-                        warn!(target: "ruststream::dispatch", error = %err, "nack failed");
-                    }
-                }
-            }
-        }
+        let (values, accepted) = decode_batch(batch, &self.codec, self.on_decode_failure).await;
         if accepted.is_empty() {
             return;
         }
@@ -338,7 +310,45 @@ where
     }
 }
 
-async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult) {
+/// Decodes each element of one raw batch independently: failures are nacked per
+/// `on_decode_failure` and never reach the handler; the rest pass through, each decoded value
+/// paired with its delivery (`values[i]` decodes `accepted[i]`).
+pub(crate) async fn decode_batch<M, T, C>(
+    batch: Vec<M>,
+    codec: &C,
+    on_decode_failure: DecodeFailure,
+) -> (Vec<T>, Vec<M>)
+where
+    M: IncomingMessage,
+    T: DeserializeOwned,
+    C: Codec,
+{
+    let mut values = Vec::with_capacity(batch.len());
+    let mut accepted = Vec::with_capacity(batch.len());
+    for msg in batch {
+        match codec.decode::<T>(msg.payload()) {
+            Ok(value) => {
+                values.push(value);
+                accepted.push(msg);
+            }
+            Err(err) => {
+                warn!(
+                    target: "ruststream::dispatch",
+                    error = %err,
+                    "codec decode failed",
+                );
+                let requeue = matches!(on_decode_failure, DecodeFailure::Requeue);
+                if let Err(err) = msg.nack(requeue).await {
+                    warn!(target: "ruststream::dispatch", error = %err, "nack failed");
+                }
+            }
+        }
+    }
+    (values, accepted)
+}
+
+/// Applies one settlement to one delivery's own `ack` / `nack`.
+pub(crate) async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult) {
     let ack_result = match result {
         HandlerResult::Ack => msg.ack().await,
         HandlerResult::Nack { requeue } => msg.nack(requeue).await,

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -15,12 +15,13 @@ use tracing::warn;
 use crate::IncomingMessage;
 use crate::codec::Codec;
 
-use super::batch::BatchHandler;
+use super::batch::{BatchHandler, decode_batch, settle};
 use super::context::Context;
 use super::dispatch::Workers;
 use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
 use super::publish::{PublishMiddleware, ReplyPublisher};
+use super::typed::DecodeFailure;
 
 /// A batch subscriber definition that produces replies to publish.
 ///
@@ -92,21 +93,14 @@ pub(crate) fn batch_publishing_metadata<D: BatchPublishingDef>(
     name: String,
     def: &D,
 ) -> HandlerMetadata {
-    let mut meta = HandlerMetadata::typed::<D::Input>(name)
-        .with_output_type(std::any::type_name::<D::Reply>());
-    if let Some(description) = def.description() {
-        meta = meta.with_description(description.to_owned());
-    }
-    if let Some(schema) = def.input_schema() {
-        meta = meta.with_payload_schema(schema);
-    }
-    if let Some(message_name) = def.message_name() {
-        meta = meta.with_message_name(message_name);
-    }
-    if let Some(message_description) = def.message_description() {
-        meta = meta.with_message_description(message_description);
-    }
-    meta
+    HandlerMetadata::typed::<D::Input>(name)
+        .with_output_type(std::any::type_name::<D::Reply>())
+        .with_def_details(
+            def.description(),
+            def.input_schema(),
+            def.message_name(),
+            def.message_description(),
+        )
 }
 
 /// The [`BatchHandler`] built from a [`BatchPublishingDef`]: decode the batch, run the handler,
@@ -141,26 +135,8 @@ where
     R: ReplyPublisher,
 {
     async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_>) {
-        let mut values = Vec::with_capacity(batch.len());
-        let mut accepted = Vec::with_capacity(batch.len());
-        for msg in batch {
-            match self.codec.decode::<D::Input>(msg.payload()) {
-                Ok(value) => {
-                    values.push(value);
-                    accepted.push(msg);
-                }
-                Err(err) => {
-                    warn!(
-                        target: "ruststream::dispatch",
-                        error = %err,
-                        "codec decode failed",
-                    );
-                    if let Err(err) = msg.nack(false).await {
-                        warn!(target: "ruststream::dispatch", error = %err, "nack failed");
-                    }
-                }
-            }
-        }
+        let (values, accepted) =
+            decode_batch::<M, D::Input, C>(batch, &self.codec, DecodeFailure::default()).await;
         if accepted.is_empty() {
             return;
         }
@@ -186,14 +162,7 @@ where
             Err(result) => result,
         };
         for msg in accepted {
-            let ack_result = match outcome {
-                HandlerResult::Ack => msg.ack().await,
-                HandlerResult::Nack { requeue } => msg.nack(requeue).await,
-                HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
-            };
-            if let Err(err) = ack_result {
-                warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");
-            }
+            settle(msg, outcome).await;
         }
     }
 }

--- a/src/runtime/metadata.rs
+++ b/src/runtime/metadata.rs
@@ -105,4 +105,30 @@ impl HandlerMetadata {
         self.message_description = Some(description.into());
         self
     }
+
+    /// Attaches the optional descriptive fields that every generated definition trait exposes
+    /// with identical signatures (`description`, `input_schema`, `message_name`,
+    /// `message_description`). Shared tail of the per-definition metadata builders.
+    #[must_use]
+    pub(crate) fn with_def_details(
+        mut self,
+        description: Option<&str>,
+        input_schema: Option<String>,
+        message_name: Option<&'static str>,
+        message_description: Option<&'static str>,
+    ) -> Self {
+        if let Some(description) = description {
+            self = self.with_description(description.to_owned());
+        }
+        if let Some(schema) = input_schema {
+            self = self.with_payload_schema(schema);
+        }
+        if let Some(name) = message_name {
+            self = self.with_message_name(name);
+        }
+        if let Some(description) = message_description {
+            self = self.with_message_description(description);
+        }
+        self
+    }
 }

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -84,21 +84,14 @@ pub trait PublishingDef: Send + Sync {
 
 /// Builds the registration metadata for a publishing definition mounted under `name`.
 pub(crate) fn publishing_metadata<D: PublishingDef>(name: String, def: &D) -> HandlerMetadata {
-    let mut meta = HandlerMetadata::typed::<D::Input>(name)
-        .with_output_type(std::any::type_name::<D::Reply>());
-    if let Some(description) = def.description() {
-        meta = meta.with_description(description.to_owned());
-    }
-    if let Some(schema) = def.input_schema() {
-        meta = meta.with_payload_schema(schema);
-    }
-    if let Some(message_name) = def.message_name() {
-        meta = meta.with_message_name(message_name);
-    }
-    if let Some(message_description) = def.message_description() {
-        meta = meta.with_message_description(message_description);
-    }
-    meta
+    HandlerMetadata::typed::<D::Input>(name)
+        .with_output_type(std::any::type_name::<D::Reply>())
+        .with_def_details(
+            def.description(),
+            def.input_schema(),
+            def.message_name(),
+            def.message_description(),
+        )
 }
 
 /// The [`Handler`] built from a [`PublishingDef`]: decode, run, encode the reply, publish, ack.


### PR DESCRIPTION
## Problem

The publishing layer grew by accretion over the batch PR stack (#39-#43), leaving three copies of the same logic:

- `publishing_metadata`, `batch_metadata`, `batch_publishing_metadata` shared an identical ~15-line optional-fields tail (description, payload schema, message name/description).
- The per-element batch decode loop existed twice: `TypedBatch::handle_batch` (src/runtime/batch.rs) and `BatchPublishingHandler::handle_batch` (src/runtime/batch_publishing.rs), the latter with a hardcoded `nack(false)` where the former consults `DecodeFailure`.
- `BatchPublishingHandler`'s manual ack/nack/nack_after match duplicated `batch::settle`.

## Change

All internal (`pub(crate)`), zero public-API change:

- `HandlerMetadata::with_def_details` owns the shared builder tail; the three per-definition builders are thin wrappers differing only in their `typed`/`with_output_type` head.
- `batch::decode_batch` owns the decode loop; the publishing side passes `DecodeFailure::default()`, which is `Drop` = `nack(false)` - exactly the semantics it hardcoded.
- `batch::settle` is `pub(crate)` and reused for the uniform settlement loop.

Net diff: 93 insertions, 95 deletions.

## Verification

- `cargo test --all-features`: 126 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`: clean.
- `cargo check --no-default-features`: clean.

Part of the 0.3.1 cleanup; independent of #45.