### PR TITLE
runtime: functional-path workers and batch on Router

### DIFF
--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use crate::codec::Codec;
 use crate::{BatchSubscriber, Broker, Publisher, Subscriber, SubscriptionSource};
 
-use crate::runtime::batch::{BatchDef, batch_metadata, typed_batch};
+use crate::runtime::batch::{BatchDef, SliceHandler, batch_metadata, typed_batch};
 use crate::runtime::batch_publishing::{
     BatchPublishingDef, BatchPublishingHandler, batch_publishing_metadata,
 };
@@ -26,7 +26,7 @@ use super::routes::{BatchRoute, HandleRoute, MountRoute, RouterDef, SubscribeRou
 use super::sink::RouterSink;
 use super::{
     BatchPublishingRouter, IncludedBatchRouter, IncludedRouter, MergedRouter, PublishingRouter,
-    SourceMessage,
+    SourceMessage, SubscribedBatchRouter,
 };
 
 /// A statically-typed, lazily-bound group of handler registrations, not attached to any broker.
@@ -211,6 +211,38 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         }
     }
 
+    /// Wraps `handler` in a [`TypedBatch`](crate::runtime::TypedBatch) decoding with `codec` and
+    /// prepends the batch registration. The shared tail of the `subscribe_batch` forms.
+    pub(super) fn push_batch_route<S, T, C, H>(
+        self,
+        source: S,
+        handler: H,
+        codec: C,
+        meta: HandlerMetadata,
+    ) -> SubscribedBatchRouter<B, S, T, C, H, RC, RL, R>
+    where
+        S: SubscriptionSource<B> + Send + 'static,
+        S::Subscriber: BatchSubscriber + Send + 'static,
+        T: DeserializeOwned + Send + Sync + 'static,
+        C: Codec + 'static,
+        H: SliceHandler<T> + 'static,
+    {
+        Router {
+            routes: (
+                BatchRoute {
+                    source,
+                    handler: typed_batch(codec, handler),
+                    meta,
+                    workers: Workers::sequential(),
+                },
+                self.routes,
+            ),
+            codec: self.codec,
+            layers: self.layers,
+            _broker: PhantomData,
+        }
+    }
+
     /// Mounts a definition on `source`, decoding with `codec`. The shared tail of the
     /// `include` / `include_on` forms.
     pub(super) fn mount_subscriber<S, D, C>(
@@ -368,6 +400,54 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
             layers: self.layers,
             _broker: PhantomData,
         }
+    }
+}
+
+impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
+    /// Sets the concurrency policy of the registration just added (the preceding `subscribe` /
+    /// `include` call), replacing its default.
+    ///
+    /// The functional-path counterpart of the macro's `workers(..)` clause: [`Workers::pool`]
+    /// processes up to `n` deliveries of this subscriber concurrently, [`Workers::keyed`]
+    /// dispatches over per-key sequential lanes. On an `include`d definition this overrides the
+    /// attribute's `workers(..)` clause.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "memory")]
+    /// # fn build() {
+    /// use ruststream::Name;
+    /// use ruststream::memory::MemoryBroker;
+    /// use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, Router, Workers};
+    ///
+    /// let router = Router::<MemoryBroker>::new()
+    ///     .subscribe(
+    ///         Name::new("jobs"),
+    ///         |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
+    ///         HandlerMetadata::raw("jobs"),
+    ///     )
+    ///     .workers(Workers::pool(4));
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn workers(mut self, workers: Workers) -> Self {
+        self.routes.0.workers = workers;
+        self
+    }
+}
+
+impl<B, S, H, R, RC, RL> Router<B, (BatchRoute<S, H>, R), RC, RL> {
+    /// Sets the concurrency policy of the batch registration just added (the preceding
+    /// `subscribe_batch` / `include_batch` call), replacing its default.
+    ///
+    /// [`Workers::pool`] keeps up to `n` batches in flight at once. Keyed lanes order single
+    /// messages per key and do not apply to batches: a [`Workers::keyed`] policy here behaves
+    /// like a plain pool of the same size.
+    #[must_use]
+    pub fn workers(mut self, workers: Workers) -> Self {
+        self.routes.0.workers = workers;
+        self
     }
 }
 

--- a/src/runtime/router/include.rs
+++ b/src/runtime/router/include.rs
@@ -7,14 +7,18 @@ use serde::de::DeserializeOwned;
 use crate::codec::Codec;
 use crate::{BatchSubscriber, Broker, Publisher, SubscriptionSource};
 
-use crate::runtime::batch::BatchDef;
+use crate::runtime::batch::{BatchDef, SliceHandler};
 use crate::runtime::batch_publishing::BatchPublishingDef;
+use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::publish::{PublishLayer, ReplyPublisher, TypedPublisher};
 use crate::runtime::publishing::PublishingDef;
 use crate::runtime::subscriber_def::SubscriberDef;
 
 use super::builder::Router;
-use super::{BatchPublishingRouter, IncludedBatchRouter, IncludedRouter, PublishingRouter};
+use super::{
+    BatchPublishingRouter, IncludedBatchRouter, IncludedRouter, PublishingRouter,
+    SubscribedBatchRouter,
+};
 
 impl<B: Broker + 'static, R, RL> Router<B, R, (), RL> {
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
@@ -101,6 +105,30 @@ impl<B: Broker + 'static, R, RL> Router<B, R, (), RL> {
         D::Handler: 'static,
     {
         self.mount_batch(source, def, crate::codec::DefaultCodec::default())
+    }
+
+    /// Attaches a slice handler to a batch subscription described by `source`, decoding each
+    /// element with the [`DefaultCodec`](crate::codec::DefaultCodec).
+    ///
+    /// The functional-path counterpart of [`include_batch`](Self::include_batch): `handler` is
+    /// any [`SliceHandler`](crate::runtime::SliceHandler), typically a closure
+    /// `|batch: &[T], ctx: &mut Context| async { .. }`. The source's subscriber must implement
+    /// [`BatchSubscriber`] - natively, or through the [`Buffered`](crate::Buffered) adapter.
+    /// Set the dispatch concurrency with [`workers`](Router::workers) on the returned router.
+    #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+    pub fn subscribe_batch<S, T, H>(
+        self,
+        source: S,
+        handler: H,
+        meta: HandlerMetadata,
+    ) -> SubscribedBatchRouter<B, S, T, crate::codec::DefaultCodec, H, (), RL, R>
+    where
+        S: SubscriptionSource<B> + Send + 'static,
+        S::Subscriber: BatchSubscriber + Send + 'static,
+        T: DeserializeOwned + Send + Sync + 'static,
+        H: SliceHandler<T> + 'static,
+    {
+        self.push_batch_route(source, handler, crate::codec::DefaultCodec::default(), meta)
     }
 
     /// Mounts a `#[subscriber(batch(..), publish("name"))]`-generated definition on its own
@@ -262,6 +290,26 @@ impl<B: Broker + 'static, R, C: Codec + Clone + 'static, RL> Router<B, R, C, RL>
     {
         let codec = self.codec.clone();
         self.mount_batch(source, def, codec)
+    }
+
+    /// Attaches a slice handler to a batch subscription described by `source`, decoding each
+    /// element with the chain's codec (set by [`with_codec`](Self::with_codec)).
+    ///
+    /// See the default-codec form for details on the handler shape.
+    pub fn subscribe_batch<S, T, H>(
+        self,
+        source: S,
+        handler: H,
+        meta: HandlerMetadata,
+    ) -> SubscribedBatchRouter<B, S, T, C, H, C, RL, R>
+    where
+        S: SubscriptionSource<B> + Send + 'static,
+        S::Subscriber: BatchSubscriber + Send + 'static,
+        T: DeserializeOwned + Send + Sync + 'static,
+        H: SliceHandler<T> + 'static,
+    {
+        let codec = self.codec.clone();
+        self.push_batch_route(source, handler, codec, meta)
     }
 
     /// Mounts a `#[subscriber(batch(..), publish("name"))]`-generated definition on its own

--- a/src/runtime/router/mod.rs
+++ b/src/runtime/router/mod.rs
@@ -70,6 +70,11 @@ type PublishingRouter<B, S, D, C, P, PC, PL, RC, RL, R> =
 type BatchPublishingRouter<B, S, D, C, RP, RC, RL, R> =
     Router<B, (BatchRoute<S, BatchPublishingHandler<D, C, RP>>, R), RC, RL>;
 
+/// The router that a [`Router::subscribe_batch`] closure registration produces: the slice
+/// handler `H` is wrapped in a [`TypedBatch`] decoding elements to `T` with `C`.
+type SubscribedBatchRouter<B, S, T, C, H, RC, RL, R> =
+    Router<B, (BatchRoute<S, TypedBatch<SourceMessage<B, S>, T, C, H>>, R), RC, RL>;
+
 /// The router that [`Router::merge`] produces: the merged router becomes one registration in the
 /// list.
 type MergedRouter<B, R2, C2, L2, RC, RL, R> = Router<B, (Router<B, R2, C2, L2>, R), RC, RL>;

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -13,9 +13,12 @@ use std::{
 };
 
 use common::handler_signal;
+use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
-use ruststream::{Headers, OutgoingMessage, Publisher, subscriber};
+use ruststream::runtime::{
+    AppInfo, Context, HandlerMetadata, HandlerResult, Router, RustStream, Workers, typed,
+};
+use ruststream::{Headers, Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Barrier, Notify};
 
@@ -229,6 +232,153 @@ async fn batch_pool_dispatches_batches() {
     })
     .await;
     assert!(result.is_ok(), "no batch was dispatched through the pool");
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+/// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(3))`.
+/// Three deliveries must be in flight at once to pass the barrier; the default sequential loop
+/// would deadlock on the first one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closure_subscription_pool_runs_concurrently() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let warmed = Arc::new(AtomicU32::new(0));
+    let crunched = Arc::new(AtomicU32::new(0));
+    let signal = Arc::new(Notify::new());
+    let gate = Arc::new(Barrier::new(3));
+
+    let handler = {
+        let warmed = Arc::clone(&warmed);
+        let crunched = Arc::clone(&crunched);
+        let signal = Arc::clone(&signal);
+        let gate = Arc::clone(&gate);
+        typed(JsonCodec, move |order: &Order, _ctx: &mut Context| {
+            let warmed = Arc::clone(&warmed);
+            let crunched = Arc::clone(&crunched);
+            let signal = Arc::clone(&signal);
+            let gate = Arc::clone(&gate);
+            let id = order.id;
+            async move {
+                if id == 0 {
+                    warmed.fetch_add(1, Ordering::SeqCst);
+                    signal.notify_one();
+                    return HandlerResult::Ack;
+                }
+                gate.wait().await;
+                crunched.fetch_add(1, Ordering::SeqCst);
+                signal.notify_one();
+                HandlerResult::Ack
+            }
+        })
+    };
+
+    let router = Router::<MemoryBroker>::new()
+        .subscribe(
+            Name::new("fn-jobs"),
+            handler,
+            HandlerMetadata::raw("fn-jobs"),
+        )
+        .workers(Workers::pool(3));
+
+    let app = RustStream::new(AppInfo::new("fn-jobs", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(router));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("fn-jobs", &order_bytes(0)))
+                .await;
+            handler_signal(&signal).await;
+            if warmed.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(warmup.is_ok(), "subscription did not come up");
+
+    for id in 1..=3u32 {
+        publisher
+            .publish(OutgoingMessage::new("fn-jobs", &order_bytes(id)))
+            .await
+            .unwrap();
+    }
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        while crunched.load(Ordering::SeqCst) < 3 {
+            signal.notified().await;
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "3 deliveries never ran concurrently (sequential dispatch would deadlock the barrier)",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+/// The functional batch path: a `Router::subscribe_batch` slice closure receives whole decoded
+/// batches without a macro definition.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closure_batch_subscription_receives_batches() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let signal = Arc::new(Notify::new());
+
+    let handler = {
+        let seen = Arc::clone(&seen);
+        let signal = Arc::clone(&signal);
+        move |orders: &[Order], _ctx: &mut Context| {
+            let count = orders.len();
+            let seen = Arc::clone(&seen);
+            let signal = Arc::clone(&signal);
+            async move {
+                seen.fetch_add(count, Ordering::SeqCst);
+                signal.notify_one();
+                HandlerResult::Ack
+            }
+        }
+    };
+
+    let router = Router::<MemoryBroker>::new()
+        .subscribe_batch(
+            Name::new("fn-pages"),
+            handler,
+            HandlerMetadata::raw("fn-pages"),
+        )
+        .workers(Workers::pool(2));
+
+    let app = RustStream::new(AppInfo::new("fn-pages", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(router));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("fn-pages", &order_bytes(1)))
+                .await;
+            handler_signal(&signal).await;
+            if seen.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "no batch reached the slice closure");
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();


### PR DESCRIPTION
Item 7 of the 0.3.1 cleanup backlog (additive): the closure path could not name a dispatch policy - `Router::subscribe` hardcoded `Workers::sequential()` - and had no batch form at all; both were macro-only. The macro path already covers batch/workers/by_key/publish/transactional.

## API

- **`Router::workers(Workers)`** - sets the concurrency policy of the registration just added, as a consuming-builder step:

  ```rust
  Router::<MemoryBroker>::new()
      .subscribe(Name::new("jobs"), handler, HandlerMetadata::raw("jobs"))
      .workers(Workers::pool(4));
  ```

  Defined on the route-head types (`SubscribeRoute` / `BatchRoute` heads), so it is available right after `subscribe`, `subscribe_batch`, `include`, `include_batch` and the publishing forms that produce those routes. On an `include`d definition it overrides the attribute's `workers(..)` clause (last writer wins, consistent with the chain style). For batch registrations keyed lanes do not apply - a `Workers::keyed` policy behaves like a plain pool of the same size, documented on the method.

- **`Router::subscribe_batch(source, handler, meta)`** - the functional counterpart of `include_batch`: takes any `SliceHandler` (typically a `|batch: &[T], ctx| async { .. }` closure), wraps it in the existing `TypedBatch` decode adapter, and mirrors `include_batch`'s two codec forms - `DefaultCodec` on the `C = ()` block, the chain codec on the `with_codec` block.

The `BrokerScope` closure path gets the same capabilities through `include_router` (the scope itself stays a plain `&mut` registrar); raw-batch closures stay out on purpose - `BatchHandler` (settling raw deliveries) is an internal dispatch contract, and the typed slice level is the functional granularity, same as the macro.

## Tests

- `closure_subscription_pool_runs_concurrently` - a closure pool must pass a 3-party `Barrier` (sequential dispatch would deadlock), notify-driven like the rest of `tests/workers.rs`.
- `closure_batch_subscription_receives_batches` - a slice closure receives decoded batches through `subscribe_batch` + `.workers(pool(2))`.
- A compiling doctest on `workers()`.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features`: 130 passed
- `cargo check --no-default-features`: clean
- `cargo doc --all-features --no-deps`: 9 warnings, all pre-existing