### PR TITLE
docs: composition rules for subscriber features, pinned by tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ name = "batch_subscriber"
 required-features = ["macros", "memory", "json"]
 
 [[test]]
+name = "composition_rules"
+required-features = ["macros", "memory", "json"]
+
+[[test]]
 name = "conformance_self"
 required-features = ["conformance", "memory"]
 

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -205,6 +205,21 @@ single-message subscribers; batch forms take a plain `workers(n)` pool of batche
 On shutdown, the subscriber stops pulling new deliveries and in-flight workers drain under the
 app's `shutdown_timeout`.
 
+## Composition rules
+
+The subscriber features compose; these are the rules at each intersection, each pinned by an
+integration test.
+
+| Combination | Rule |
+|---|---|
+| `workers(n)` × `batch(..)` | The pool holds up to `n` **batches** in flight. `by_key` does not apply to batch forms: lanes order single messages per key, and the macro rejects the combination at compile time. |
+| `retry()` / `retry_after` × `workers(n)` | Retried deliveries re-enter the pool and complete like any other delivery. |
+| `retry()` / `retry_after` × `workers(n, by_key)` | Retries complete, but per-key ordering across a retry is **not** promised: a requeued message rejoins the stream from the back. If a key's messages must stay ordered even through failures, the handler has to absorb the failure instead of nacking. |
+| `.transactional()` × `workers(n)` | One transaction per batch, exactly as in the sequential loop. Concurrent batches run concurrent, independent transactions; each stays atomic (commit-then-ack per batch). |
+| `Buffered` × `workers(n)` | Batches still close by `max_size` / `max_wait` only; the pool bounds how many closed batches are processed at once and never affects batch boundaries. |
+| `publish(..)` × `workers(n)` | Replies are produced concurrently, so reply order across deliveries is not promised. A failed reply publish retries only its own delivery. |
+| middleware × `batch(..)` | App-global and router layers wrap per-message handlers and do not apply to batch registrations (a per-message layer cannot wrap a whole-batch handler). |
+
 ## Macro or manual
 
 `#[subscriber]` is sugar over a generic API. The macro generates a typed handler and its metadata;

--- a/tests/composition_rules.rs
+++ b/tests/composition_rules.rs
@@ -1,0 +1,209 @@
+//! Integration tests pinning the composition rules documented in the Subscribers guide: the
+//! feature pairs (transactional x workers, Buffered x workers, publishing x workers) whose
+//! interaction is promised in prose. The remaining pairs are pinned elsewhere: workers x batch
+//! and retry x pools / lanes in `workers.rs` and `retry_semantics.rs`.
+#![cfg(feature = "macros")]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use common::handler_signal;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
+use ruststream::testing::TestClient;
+use ruststream::{Buffered, Name, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Receipt {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+static TX_HANDLED: AtomicUsize = AtomicUsize::new(0);
+static TX_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+/// Each batch's replies go out in one transaction; the pool runs the batches concurrently.
+#[subscriber(batch("tx-in"), publish("tx-out"), workers(2))]
+async fn tx_confirm(orders: &[Order]) -> Vec<Receipt> {
+    TX_HANDLED.fetch_add(orders.len(), Ordering::SeqCst);
+    TX_NOTIFY.notify_one();
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+/// Transactional reply publishing composes with a batch pool: every delivered order is
+/// confirmed exactly through its own batch's transaction, with batches in flight concurrently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transactional_replies_compose_with_a_batch_pool() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let observer = broker.clone();
+
+    let replies = TypedPublisher::new(broker.publisher()).transactional();
+    let app = RustStream::new(AppInfo::new("tx", "0.1.0"))
+        .with_broker(broker, |b| b.include_batch_publishing(tx_confirm, replies));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // Publish until at least four orders made it through (early publishes are lost while the
+    // subscription opens), then expect one committed receipt per handled order.
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut id = 1u32;
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("tx-in", &order_bytes(id)))
+                .await;
+            id += 1;
+            handler_signal(&TX_NOTIFY).await;
+            if TX_HANDLED.load(Ordering::SeqCst) >= 4 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "batches did not flow through the pool");
+
+    let handled = TX_HANDLED.load(Ordering::SeqCst);
+    let receipts = observer
+        .expect_published("tx-out", handled, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(
+        receipts.len() >= handled,
+        "{} orders handled but only {} receipts committed",
+        handled,
+        receipts.len(),
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static BUF_SEEN: AtomicUsize = AtomicUsize::new(0);
+static BUF_BATCHES: AtomicUsize = AtomicUsize::new(0);
+static BUF_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+/// Client-side batching under a pool: the deadline (not the pool) closes a batch.
+#[subscriber(batch(Buffered::<Name>::new(Name::new("buf-in"))
+    .max_size(2)
+    .max_wait(Duration::from_millis(10))), workers(2))]
+async fn buffered_drain(orders: &[Order]) -> HandlerResult {
+    BUF_SEEN.fetch_add(orders.len(), Ordering::SeqCst);
+    BUF_BATCHES.fetch_add(1, Ordering::SeqCst);
+    BUF_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// The Buffered adapter composes with a batch pool: batches still close by size or deadline,
+/// the pool only bounds how many are processed at once. Every delivery is drained.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn buffered_sources_compose_with_a_batch_pool() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("buf", "0.1.0"))
+        .with_broker(broker, |b| b.include_batch(buffered_drain));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut id = 1u32;
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("buf-in", &order_bytes(id)))
+                .await;
+            id += 1;
+            handler_signal(&BUF_NOTIFY).await;
+            if BUF_SEEN.load(Ordering::SeqCst) >= 6 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "buffered batches did not drain through the pool"
+    );
+    assert!(
+        BUF_BATCHES.load(Ordering::SeqCst) >= 2,
+        "everything arrived as a single batch; size/deadline closing did not engage",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static PUB_REPLIED: AtomicUsize = AtomicUsize::new(0);
+static PUB_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+/// Reply publishing under a pool: replies are produced concurrently.
+#[subscriber("pub-in", publish("pub-out"), workers(3))]
+async fn pooled_relay(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("pub-out")]
+async fn pooled_check(_r: &Receipt) -> HandlerResult {
+    PUB_REPLIED.fetch_add(1, Ordering::SeqCst);
+    PUB_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// A publishing handler composes with a worker pool: every delivery's reply arrives; reply
+/// order across deliveries is not promised (the pool processes them concurrently).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publishing_replies_compose_with_a_worker_pool() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("pub", "0.1.0")).with_broker(broker, |b| {
+        b.include_publishing(pooled_relay, TypedPublisher::new(b.broker().publisher()));
+        b.include(pooled_check);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut id = 1u32;
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("pub-in", &order_bytes(id)))
+                .await;
+            id += 1;
+            handler_signal(&PUB_NOTIFY).await;
+            if PUB_REPLIED.load(Ordering::SeqCst) >= 4 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "pooled publishing handler did not reply to every delivery",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
Backlog item 9: a "Composition rules" section in `guides/subscribers.md` - one row per feature intersection, each backed by an integration test, with the three previously untested pairs landing in this same PR (test first, then the paragraph, per the item's own rule).

## The table

| Combination | Rule |
|---|---|
| `workers(n)` x `batch(..)` | pool of batches; `by_key` rejected at compile time for batch forms |
| retry x `workers(n)` | retries re-enter the pool and complete |
| retry x `workers(n, by_key)` | retries complete; per-key order across a retry is explicitly not promised |
| `.transactional()` x `workers(n)` | one transaction per batch; concurrent batches = concurrent independent transactions |
| `Buffered` x `workers(n)` | batch boundaries close by size/deadline only; the pool never affects them |
| `publish(..)` x `workers(n)` | replies concurrent, cross-delivery reply order not promised |
| middleware x `batch(..)` | per-message layers do not wrap batch registrations |

## New tests (`tests/composition_rules.rs`)

- `transactional_replies_compose_with_a_batch_pool` - `batch + publish + workers(2)` with a `.transactional()` publisher: every handled order's receipt commits.
- `buffered_sources_compose_with_a_batch_pool` - a `Buffered(max_size=2, max_wait=10ms)` source under `workers(2)`: everything drains and more than one batch forms (size/deadline closing engages, the pool does not merge batches).
- `publishing_replies_compose_with_a_worker_pool` - `publish + workers(3)`: every delivery's reply arrives end to end.

The other rows were pinned earlier: workers x batch and the barrier-style concurrency proofs in `workers.rs` (#42, #51), retry x pools/lanes and batch-pool overlap in `retry_semantics.rs` (#54), and the macro rejects `by_key` on batch forms at compile time.

## Verification

- `cargo fmt --check`, clippy all-targets all-features: clean
- `cargo test --all-features`: 16 suites green (149 tests, 146 + 3 new)
- `mkdocs build --strict`: clean