### PR TITLE
docs: document delayed redelivery end to end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ name = "publishing"
 required-features = ["macros", "memory", "json"]
 
 [[example]]
+name = "retry"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
 name = "routing"
 required-features = ["macros", "memory", "json"]
 

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -68,8 +68,21 @@ pub trait IncomingMessage: Send + Sync {
     fn headers(&self) -> &Headers;
     async fn ack(self) -> Result<(), AckError>;
     async fn nack(self, requeue: bool) -> Result<(), AckError>;
+
+    // Defaulted: a plain nack(true). Override when the transport has native
+    // delayed redelivery (JetStream NAK with delay); handlers reach it through
+    // HandlerResult::retry_after.
+    async fn nack_after(self, delay: Duration) -> Result<(), AckError>;
+
+    // Defaulted: None. Override (with the Partitioned capability) to feed the
+    // runtime's keyed worker lanes, workers(n, by_key).
+    fn partition_key(&self) -> Option<&[u8]>;
 }
 ```
+
+The two defaulted methods are how optional broker behaviour degrades gracefully: a broker that
+overrides neither still works with every runtime feature, with `retry_after` falling back to an
+immediate requeue and keyed lanes rotating keyless messages.
 
 ### `Publisher`
 

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -48,12 +48,27 @@ The return type is anything that converts into a [`HandlerResult`]:
 
 On the message itself, ack consumes `self`, so the type system prevents acking twice.
 
+### Delayed redelivery
+
 `retry_after` covers the not-ready-yet case (a dependency has not arrived, an upstream is
-rate-limited), where an immediate redelivery would just spin. The delay is a hint: brokers with
-native delayed redelivery (JetStream `NAK` with delay, the in-memory broker) honour it, others
-fall back to an immediate requeue. It composes with
-[selective batch outcomes](#selective-acknowledgement): a `Vec<HandlerResult>` can carry
-per-element delays.
+rate-limited), where an immediate redelivery would just spin:
+
+```rust
+--8<-- "examples/retry.rs:retry_after"
+```
+
+Under the hood the dispatcher settles the message with `IncomingMessage::nack_after(delay)`. A
+broker overrides that method when the transport has native delayed redelivery (JetStream `NAK`
+with delay; the in-memory broker re-delivers on a timer); the trait's default degrades to a
+plain `nack(requeue = true)`. The delay is therefore a hint, not a guarantee - on a broker
+without the capability the message comes back immediately.
+
+It composes with [selective batch outcomes](#selective-acknowledgement): a `Vec<HandlerResult>`
+carries per-element delays, so pending entries back off without holding up the rest of the page:
+
+```rust
+--8<-- "examples/retry.rs:batch_retry_after"
+```
 
 ## Choosing the subscription source
 

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -1,0 +1,58 @@
+//! Delayed redelivery from the Subscribers guide: `retry_after` for the not-ready-yet case,
+//! and per-element delays in a selective batch outcome.
+//!
+//! ```text
+//! cargo run --example retry --features macros,memory,json -- run
+//! ```
+
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Payment {
+    id: u64,
+    settled: bool,
+}
+
+// --8<-- [start:retry_after]
+/// The not-ready-yet case: the upstream has not settled this payment, so an immediate
+/// redelivery would just spin. Ask the broker to redeliver no sooner than five seconds from now.
+#[subscriber("payments")]
+async fn reconcile(payment: &Payment) -> HandlerResult {
+    if !payment.settled {
+        return HandlerResult::retry_after(Duration::from_secs(5));
+    }
+    println!("payment {} settled", payment.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:retry_after]
+
+// --8<-- [start:batch_retry_after]
+/// Selective outcomes carry per-element delays: settled payments ack immediately, pending ones
+/// come back in thirty seconds without holding up the rest of the page.
+#[subscriber(batch("payments"))]
+async fn reconcile_page(payments: &[Payment]) -> Vec<HandlerResult> {
+    payments
+        .iter()
+        .map(|payment| {
+            if payment.settled {
+                HandlerResult::Ack
+            } else {
+                HandlerResult::retry_after(Duration::from_secs(30))
+            }
+        })
+        .collect()
+}
+// --8<-- [end:batch_retry_after]
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("retry", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(reconcile);
+        b.include_batch(reconcile_page);
+    })
+}


### PR DESCRIPTION
The `retry_after`/`nack_after` slice of backlog item 8: `nack_after` had zero mentions anywhere in docs/, and no example used either form.

- **`examples/retry.rs`** (new, compiled, snippet-anchored): the not-ready-yet single-message form (`HandlerResult::retry_after`) and per-element delays in a selective batch outcome (`Vec<HandlerResult>` carrying `retry_after` entries).
- **`guides/subscribers.md`**: the lone `retry_after` paragraph grows into a "Delayed redelivery" section embedding both snippets and explaining the mechanism - the dispatcher settles via `IncomingMessage::nack_after(delay)`, brokers with native delayed redelivery override it (JetStream NAK with delay, the in-memory timer), the trait default degrades to an immediate requeue, so the delay is a hint, not a guarantee.
- **`broker-authors/index.md`**: the `IncomingMessage` contract sketch catches up with the published trait - it was missing the defaulted `nack_after` and `partition_key` methods entirely; a closing paragraph explains the graceful-degradation pattern both defaults implement.

The wholesale fence-to-snippet conversion (the rest of item 8, ~45 inline fences with broker-authors/ as the hotspot) stays separate - this PR is the named retry/nack_after gap.

## Verification

- `cargo check --example retry --features macros,memory,json`, clippy all-targets all-features: clean
- `mkdocs build --strict`: clean (snippet anchors resolve)
- `cargo test --all-features`: all suites pass