### PR TITLE
ci: line-coverage gate via cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,12 @@ jobs:
       # multi-package form resolves in-workspace dependencies through a local overlay instead.
       # Still not `--workspace`: the dev-only `[patch.crates-io]` self-patch used by the `nats_*`
       # examples trips its checksum.
+      #
+      # CARGO_HTTP_MULTIPLEXING=false works around recurring "[16] Error in the HTTP2 framing
+      # layer" curl failures on the runners when this job re-downloads registry deps.
       - name: cargo publish dry-run (no upload)
+        env:
+          CARGO_HTTP_MULTIPLEXING: "false"
         run: cargo publish --dry-run -p ruststream-macros -p ruststream --all-features
 
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,34 @@ jobs:
         if: matrix.toolchain == 'stable' || matrix.toolchain == '1.85'
         run: cargo test --workspace --all-features
 
+  coverage:
+    name: Coverage
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Line-coverage gate. The floor ratchets up toward the 90% target as the
+      # coverage backlog items land; raise it here and in the justfile together.
+      - name: cargo llvm-cov
+        run: cargo llvm-cov --workspace --all-features --fail-under-lines 73
+
   package:
     name: Package (publish dry-run)
     needs: changes

--- a/justfile
+++ b/justfile
@@ -22,6 +22,17 @@ fmt:
 deny:
     cargo deny check
 
+# Line-coverage gate, same threshold as CI. The floor ratchets up toward the
+# 90% target as the coverage backlog items land; raise it here and in ci.yml
+# together. Needs cargo-llvm-cov: cargo install cargo-llvm-cov --locked
+cov:
+    cargo llvm-cov --workspace --all-features --fail-under-lines 73
+
+# HTML coverage report at target/llvm-cov/html/index.html, for finding the
+# uncovered lines the gate complains about.
+cov-html:
+    cargo llvm-cov --workspace --all-features --html
+
 build:
     cargo build --workspace --release
 


### PR DESCRIPTION
The CI half of backlog item 11: a `Coverage` job (gated by the existing `rust` path filter) installs `cargo-llvm-cov` via `taiki-e/install-action` and runs the line-coverage gate; `just cov` runs the identical gate locally, and `just cov-html` renders the HTML report for finding uncovered lines.

The floor is `--fail-under-lines 73` - the current baseline (73.83% on this branch), so it catches regressions today without going red. It ratchets up toward the 90% DoD target as the coverage items (backlog 10) land; the threshold lives in two places (ci.yml + justfile) with a comment in each pointing at the other.

Deliberately not included: the docs lint forbidding inline rust fences (the other half of item 11). It would fail on the ~45 fences that item 8 is yet to convert to compiled snippets, so it lands with that conversion.

## Verification

- `just cov` locally: passes at 73.83% lines.
- The job reuses the existing `changes` filter and action pinning conventions of ci.yml.