### PR TITLE
runtime: stop paying per-delivery clones in the dispatch hot path

### DIFF
--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -406,7 +406,8 @@ mod tests {
 
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("selective", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("selective", &headers, &state, &delivery);
         let batch = pull_batch(&mut sub).await;
         assert_eq!(batch.len(), 3);
         handler.handle_batch(batch, &mut ctx).await;
@@ -434,7 +435,8 @@ mod tests {
 
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("short", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("short", &headers, &state, &delivery);
         let batch = pull_batch(&mut sub).await;
         assert_eq!(batch.len(), 3);
         handler.handle_batch(batch, &mut ctx).await;
@@ -468,7 +470,8 @@ mod tests {
 
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("delayed", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("delayed", &headers, &state, &delivery);
         let batch = pull_batch(&mut sub).await;
         handler.handle_batch(batch, &mut ctx).await;
 
@@ -494,7 +497,8 @@ mod tests {
 
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("uniform", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("uniform", &headers, &state, &delivery);
         let batch = pull_batch(&mut sub).await;
         assert_eq!(batch.len(), 2);
         handler.handle_batch(batch, &mut ctx).await;

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -243,7 +243,8 @@ mod tests {
         publish_numbers(&broker, "orders", &[1, 2]).await;
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("orders", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("orders", &headers, &state, &delivery);
         let batch = pull_batch(&mut input).await;
         handler.handle_batch(batch, &mut ctx).await;
 
@@ -279,7 +280,8 @@ mod tests {
         publish_numbers(&broker, "orders", &[1, 2]).await;
         let state = State::default();
         let delivery = Delivery::empty();
-        let mut ctx = Context::new("orders", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("orders", &headers, &state, &delivery);
         let batch = pull_batch(&mut input).await;
         handler.handle_batch(batch, &mut ctx).await;
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,8 +1,10 @@
 //! Per-delivery [`Context`] and the app-level [`State`] type-map.
 //!
 //! A `Context` is built for each delivery and threaded (as `&mut`) through the middleware chain
-//! into the handler. It carries the channel the message arrived on, a mutable working copy of the
-//! headers (middleware may enrich them), and shared application state.
+//! into the handler. It carries the channel the message arrived on, a working copy of the
+//! headers (middleware may enrich them), and shared application state. The copy is lazy: the
+//! message headers are borrowed until the first [`headers_mut`](Context::headers_mut), so a
+//! delivery whose middleware never touches them pays no clone.
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
@@ -45,31 +47,33 @@ impl std::fmt::Debug for State {
 
 /// Per-delivery context, threaded through middleware and into the handler.
 ///
-/// Carries the channel ([`name`](Self::name)), a mutable working copy of the message
+/// Carries the channel ([`name`](Self::name)), a working copy of the message
 /// [`headers`](Self::headers) (middleware may enrich them for the handler; the broker message
 /// itself is untouched), shared application [state](Self::get), and access to named
-/// [`publisher`](Self::publisher)s for publishing from inside a handler. Outgoing messages do not
-/// inherit the copy: replies and manual publishes start from fresh headers, shaped by the publish
-/// pipeline.
+/// [`publisher`](Self::publisher)s for publishing from inside a handler. The copy is made lazily
+/// on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit it:
+/// replies and manual publishes start from fresh headers, shaped by the publish pipeline.
 #[derive(Debug)]
 pub struct Context<'a> {
     name: &'a str,
-    headers: Headers,
+    original: &'a Headers,
+    modified: Option<Headers>,
     state: &'a State,
     delivery: &'a Delivery,
 }
 
 impl<'a> Context<'a> {
-    /// Creates a context for one delivery.
+    /// Creates a context for one delivery, borrowing the message headers until first mutation.
     pub(crate) fn new(
         name: &'a str,
-        headers: Headers,
+        headers: &'a Headers,
         state: &'a State,
         delivery: &'a Delivery,
     ) -> Self {
         Self {
             name,
-            headers,
+            original: headers,
+            modified: None,
             state,
             delivery,
         }
@@ -99,17 +103,46 @@ impl<'a> Context<'a> {
     /// The working copy of the message headers.
     #[must_use]
     pub fn headers(&self) -> &Headers {
-        &self.headers
+        self.modified.as_ref().unwrap_or(self.original)
     }
 
-    /// The working copy of the message headers, mutably.
+    /// The working copy of the message headers, mutably. The first call clones the message
+    /// headers; later calls return the same copy.
     pub fn headers_mut(&mut self) -> &mut Headers {
-        &mut self.headers
+        self.modified.get_or_insert_with(|| self.original.clone())
     }
 
     /// Returns shared application state of type `T`, if registered.
     #[must_use]
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
         self.state.get::<T>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Context, State};
+    use crate::Headers;
+    use crate::runtime::dispatch::Delivery;
+
+    #[test]
+    fn headers_clone_only_on_first_mutation() {
+        let mut original = Headers::new();
+        original.insert("k", "v");
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("test", &original, &state, &delivery);
+
+        // Untouched: the context borrows the message headers, no copy exists.
+        assert!(std::ptr::eq(ctx.headers(), &raw const original));
+
+        ctx.headers_mut().insert("added", "1");
+        ctx.headers_mut().insert("added2", "2");
+
+        // Mutations land in one lazily-made copy; the original is untouched.
+        assert!(!std::ptr::eq(ctx.headers(), &raw const original));
+        assert_eq!(ctx.headers().get("added"), Some(&b"1"[..]));
+        assert_eq!(ctx.headers().get("k"), Some(&b"v"[..]));
+        assert_eq!(original.get("added"), None);
     }
 }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -387,7 +387,8 @@ where
                             // A batch has no single working copy of headers, so the context
                             // starts with an empty set; per-message headers stay on the broker
                             // deliveries.
-                            let mut ctx = Context::new(&name, Headers::new(), &state, &delivery);
+                            let empty = Headers::new();
+                            let mut ctx = Context::new(&name, &empty, &state, &delivery);
                             handler.handle_batch(batch, &mut ctx).await;
                         } else {
                             let handler = Arc::clone(&handler);
@@ -395,8 +396,8 @@ where
                             let state = Arc::clone(&state);
                             let delivery = Arc::clone(&delivery);
                             tasks.spawn(async move {
-                                let mut ctx =
-                                    Context::new(&name, Headers::new(), &state, &delivery);
+                                let empty = Headers::new();
+                                let mut ctx = Context::new(&name, &empty, &state, &delivery);
                                 handler.handle_batch(batch, &mut ctx).await;
                             });
                         }
@@ -430,7 +431,7 @@ where
     H: Handler<M>,
     M: IncomingMessage,
 {
-    let mut ctx = Context::new(name, msg.headers().clone(), state, delivery);
+    let mut ctx = Context::new(name, msg.headers(), state, delivery);
     let outcome = handler.handle(&msg, &mut ctx).await;
     let ack_result = match outcome {
         HandlerResult::Ack => msg.ack().await,

--- a/src/runtime/dynstack.rs
+++ b/src/runtime/dynstack.rs
@@ -117,7 +117,7 @@ where
     fn layer(&self, inner: H) -> Self::Handler {
         DynStackHandler {
             chain: self.0.clone(),
-            inner: Arc::new(inner),
+            inner,
         }
     }
 }
@@ -126,7 +126,7 @@ where
 /// handler.
 pub struct DynStackHandler<I, H> {
     chain: Arc<[Arc<dyn DynMiddleware<I>>]>,
-    inner: Arc<H>,
+    inner: H,
 }
 
 impl<I, H> std::fmt::Debug for DynStackHandler<I, H> {
@@ -142,13 +142,16 @@ where
     I: Sync,
     H: Handler<I>,
 {
-    fn handle(&self, input: &I, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send {
-        let chain = self.chain.clone();
-        let inner = self.inner.clone();
-        async move {
-            let tail: &dyn ErasedHandler<I> = &inner;
-            Next { rest: &chain, tail }.run(input, ctx).await
+    // The returned future captures &self, so the chain and the wrapped handler are borrowed:
+    // no Arc refcount traffic per message.
+    async fn handle(&self, input: &I, ctx: &mut Context<'_>) -> HandlerResult {
+        let tail: &dyn ErasedHandler<I> = &self.inner;
+        Next {
+            rest: &self.chain,
+            tail,
         }
+        .run(input, ctx)
+        .await
     }
 }
 
@@ -198,7 +201,8 @@ mod tests {
         let handler = inner.with(stack);
         let state = State::default();
         let delivery = crate::runtime::dispatch::Delivery::empty();
-        let mut ctx = Context::new("test", Headers::new(), &state, &delivery);
+        let headers = Headers::new();
+        let mut ctx = Context::new("test", &headers, &state, &delivery);
         assert_eq!(handler.handle(&Input, &mut ctx).await, HandlerResult::Ack);
         assert_eq!(*log.lock().expect("poisoned"), vec!["a", "b", "inner"]);
     }


### PR DESCRIPTION
Item 6 of the 0.3.1 cleanup backlog - the two non-breaking hot-path fixes found by the zero-cost audit. Independent of the module splits, based on main.

## (a) Context is copy-on-write over the message headers

`dispatch` cloned the full `Headers` map into every `Context`, on every delivery, whether or not anything touched them. `Context` now holds `&Headers` plus an `Option<Headers>` working copy created on the first `headers_mut()` call:

- `headers()` / `headers_mut()` signatures and the enrichment contract are unchanged: middleware mutations land in the working copy, the broker message stays untouched, replies still start from fresh headers.
- A delivery whose middleware never calls `headers_mut()` now pays zero header clones.
- `Context::new` is `pub(crate)`, so taking `&Headers` is not an API change. Batch contexts pass a local empty set (`Headers::new()` does not allocate).
- A new unit test pins the semantics: before mutation the context borrows the original (pointer-equal); after, mutations land in one lazily-made copy and the original is untouched.

## (b) DynStackHandler borrows instead of cloning Arcs

`DynStackHandler::handle` bumped two Arc refcounts per message (chain + wrapped handler) to move owned clones into the future. The RPITIT future already captures `&self`, so both are borrowed now. That also made the `Arc` around the wrapped handler pointless - the field is plain `H` (private field of a public type, no API change), dropping an allocation per `layer()` call.

Everything else type-erased was confirmed setup-time-only by the audit; the remaining publish-path copies are the breaking candidate tracked in #44.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features`: 127 passed (126 + the new copy-on-write test)
- `cargo check --no-default-features`: clean
- `cargo doc --all-features --no-deps`: 9 warnings, all pre-existing