### PR TITLE
tests: cover the Router include family, typed adapter and def defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -66,6 +66,43 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-nats"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -132,16 +169,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -223,16 +294,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "equivalent"
@@ -247,7 +455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,6 +463,18 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -363,6 +583,27 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -491,10 +732,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -543,6 +886,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -594,7 +943,22 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand",
+ "signatory",
 ]
 
 [[package]]
@@ -603,8 +967,23 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -626,6 +1005,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "parking_lot"
@@ -651,16 +1036,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -692,7 +1146,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -709,6 +1163,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -740,6 +1224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +1251,20 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rmp"
@@ -776,6 +1286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +1304,73 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -801,12 +1386,13 @@ dependencies = [
  "prometheus",
  "rmp-serde",
  "ruststream-macros",
+ "ruststream-nats",
  "schemars",
  "serde",
  "serde_json",
  "serde_norway",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -823,10 +1409,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruststream-nats"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51090e9274ce127bbabfa18dc70a84ba71e7f5c38311e94cb5e0fed78c29f99f"
+dependencies = [
+ "async-nats",
+ "bytes",
+ "futures",
+ "ruststream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -858,6 +1468,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -920,6 +1553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_norway"
 version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1586,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1642,28 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -993,14 +1685,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1020,16 +1734,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1038,7 +1772,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1062,18 +1807,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1088,6 +1875,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1907,27 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1192,6 +2021,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +2055,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +2089,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1280,10 +2155,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1293,6 +2195,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1389,6 +2355,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +2397,66 @@ name = "zerocopy-derive"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ruststream-macros"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,22 +90,17 @@ required-features = ["macros", "memory", "json", "logging"]
 name = "logging_middleware"
 required-features = ["macros", "memory", "json", "logging"]
 
-# The nats_* examples and the doc_testing_nats test depend on ruststream-nats, which is still on
-# ruststream 0.2 and cannot compile against this 0.3 tree. autoexamples/autotests are off so the
-# files stay in place (the docs embed snippets from them) without being built. Re-enable these
-# entries and the ruststream-nats dev-dependency once ruststream-nats 0.3 is published.
-#
-# [[example]]
-# name = "nats_core"
-# required-features = ["macros", "json"]
-#
-# [[example]]
-# name = "nats_jetstream"
-# required-features = ["macros", "json"]
-#
-# [[example]]
-# name = "nats_request_reply"
-# required-features = ["macros"]
+[[example]]
+name = "nats_core"
+required-features = ["macros", "json"]
+
+[[example]]
+name = "nats_jetstream"
+required-features = ["macros", "json"]
+
+[[example]]
+name = "nats_request_reply"
+required-features = ["macros"]
 
 [[test]]
 name = "app_dispatch"
@@ -147,9 +142,9 @@ required-features = ["macros", "memory", "json"]
 name = "workers"
 required-features = ["macros", "memory", "json"]
 
-# [[test]]
-# name = "doc_testing_nats"
-# required-features = ["macros", "json"]
+[[test]]
+name = "doc_testing_nats"
+required-features = ["macros", "json"]
 
 [package]
 name = "ruststream"
@@ -163,10 +158,6 @@ description = "Async messaging framework for Rust: broker-agnostic traits, route
 readme = "README.md"
 keywords = ["messaging", "async", "broker", "faststream", "nats"]
 categories = ["asynchronous", "network-programming"]
-# Examples and tests are listed explicitly so the parked nats_* targets (see the commented-out
-# entries above) are not auto-discovered while ruststream-nats is still on 0.2.
-autoexamples = false
-autotests = false
 
 [features]
 default = ["json"]
@@ -191,7 +182,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
-ruststream-macros = { version = "0.3.0", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "0.3", path = "crates/ruststream-macros", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }
@@ -208,10 +199,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "test-util"] }
 tempfile = "3"
 axum = "0.8"
-# `testing` pulls the in-memory NATS test broker used by tests/doc_testing_nats.rs (the snippet
-# source for the testing guide). Parked until ruststream-nats 0.3 is published; see the note on
-# the nats_* example entries.
-# ruststream-nats = { version = "0.2", features = ["testing"] }
+ruststream-nats = { version = "0.3", features = ["testing"] }
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,14 @@ name = "metrics"
 required-features = ["metrics", "memory", "json"]
 
 [[test]]
+name = "router_include"
+required-features = ["macros", "memory", "json"]
+
+[[test]]
+name = "router_publishing"
+required-features = ["macros", "memory", "json"]
+
+[[test]]
 name = "workers"
 required-features = ["macros", "memory", "json"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,10 @@
 
 [graph]
 all-features = true
+# Gate the published surface, not the dev tooling: the ruststream-nats
+# dev-dependency (testing + the nats_* examples) pulls the async-nats tree,
+# whose TLS advisories belong to that crate's own CI - nothing here ships them.
+exclude-dev = true
 
 [advisories]
 yanked = "deny"

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ cov-html:
     cargo llvm-cov --workspace --all-features --html
 
 build:
-    cargo build --workspace --release
+    cargo build --workspace --release --all-features
 
 clean:
     cargo clean

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -77,3 +77,52 @@ pub(crate) fn subscriber_metadata<D: SubscriberDef>(name: String, def: &D) -> Ha
     }
     meta
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{SubscriberDef, subscriber_metadata};
+    use crate::Name;
+    use crate::runtime::context::Context;
+    use crate::runtime::dispatch::Workers;
+    use crate::runtime::handler::{Handler, HandlerResult};
+
+    struct Noop;
+
+    impl Handler<u32> for Noop {
+        async fn handle(&self, _msg: &u32, _ctx: &mut Context<'_>) -> HandlerResult {
+            HandlerResult::Ack
+        }
+    }
+
+    /// A hand-written def overriding nothing: pins the trait's default contract, which the
+    /// macro-generated defs always override.
+    struct ManualDef;
+
+    impl SubscriberDef for ManualDef {
+        type Input = u32;
+        type Handler = Noop;
+        type Source = Name;
+
+        fn source(&self) -> Name {
+            Name::new("manual")
+        }
+
+        fn into_handler(self) -> Noop {
+            Noop
+        }
+    }
+
+    #[test]
+    fn defaults_omit_metadata_and_dispatch_sequentially() {
+        let def = ManualDef;
+        assert_eq!(def.workers(), Workers::sequential());
+        assert!(def.description().is_none());
+        assert!(def.input_schema().is_none());
+        assert!(def.message_name().is_none());
+        assert!(def.message_description().is_none());
+
+        let meta = subscriber_metadata("manual".to_owned(), &def);
+        assert_eq!(meta.name, "manual");
+        assert_eq!(meta.input_type, "u32");
+    }
+}

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -98,3 +98,94 @@ where
         }
     }
 }
+
+#[cfg(all(test, feature = "json"))]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
+
+    use super::{DecodeFailure, typed};
+    use crate::codec::JsonCodec;
+    use crate::runtime::context::{Context, State};
+    use crate::runtime::dispatch::Delivery;
+    use crate::runtime::handler::{Handler, HandlerResult};
+    use crate::{AckError, Headers, IncomingMessage};
+
+    struct StubMsg(Vec<u8>, Headers);
+
+    impl IncomingMessage for StubMsg {
+        fn payload(&self) -> &[u8] {
+            &self.0
+        }
+
+        fn headers(&self) -> &Headers {
+            &self.1
+        }
+
+        async fn ack(self) -> Result<(), AckError> {
+            Ok(())
+        }
+
+        async fn nack(self, _requeue: bool) -> Result<(), AckError> {
+            Ok(())
+        }
+    }
+
+    fn counting_inner(seen: &Arc<AtomicU32>) -> impl Handler<u32> {
+        let seen = Arc::clone(seen);
+        move |value: &u32, _ctx: &mut Context| {
+            let seen = Arc::clone(&seen);
+            let value = *value;
+            async move {
+                seen.store(value, Ordering::SeqCst);
+                HandlerResult::Ack
+            }
+        }
+    }
+
+    // Plain #[tokio::test]: nothing is spawned, the handler future is awaited inline.
+    #[tokio::test]
+    async fn decoded_value_reaches_inner() {
+        let seen = Arc::new(AtomicU32::new(0));
+        let handler = typed(JsonCodec, counting_inner(&seen));
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("typed", &headers, &state, &delivery);
+
+        let msg = StubMsg(b"7".to_vec(), Headers::new());
+        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::Ack);
+        assert_eq!(seen.load(Ordering::SeqCst), 7);
+    }
+
+    #[tokio::test]
+    async fn decode_failure_drops_by_default() {
+        let seen = Arc::new(AtomicU32::new(0));
+        let handler = typed(JsonCodec, counting_inner(&seen));
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("typed", &headers, &state, &delivery);
+
+        let msg = StubMsg(b"not json".to_vec(), Headers::new());
+        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::drop());
+        assert_eq!(seen.load(Ordering::SeqCst), 0, "inner must not run");
+    }
+
+    #[tokio::test]
+    async fn decode_failure_requeues_when_overridden() {
+        let seen = Arc::new(AtomicU32::new(0));
+        let handler =
+            typed(JsonCodec, counting_inner(&seen)).on_decode_failure(DecodeFailure::Requeue);
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("typed", &headers, &state, &delivery);
+
+        let msg = StubMsg(b"not json".to_vec(), Headers::new());
+        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::retry());
+        assert_eq!(seen.load(Ordering::SeqCst), 0, "inner must not run");
+    }
+}

--- a/tests/router_include.rs
+++ b/tests/router_include.rs
@@ -1,0 +1,236 @@
+//! Integration tests for the `Router` include family (subscribe and batch forms), in both codec
+//! forms: the default codec and a chain codec set with `with_codec`. Also covers `merge`, the
+//! router's own `layer` stack, and `handlers()` metadata collection.
+#![cfg(feature = "macros")]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use common::handler_signal;
+use ruststream::codec::JsonCodec;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, layers::TracingLayer};
+use ruststream::{Name, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+/// Publishes `payload` to each topic until every counter is non-zero (subscriptions open inside
+/// `run()`, so early publishes are lost), bounded by a hang guard.
+async fn drive_until_all_seen(
+    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    topics: &[&str],
+    counters: &[&AtomicUsize],
+    signal: &Notify,
+) {
+    let payload = order_bytes(1);
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            for topic in topics {
+                let _ = publisher
+                    .publish(OutgoingMessage::new(topic, &payload))
+                    .await;
+            }
+            handler_signal(signal).await;
+            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "not every include form dispatched");
+}
+
+static RI_PLAIN: AtomicUsize = AtomicUsize::new(0);
+static RI_ON: AtomicUsize = AtomicUsize::new(0);
+static RI_BATCH: AtomicUsize = AtomicUsize::new(0);
+static RI_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
+static RI_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("ri-plain")]
+async fn ri_plain(_o: &Order) -> HandlerResult {
+    RI_PLAIN.fetch_add(1, Ordering::SeqCst);
+    RI_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("ri-ignored")]
+async fn ri_on(_o: &Order) -> HandlerResult {
+    RI_ON.fetch_add(1, Ordering::SeqCst);
+    RI_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("ri-batch"))]
+async fn ri_batch(orders: &[Order]) -> HandlerResult {
+    RI_BATCH.fetch_add(orders.len(), Ordering::SeqCst);
+    RI_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("ri-ignored"))]
+async fn ri_batch_on(orders: &[Order]) -> HandlerResult {
+    RI_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
+    RI_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// All four default-codec router forms dispatch: `include` (macro source), `include_on`
+/// (explicit source), `include_batch`, `include_batch_on`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_codec_router_includes_dispatch() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .include(ri_plain)
+        .include_on(Name::new("ri-on"), ri_on)
+        .include_batch(ri_batch)
+        .include_batch_on(Name::new("ri-batch-on"), ri_batch_on);
+
+    let app = RustStream::new(AppInfo::new("ri", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(router));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_all_seen(
+        &publisher,
+        &["ri-plain", "ri-on", "ri-batch", "ri-batch-on"],
+        &[&RI_PLAIN, &RI_ON, &RI_BATCH, &RI_BATCH_ON],
+        &RI_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static RC_PLAIN: AtomicUsize = AtomicUsize::new(0);
+static RC_ON: AtomicUsize = AtomicUsize::new(0);
+static RC_BATCH: AtomicUsize = AtomicUsize::new(0);
+static RC_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
+static RC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("rc-plain")]
+async fn rc_plain(_o: &Order) -> HandlerResult {
+    RC_PLAIN.fetch_add(1, Ordering::SeqCst);
+    RC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("rc-ignored")]
+async fn rc_on(_o: &Order) -> HandlerResult {
+    RC_ON.fetch_add(1, Ordering::SeqCst);
+    RC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("rc-batch"))]
+async fn rc_batch(orders: &[Order]) -> HandlerResult {
+    RC_BATCH.fetch_add(orders.len(), Ordering::SeqCst);
+    RC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("rc-ignored"))]
+async fn rc_batch_on(orders: &[Order]) -> HandlerResult {
+    RC_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
+    RC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// The same four forms decode through a chain codec named once with `with_codec`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chain_codec_router_includes_dispatch() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .with_codec(JsonCodec)
+        .include(rc_plain)
+        .include_on(Name::new("rc-on"), rc_on)
+        .include_batch(rc_batch)
+        .include_batch_on(Name::new("rc-batch-on"), rc_batch_on);
+
+    let app = RustStream::new(AppInfo::new("rc", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(router));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_all_seen(
+        &publisher,
+        &["rc-plain", "rc-on", "rc-batch", "rc-batch-on"],
+        &[&RC_PLAIN, &RC_ON, &RC_BATCH, &RC_BATCH_ON],
+        &RC_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static RM_A: AtomicUsize = AtomicUsize::new(0);
+static RM_B: AtomicUsize = AtomicUsize::new(0);
+static RM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("rm-a")]
+async fn rm_a(_o: &Order) -> HandlerResult {
+    RM_A.fetch_add(1, Ordering::SeqCst);
+    RM_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("rm-b")]
+async fn rm_b(_o: &Order) -> HandlerResult {
+    RM_B.fetch_add(1, Ordering::SeqCst);
+    RM_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// `merge` keeps both routers' registrations (and their metadata order: own first, merged
+/// after); a router-scope `layer` on the merged router still dispatches.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn merged_router_dispatches_and_collects_metadata() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let merged = Router::<MemoryBroker>::new().include(rm_a).merge(
+        Router::<MemoryBroker>::new()
+            .layer(TracingLayer::default())
+            .include(rm_b),
+    );
+
+    let names: Vec<_> = merged.handlers().into_iter().map(|m| m.name).collect();
+    assert_eq!(names, ["rm-a", "rm-b"]);
+
+    let app = RustStream::new(AppInfo::new("rm", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(merged));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_all_seen(&publisher, &["rm-a", "rm-b"], &[&RM_A, &RM_B], &RM_NOTIFY).await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}

--- a/tests/router_publishing.rs
+++ b/tests/router_publishing.rs
@@ -1,0 +1,323 @@
+//! Integration tests for the `Router` publishing include family (single-message and batch),
+//! in both codec forms: the default codec and a chain codec set with `with_codec`. Replies are
+//! verified end to end by plain subscribers on the reply topics.
+#![cfg(feature = "macros")]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use common::handler_signal;
+use ruststream::codec::JsonCodec;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, TypedPublisher};
+use ruststream::{Name, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Receipt {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+/// Publishes orders to each ingress topic until every reply counter is non-zero (subscriptions
+/// open inside `run()`, so early publishes are lost), bounded by a hang guard.
+async fn drive_until_replied(
+    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    topics: &[&str],
+    counters: &[&AtomicUsize],
+    signal: &Notify,
+) {
+    let payload = order_bytes(1);
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            for topic in topics {
+                let _ = publisher
+                    .publish(OutgoingMessage::new(topic, &payload))
+                    .await;
+            }
+            handler_signal(signal).await;
+            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "not every publishing form replied");
+}
+
+static RP_OUT: AtomicUsize = AtomicUsize::new(0);
+static RP_OUT_ON: AtomicUsize = AtomicUsize::new(0);
+static RP_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("rp-in", publish("rp-out"))]
+async fn rp_relay(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("rp-ignored", publish("rp-out-on"))]
+async fn rp_relay_on(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("rp-out")]
+async fn rp_check(_r: &Receipt) -> HandlerResult {
+    RP_OUT.fetch_add(1, Ordering::SeqCst);
+    RP_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("rp-out-on")]
+async fn rp_check_on(_r: &Receipt) -> HandlerResult {
+    RP_OUT_ON.fetch_add(1, Ordering::SeqCst);
+    RP_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// Default-codec `include_publishing` / `include_publishing_on`: replies reach the reply topics.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_codec_router_publishing_replies() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .include_publishing(rp_relay, TypedPublisher::new(broker.publisher()))
+        .include_publishing_on(
+            Name::new("rp-in-on"),
+            rp_relay_on,
+            TypedPublisher::new(broker.publisher()),
+        );
+
+    let app = RustStream::new(AppInfo::new("rp", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(router);
+        b.include(rp_check);
+        b.include(rp_check_on);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_replied(
+        &publisher,
+        &["rp-in", "rp-in-on"],
+        &[&RP_OUT, &RP_OUT_ON],
+        &RP_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static RPC_OUT: AtomicUsize = AtomicUsize::new(0);
+static RPC_OUT_ON: AtomicUsize = AtomicUsize::new(0);
+static RPC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("rpc-in", publish("rpc-out"))]
+async fn rpc_relay(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("rpc-ignored", publish("rpc-out-on"))]
+async fn rpc_relay_on(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("rpc-out")]
+async fn rpc_check(_r: &Receipt) -> HandlerResult {
+    RPC_OUT.fetch_add(1, Ordering::SeqCst);
+    RPC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("rpc-out-on")]
+async fn rpc_check_on(_r: &Receipt) -> HandlerResult {
+    RPC_OUT_ON.fetch_add(1, Ordering::SeqCst);
+    RPC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// Chain-codec `include_publishing` / `include_publishing_on`: the input decodes with the
+/// `with_codec` codec, the reply goes through the publisher's own.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chain_codec_router_publishing_replies() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .with_codec(JsonCodec)
+        .include_publishing(rpc_relay, TypedPublisher::new(broker.publisher()))
+        .include_publishing_on(
+            Name::new("rpc-in-on"),
+            rpc_relay_on,
+            TypedPublisher::new(broker.publisher()),
+        );
+
+    let app = RustStream::new(AppInfo::new("rpc", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(router);
+        b.include(rpc_check);
+        b.include(rpc_check_on);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_replied(
+        &publisher,
+        &["rpc-in", "rpc-in-on"],
+        &[&RPC_OUT, &RPC_OUT_ON],
+        &RPC_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static BP_OUT: AtomicUsize = AtomicUsize::new(0);
+static BP_OUT_ON: AtomicUsize = AtomicUsize::new(0);
+static BP_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber(batch("bp-in"), publish("bp-out"))]
+async fn bp_relay(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber(batch("bp-ignored"), publish("bp-out-on"))]
+async fn bp_relay_on(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber("bp-out")]
+async fn bp_check(_r: &Receipt) -> HandlerResult {
+    BP_OUT.fetch_add(1, Ordering::SeqCst);
+    BP_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("bp-out-on")]
+async fn bp_check_on(_r: &Receipt) -> HandlerResult {
+    BP_OUT_ON.fetch_add(1, Ordering::SeqCst);
+    BP_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// Default-codec `include_batch_publishing` / `include_batch_publishing_on`: every batch element
+/// is republished to the reply topic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_codec_router_batch_publishing_replies() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .include_batch_publishing(bp_relay, TypedPublisher::new(broker.publisher()))
+        .include_batch_publishing_on(
+            Name::new("bp-in-on"),
+            bp_relay_on,
+            TypedPublisher::new(broker.publisher()),
+        );
+
+    let app = RustStream::new(AppInfo::new("bp", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(router);
+        b.include(bp_check);
+        b.include(bp_check_on);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_replied(
+        &publisher,
+        &["bp-in", "bp-in-on"],
+        &[&BP_OUT, &BP_OUT_ON],
+        &BP_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static BPC_OUT: AtomicUsize = AtomicUsize::new(0);
+static BPC_OUT_ON: AtomicUsize = AtomicUsize::new(0);
+static BPC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber(batch("bpc-in"), publish("bpc-out"))]
+async fn bpc_relay(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber(batch("bpc-ignored"), publish("bpc-out-on"))]
+async fn bpc_relay_on(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber("bpc-out")]
+async fn bpc_check(_r: &Receipt) -> HandlerResult {
+    BPC_OUT.fetch_add(1, Ordering::SeqCst);
+    BPC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("bpc-out-on")]
+async fn bpc_check_on(_r: &Receipt) -> HandlerResult {
+    BPC_OUT_ON.fetch_add(1, Ordering::SeqCst);
+    BPC_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// Chain-codec `include_batch_publishing` / `include_batch_publishing_on`: elements decode with
+/// the `with_codec` codec, replies go through the publisher's own.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chain_codec_router_batch_publishing_replies() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let router = Router::<MemoryBroker>::new()
+        .with_codec(JsonCodec)
+        .include_batch_publishing(bpc_relay, TypedPublisher::new(broker.publisher()))
+        .include_batch_publishing_on(
+            Name::new("bpc-in-on"),
+            bpc_relay_on,
+            TypedPublisher::new(broker.publisher()),
+        );
+
+    let app = RustStream::new(AppInfo::new("bpc", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(router);
+        b.include(bpc_check);
+        b.include(bpc_check_on);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    drive_until_replied(
+        &publisher,
+        &["bpc-in", "bpc-in-on"],
+        &[&BPC_OUT, &BPC_OUT_ON],
+        &BPC_NOTIFY,
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
The include-family coverage slice of backlog item 10 (line coverage 73.8% -> 82.1%), plus the maintainer's re-enabling of the parked NATS targets as a second commit.

## Commit 1: include-family tests

Two new integration suites mount every `Router` include form on `MemoryBroker` and verify dispatch end to end:

- `tests/router_include.rs` - `include` / `include_on` / `include_batch` / `include_batch_on` in both codec forms (default and `with_codec` chain), plus `merge` (with `handlers()` metadata order pinned) and a router-scope `layer`.
- `tests/router_publishing.rs` - `include_publishing(_on)` and `include_batch_publishing(_on)` in both codec forms; replies verified end to end by plain subscribers on the reply topics.

Unit tests pin the remaining uncovered contracts:

- `Typed`'s decode-failure branches: `Drop` by default, `Requeue` when overridden, and the inner handler never runs on a decode failure.
- `SubscriberDef`'s default methods via a hand-written def that overrides nothing - the macro always overrides them, so the default bodies were never executed by any test.

Coverage: `router/include.rs` 5.5% -> 94.7%, `router/builder.rs` 30.7% -> 90.2%, `typed.rs` 56% -> 84%, `subscriber_def.rs` 58% -> 79%. The CI gate stays at 73 for now; it can ratchet once the remaining item-10 slices (retry semantics under paused time, pools/lanes) land.

## Commit 2: NATS targets re-enabled (maintainer change, carried here)

`ruststream-nats` 0.3 is published and compatible with this tree, so the parked targets come back: the `nats_*` examples, the `doc_testing_nats` test and the `ruststream-nats` dev-dependency (`testing` feature) are uncommented, the `autoexamples`/`autotests` opt-out is gone, and `just build` compiles with `--all-features`. Verified locally: `doc_testing_nats` passes against the published 0.3, clippy compiles all `nats_*` examples clean.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features`: 142 passed (includes `doc_testing_nats`)
- `cargo check --no-default-features`: clean