### PR TITLE
ci: ratchet the coverage floor to 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       # Line-coverage gate. The floor ratchets up toward the 90% target as the
       # coverage backlog items land; raise it here and in the justfile together.
       - name: cargo llvm-cov
-        run: cargo llvm-cov --workspace --all-features --fail-under-lines 73
+        run: cargo llvm-cov --workspace --all-features --fail-under-lines 81
 
   package:
     name: Package (publish dry-run)

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ deny:
 # 90% target as the coverage backlog items land; raise it here and in ci.yml
 # together. Needs cargo-llvm-cov: cargo install cargo-llvm-cov --locked
 cov:
-    cargo llvm-cov --workspace --all-features --fail-under-lines 73
+    cargo llvm-cov --workspace --all-features --fail-under-lines 81
 
 # HTML coverage report at target/llvm-cov/html/index.html, for finding the
 # uncovered lines the gate complains about.


### PR DESCRIPTION
Backlog item 10's test slices (#53, #54) lifted line coverage from 73.8% to 82.1%, so the gate ratchets from 73 to 81 - a point of headroom for normal churn - in ci.yml and the justfile together, per the comment both carry. `just cov` passes locally at 82.08%.

Remaining distance to the 90% DoD target comes from the docs/examples items (8, 9, 12) and whatever uncovered tails they pin along the way.