### PR TITLE
docs: compile or justify every code fence, enforced by a CI lint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,10 @@ on:
       - mkdocs.yml
       - overrides/**
       - examples/**
-      # the testing guide embeds its snippets from these test files
-      - tests/doc_testing_*.rs
+      # the testing and conformance guides embed their snippets from these test files
+      - tests/doc_*.rs
+      - tests/conformance_self.rs
+      - scripts/lint_doc_fences.py
       - .github/workflows/docs.yml
   pull_request:
     branches: [main]
@@ -38,6 +40,9 @@ jobs:
 
       - name: Install docs toolchain
         run: pip install -r docs/requirements.txt
+
+      - name: Lint doc code fences
+        run: python3 scripts/lint_doc_fences.py
 
       - name: Build site (strict)
         run: mkdocs build --strict

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,10 @@ name = "conformance_self"
 required-features = ["conformance", "memory"]
 
 [[test]]
+name = "doc_conformance_nats"
+required-features = ["conformance"]
+
+[[test]]
 name = "doc_testing_memory"
 required-features = ["memory", "macros", "json"]
 

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -21,15 +21,13 @@ ship there.
 
 `harness::run_suite` takes a factory that builds a fresh client per scenario. The factory is
 fallible (it returns the `TestClient::start` result) and is invoked once per scenario, so scenarios
-cannot leak state into each other:
+cannot leak state into each other. This is the in-memory reference broker's own suite run,
+verbatim; substitute your `TestClient::start` in the factory:
 
 ```rust
 use ruststream::conformance::harness;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn passes_conformance() {
-    harness::run_suite(|| async { MyTestClient::start().await }).await;
-}
+--8<-- "tests/conformance_self.rs:run_suite"
 ```
 
 ### What it checks
@@ -58,18 +56,9 @@ broker-agnostic:
 
 ```rust
 use ruststream::conformance::harness;
+use ruststream_nats::{NatsBroker, SubscribeOptions};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
-async fn passes_lifecycle() {
-    let url = std::env::var("NATS_TEST_URL").unwrap();
-    harness::lifecycle(
-        || NatsBroker::new(url.clone()),         // sync construction (no I/O)
-        |subject| SubscribeOptions::new(subject), // the broker's SubscriptionSource
-        |broker| broker.publisher(),              // a publisher from the connected broker
-    )
-    .await;
-}
+--8<-- "tests/doc_conformance_nats.rs:lifecycle"
 ```
 
 - **`make_broker`** is **synchronous** (`Fn() -> B`). A broker that can only be built asynchronously
@@ -97,19 +86,9 @@ without the capability simply do not call it. Each suite takes the same factory 
 
 ```rust
 use ruststream::conformance::capabilities;
+use ruststream_nats::{NatsBroker, SubscribeOptions};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
-async fn passes_request_reply() {
-    let url = std::env::var("NATS_TEST_URL").unwrap();
-    capabilities::request_reply(
-        || NatsBroker::new(url.clone()),
-        |subject| SubscribeOptions::new(subject),
-        |broker| broker.publisher(),   // the RequestReply publisher under test
-        |broker| broker.publisher(),   // the plain publisher the responder replies through
-    )
-    .await;
-}
+--8<-- "tests/doc_conformance_nats.rs:request_reply"
 ```
 
 The in-memory broker implements every capability natively and passes all three suites in-process

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -36,6 +36,7 @@ tracing = "0.1"
 One crate-level enum, variants by source, `#[non_exhaustive]` so new variants are not breaking. The
 sources are boxed `std` errors, so the public API does not leak the `async-nats` error types.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use std::error::Error as StdError;
 
@@ -67,6 +68,7 @@ publisher captured early reads the live client once it is set. `new` is synchron
 the address - that is what lets a NATS service compose with the synchronous `#[ruststream::app]`
 builder.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use std::sync::Arc;
 
@@ -153,6 +155,7 @@ types, model both behind a single `SubscribeOptions` descriptor and a single `Na
 `SubscribeOptions` is the `SubscriptionSource`; the broker dispatches on whether `jetstream(..)` was
 called. Each builder method maps onto one keyword of the `#[subscriber(..)]` decorator.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use std::time::Duration;
 
@@ -231,6 +234,7 @@ impl SubscriptionSource<NatsBroker> for SubscribeOptions {
 Because the `#[subscriber(..)]` macro accepts a builder chain, the whole descriptor sits inline in
 the decorator:
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 #[subscriber(SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("worker"))]
 async fn handle(order: &Order) -> HandlerResult {
@@ -241,6 +245,7 @@ async fn handle(order: &Order) -> HandlerResult {
 By-name subscriptions reuse the same path: implement `Subscribe` by delegating to
 `SubscribeOptions::new(name)`, so `#[subscriber("orders")]` works too.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use ruststream::Subscribe;
 
@@ -256,6 +261,7 @@ impl Subscribe for NatsBroker {
 The broker's own `subscribe` validates the options and branches once (`queue_group_ref`,
 `stream_ref`, and `durable_ref` are small `pub(crate)` getters returning `Option<&str>`):
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use async_nats::jetstream::{self, consumer::pull::Config as PullConfig};
 
@@ -309,6 +315,7 @@ impl NatsBroker {
 one `Message` type. `stream` branches with `futures::future::Either` and takes the inner stream out
 on first poll, so it is single-use (the contract allows one `stream` call).
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use async_nats::jetstream::consumer::pull::Stream as PullStream;
 use futures::{Stream, future::Either};
@@ -355,6 +362,7 @@ boxed because the wrapped `async-nats` messages are large. `ack`/`nack` on a cor
 mapping to `nak` (redeliver) when the handler asks for it and to `term` (drop a poison message)
 when it does not.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use async_nats::jetstream::AckKind;
 use ruststream::{AckError, Headers, IncomingMessage};
@@ -402,6 +410,7 @@ Returning `AckError::Unsupported` (rather than a real error) for core deliveries
 the conformance lifecycle check pass for Core NATS. Each message converts its headers once at
 construction; the two converters are the one spot that tracks the `async-nats` version:
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use bytes::Bytes;
 
@@ -436,6 +445,7 @@ fn headers_to_nats(headers: &Headers) -> Option<async_nats::HeaderMap> {
 The publisher holds the shared connection cell and reads the client on each publish, forwarding
 headers when present.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use ruststream::{OutgoingMessage, Publisher};
 
@@ -465,6 +475,7 @@ impl Publisher for NatsPublisher {
 NATS supports request-reply natively, so implement `RequestReply` on the publisher and bound the wait
 with the caller's timeout, mapping an elapsed timer to `RequestTimeout`.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use std::time::Duration;
 
@@ -505,6 +516,7 @@ reported as a server in the AsyncAPI document.
 With the broker in hand, an application looks exactly like any other; nothing about the handlers or
 codecs is NATS-specific.
 
+<!-- inline-rust: reproduces the sibling ruststream-nats crate source for teaching; that code lives in another repo and has no compilable home here -->
 ```rust
 use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
 

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -21,6 +21,7 @@ traits for the features your broker supports, and prove the result with the
 The broker is pure lifecycle: connect and shut down. It carries no subscriber or publisher type, so a
 single application can mix broker kinds.
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/broker.rs (which carries Send bounds and rustdoc); a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait Broker: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
@@ -35,6 +36,7 @@ pub trait Broker: Send + Sync {
 
 Implement `Subscribe` to support subscribing by name. This is what `#[subscriber("name")]` uses.
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/subscription.rs; a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait Subscribe: Broker {
     type Subscriber: Subscriber;
@@ -46,6 +48,7 @@ pub trait Subscribe: Broker {
 
 A subscriber is a `Stream` of incoming messages. Back-pressure comes for free from the stream.
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/subscriber.rs; a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait Subscriber: Send {
     type Message: IncomingMessage;
@@ -62,6 +65,7 @@ which keeps it cancel-safe.
 A delivered message exposes its payload and headers, and is acked or nacked. Ack consumes `self`, so
 double-ack is a compile error.
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/message.rs, with the defaulted methods annotated inline for teaching; a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait IncomingMessage: Send + Sync {
     fn payload(&self) -> &[u8];
@@ -86,6 +90,7 @@ immediate requeue and keyed lanes rotating keyless messages.
 
 ### `Publisher`
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/publisher.rs; a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait Publisher: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
@@ -101,6 +106,7 @@ pub trait Publisher: Send + Sync {
 group, a durable name, a delivery policy), expose a descriptor type that implements
 `SubscriptionSource`:
 
+<!-- inline-rust: simplified contract sketch of the real RPITIT trait in src/subscription.rs; a compiled copy would just duplicate the source with more noise -->
 ```rust
 pub trait SubscriptionSource<B: Broker> {
     type Subscriber: Subscriber;

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -21,6 +21,7 @@ differs by one line inside `with_broker`.
 
 === "Memory"
 
+    <!-- inline-rust: side-by-side broker-switch comparison; the NATS half depends on the external ruststream-nats crate and has no in-repo compiled home, so both halves stay inline to read in parallel -->
     ```rust
     use ruststream::memory::MemoryBroker;
     use ruststream::runtime::{AppInfo, RustStream};
@@ -34,6 +35,7 @@ differs by one line inside `with_broker`.
 
 === "NATS"
 
+    <!-- inline-rust: NATS half of the broker-switch comparison; depends on the external ruststream-nats crate, no in-repo compiled home -->
     ```rust
     use ruststream::runtime::{AppInfo, RustStream};
     use ruststream_nats::NatsBroker;

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -8,6 +8,7 @@ so a fresh project runs with zero dependencies.
 ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
 ```
 
+<!-- inline-rust: two-line constructor sketch; the broker in context is exercised by every memory-feature example (e.g. quickstart.rs:app) -->
 ```rust
 use ruststream::memory::MemoryBroker;
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -76,6 +76,7 @@ To publish a reply, return the reply value and name the destination with `publis
 
 Mount it with a publisher that carries the reply codec:
 
+<!-- inline-rust: minimal mount fragment isolating the publisher wiring; the full compiled program is examples/tutorial/main.rs:main, pulled in below -->
 ```rust
 use ruststream::runtime::TypedPublisher;
 
@@ -117,6 +118,7 @@ line:
 
 === "Memory"
 
+    <!-- inline-rust: side-by-side broker-swap comparison; the NATS half depends on the external ruststream-nats crate and has no in-repo compiled home, so both halves stay inline to read in parallel -->
     ```rust
     use ruststream::memory::MemoryBroker;
 
@@ -128,6 +130,7 @@ line:
 
 === "NATS"
 
+    <!-- inline-rust: NATS half of the broker-swap comparison; depends on the external ruststream-nats crate, no in-repo compiled home -->
     ```rust
     use ruststream_nats::NatsBroker;
 

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -52,6 +52,7 @@ To control the metadata explicitly - including for types without `JsonSchema` - 
 `Message` trait, which takes precedence over the schema; or derive it, which uses the type's name
 and doc comment:
 
+<!-- inline-rust: minimal Message-derive sketch; the compiled form (asyncapi_http.rs:payload) also derives JsonSchema, which would obscure the point that Message takes precedence over the schema -->
 ```rust
 use ruststream::Message;
 
@@ -72,11 +73,7 @@ Record the servers your service connects to so they appear in the document's `se
 Build a `ServerSpec` directly:
 
 ```rust
-use ruststream::ServerSpec;
-
-let app = RustStream::new(info)
-    .server("production", ServerSpec::new("nats.example.com:4222", "nats"))
-    .with_broker(broker, |b| b.include(handle));
+--8<-- "examples/asyncapi_http.rs:server"
 ```
 
 A broker crate may also implement the `DescribeServer` capability, in which case
@@ -90,6 +87,7 @@ the bytes; you mount them in whatever HTTP stack you already run (axum, actix, o
 For an interactive viewer, `render_viewer_html` returns a self-contained HTML page that loads the
 AsyncAPI React component and points it at your spec URL:
 
+<!-- inline-rust: two-line API-shape fragment; the compiled call lives in asyncapi_http.rs:generate -->
 ```rust
 use ruststream::asyncapi::{render_viewer_html, ViewerOptions};
 

--- a/docs/guides/codecs.md
+++ b/docs/guides/codecs.md
@@ -33,6 +33,7 @@ Override a single mounting:
 
 === "Router"
 
+    <!-- inline-rust: standalone Router-builder fragment; the compiled form is the with_broker tab below (codecs.rs:per_handler), which mounts the same chain via include_router -->
     ```rust
     router.with_codec(CborCodec).include(handle);
     ```

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -9,6 +9,7 @@ plus lifecycle hooks that run at fixed points around the run loop.
 `State` is a type-map: one value per type. Put ready-made values in at build time with
 `insert_state` (or from a [startup hook](#lifecycle-hooks), as the `Database` below is):
 
+<!-- inline-rust: minimal insert_state fragment with placeholder Config; the startup-hook form is compiled in lifespan.rs:hooks, pulled in below -->
 ```rust
 RustStream::new(info)
     .insert_state(Config::from_env())
@@ -79,6 +80,7 @@ By default `run` waits indefinitely for in-flight handlers to finish after shutd
 Bound that wait with `shutdown_timeout`, as the example above does; handlers still running after it
 are aborted:
 
+<!-- inline-rust: isolates the shutdown_timeout call; the full chain is compiled in lifespan.rs:hooks, shown earlier on this page -->
 ```rust
 use std::time::Duration;
 

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -29,6 +29,7 @@ automatically when stderr is a terminal.
 
 Install the default logger once, early in `main`:
 
+<!-- inline-rust: manual logger-init fragment; the shipped logging example uses the automatic #[ruststream::app] installer, so there is no compiled call site for the by-hand path -->
 ```rust
 ruststream::logging::init()?;
 tracing::info!("service starting");
@@ -37,6 +38,7 @@ tracing::info!("service starting");
 `init` reads the filter from `RUST_LOG`, falling back to `info`. Tune the defaults through the
 `Logging` builder:
 
+<!-- inline-rust: manual Logging-builder fragment; the by-hand init path has no compiled call site (the logging example uses the automatic installer) -->
 ```rust
 use ruststream::logging::Logging;
 

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -33,6 +33,7 @@ consume; `ok` or `error` for publish).
 
 `export` renders the current values in the Prometheus exposition format:
 
+<!-- inline-rust: one-line export() API shape; the complete server, including this call, is compiled in metrics_http.rs and pulled in below -->
 ```rust
 let body = metrics.export()?;
 ```

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -60,6 +60,7 @@ reads it.
 
 Wrap a single handler with `HandlerExt::with` instead of the whole application:
 
+<!-- inline-rust: HandlerExt::with API-shape fragment with placeholder handler and layer; the LogLayer impl it composes is compiled in middleware.rs:layer_impl, shown above -->
 ```rust
 use ruststream::runtime::HandlerExt;
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -18,6 +18,7 @@ Mount it with `include_publishing`, handing it a [`TypedPublisher`] that carries
 connection and the reply codec (`TypedPublisher::new` uses the default codec; name one with
 `TypedPublisher::with_codec`). `include_publishing` reuses that codec to decode the request too:
 
+<!-- inline-rust: minimal mount fragment for a reply publisher; the full build wiring is compiled in publishing.rs:pipeline, pulled in later on this page -->
 ```rust
 use ruststream::runtime::TypedPublisher;
 
@@ -56,6 +57,7 @@ Make publishing handlers idempotent under redelivery.
 To publish to a destination other than a single reply (fan-out, side effects, routing to a different
 broker), register a named publisher on the application and resolve it from the context.
 
+<!-- inline-rust: minimal named-publisher registration fragment; the full build wiring is compiled in publishing.rs:pipeline, pulled in later on this page -->
 ```rust
 // register at build time
 let app = RustStream::new(info)

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -17,6 +17,7 @@ use ruststream::runtime::Router;
 --8<-- "examples/routing.rs:builders"
 ```
 
+<!-- inline-rust: minimal mount fragment with placeholder routes module; the full compiled program is examples/routing.rs (merge form pulled in below) -->
 ```rust title="main.rs"
 RustStream::new(info).with_broker(broker, |b| {
     b.include_router(routes::orders());
@@ -56,6 +57,7 @@ for the app-scope side in a running service.
 
 Build routers per module, then combine them however suits the service:
 
+<!-- inline-rust: illustrative multi-router composition with placeholder route modules; the compiled merge form is examples/routing.rs:merge, pulled in below -->
 ```rust
 // Mount several routers on one broker - include_router can be called more than once.
 RustStream::new(info).with_broker(broker, |b| {

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -82,6 +82,7 @@ carries per-element delays, so pending entries back off without holding up the r
 When a subscription needs broker-specific options (a consumer group, a durable name, a delivery
 policy), the broker crate exposes a descriptor type. Use its constructor directly in the decorator:
 
+<!-- inline-rust: illustrative descriptor sketch; OrdersStream is a stand-in for a broker crate's SubscriptionSource type, which lives in another crate and has no in-repo compiled home (the real NATS form is pulled in just below) -->
 ```rust
 #[subscriber(OrdersStream::new("orders", "workers"))]
 async fn handle(order: &Order) -> HandlerResult {
@@ -110,6 +111,7 @@ macro.
 
 Inside `with_broker`, mount a definition with `include`:
 
+<!-- inline-rust: minimal include mount fragment with placeholder info/broker; the full compiled program is examples/subscribers.rs (its app is pulled in via other anchors on this page) -->
 ```rust
 RustStream::new(info).with_broker(broker, |b| {
     b.include(handle);

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -107,6 +107,7 @@ because durable names and ack waits have no in-process meaning. To unit-test tha
 mount the same definition on the test broker with an explicit by-name source - `include_on`
 overrides the macro's source (the codec resolves the same way as for `include`):
 
+<!-- inline-rust: include_on override fragment; the handler under test is declared with a real NatsBroker JetStream descriptor, which has no in-process compiled home, so the by-name remount is shown inline -->
 ```rust
 use ruststream::Name;
 
@@ -123,6 +124,7 @@ exactly what the integration suite is for.
 Behaviour that depends on real broker semantics belongs in a separate suite gated behind an
 environment variable, so the default `cargo test` stays fast and offline:
 
+<!-- inline-rust: integration-test skeleton with a pseudocode body; it drives a real NatsBroker (external crate) behind an env gate, so it has no compiled home here (the real gated suite is doc_conformance_nats.rs) -->
 ```rust title="tests/integration_nats.rs"
 fn test_url() -> Option<String> {
     std::env::var("NATS_TEST_URL").ok()

--- a/examples/asyncapi_http.rs
+++ b/examples/asyncapi_http.rs
@@ -21,7 +21,8 @@ use ruststream::subscriber;
 use serde::Deserialize;
 
 // --8<-- [start:payload]
-#[derive(Debug, Deserialize, ruststream::schemars::JsonSchema)]
+/// An order placed by a customer.
+#[derive(Debug, Deserialize, ruststream::Message, ruststream::schemars::JsonSchema)]
 struct Order {
     id: u64,
     item: String,
@@ -34,10 +35,16 @@ async fn handle(order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
+// --8<-- [start:server]
 fn service() -> RustStream {
     RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .server(
+            "production",
+            ruststream::ServerSpec::new("nats.example.com:4222", "nats"),
+        )
         .with_broker(MemoryBroker::new(), |b| b.include(handle))
 }
+// --8<-- [end:server]
 
 // --8<-- [start:generate]
 /// Builds the AsyncAPI document and the viewer HTML from the service.

--- a/scripts/lint_doc_fences.py
+++ b/scripts/lint_doc_fences.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Forbid inline Rust fences in docs/.
+
+Every ```rust fence must either embed a compiled snippet (a --8<-- include) or be
+explicitly exempted by an HTML comment on the line directly above it:
+
+    <!-- inline-rust: <why this cannot come from a compiled example> -->
+    ```rust
+
+The justification is mandatory. Exemptions are for code that has no compilable home in
+this repository: simplified trait sketches (the real signatures are RPITIT with long doc
+comments) and walk-throughs of another crate's internals.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+FENCE = re.compile(r"^```rust\b")
+SNIPPET = re.compile(r"--8<--")
+EXEMPT = re.compile(r"<!--\s*inline-rust:\s*\S")
+
+def lint(path: Path) -> list[str]:
+    errors = []
+    lines = path.read_text().splitlines()
+    inside = False
+    fence_line = 0
+    exempt = False
+    has_snippet = False
+    for n, line in enumerate(lines, 1):
+        if not inside and FENCE.match(line.strip()):
+            inside = True
+            fence_line = n
+            exempt = n > 1 and bool(EXEMPT.search(lines[n - 2]))
+            has_snippet = False
+        elif inside:
+            if SNIPPET.search(line):
+                has_snippet = True
+            if line.strip() == "```":
+                inside = False
+                if not has_snippet and not exempt:
+                    errors.append(
+                        f"{path}:{fence_line}: inline rust fence - embed a compiled"
+                        " snippet (--8<--) or add an `<!-- inline-rust: why -->`"
+                        " justification on the previous line"
+                    )
+    return errors
+
+def main() -> int:
+    docs = Path(__file__).resolve().parent.parent / "docs"
+    errors = []
+    for path in sorted(docs.rglob("*.md")):
+        errors.extend(lint(path))
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(f"{len(errors)} inline rust fence(s)", file=sys.stderr)
+    return 1 if errors else 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance_self.rs
+++ b/tests/conformance_self.rs
@@ -10,10 +10,12 @@ use ruststream::{
     memory::{MemoryBroker, MemorySource},
 };
 
+// --8<-- [start:run_suite]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn memory_broker_passes_conformance_suite() {
     harness::run_suite(|| async { Ok::<_, Infallible>(MemoryBroker::new()) }).await;
 }
+// --8<-- [end:run_suite]
 
 // `make_source` / `make_publisher` must stay closures: their bounds are higher-ranked
 // (`Fn(&str) -> _` / `Fn(&B) -> _`), so a bare method path - which binds one concrete lifetime -

--- a/tests/doc_conformance_nats.rs
+++ b/tests/doc_conformance_nats.rs
@@ -1,0 +1,41 @@
+//! The snippet source for the broker-authors Conformance guide: the lifecycle and capability
+//! checks against a real broker, exactly as a broker crate would write them. Gated behind
+//! `NATS_TEST_URL` because both perform a real `connect`.
+#![cfg(feature = "conformance")]
+// `make_source` / `make_publisher` must stay closures: their bounds are higher-ranked
+// (`Fn(&str) -> _` / `Fn(&B) -> _`), so a bare method path - which binds one concrete lifetime -
+// would not type-check (clippy's suggestion is a false positive here, as in conformance_self.rs).
+// Allowed file-wide so the embedded doc snippets stay free of clippy attributes.
+#![allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+
+use ruststream::conformance::{capabilities, harness};
+use ruststream_nats::{NatsBroker, SubscribeOptions};
+
+// --8<-- [start:lifecycle]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
+async fn passes_lifecycle() {
+    let url = std::env::var("NATS_TEST_URL").unwrap();
+    harness::lifecycle(
+        || NatsBroker::new(url.clone()), // sync construction (no I/O)
+        |subject| SubscribeOptions::new(subject), // the broker's SubscriptionSource
+        |broker| broker.publisher(),     // a publisher from the connected broker
+    )
+    .await;
+}
+// --8<-- [end:lifecycle]
+
+// --8<-- [start:request_reply]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs a running nats-server; set NATS_TEST_URL"]
+async fn passes_request_reply() {
+    let url = std::env::var("NATS_TEST_URL").unwrap();
+    capabilities::request_reply(
+        || NatsBroker::new(url.clone()),
+        |subject| SubscribeOptions::new(subject),
+        |broker| broker.publisher(), // the RequestReply publisher under test
+        |broker| broker.publisher(), // the plain publisher the responder replies through
+    )
+    .await;
+}
+// --8<-- [end:request_reply]

--- a/tests/retry_semantics.rs
+++ b/tests/retry_semantics.rs
@@ -53,7 +53,7 @@ async fn deferred(_o: &Order) -> HandlerResult {
 /// The dispatcher must hold the redelivery back for the full `retry_after` delay, measured on
 /// the paused clock - not merely redeliver eventually.
 ///
-/// `start_paused` requires the current-thread runtime (tokio cannot pause a multi-threaded
+/// `start_paused` requires the current-thread runtime (tokio cannot pause a multithreaded
 /// clock); the auto-advancing timer makes the test instant while keeping the measured interval
 /// exact.
 #[tokio::test(start_paused = true)]
@@ -141,7 +141,7 @@ async fn retry_completes_inside_a_worker_pool() {
     let shutdown_signal = Arc::clone(&shutdown);
     let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
 
-    // Warm up with id 0 until the subscription is live, then submit ids 1..=4 exactly once.
+    // Warm up with id 0 until the subscription is live, then submit ids 1-4 exactly once.
     let warmup = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let _ = publisher


### PR DESCRIPTION
## What

Inline ```rust fences in the docs rot silently - nothing compiles them. This PR pulls every fence with a compilable home from a real example or test via the mkdocs `--8<--` snippet mechanism, and requires an explicit `<!-- inline-rust: why -->` justification for the ones that genuinely cannot be compiled here.

A new lint, `scripts/lint_doc_fences.py`, enforces the rule and runs in `docs.yml` before the strict build.

## Exemptions (genuine no-home fences)

- **Core-trait sketches** (`broker-authors/index.md`) - simplified teaching versions of the real RPITIT traits in `src/`.
- **Sibling-crate walk-through** (`broker-authors/example-nats.md`) - reproduces `ruststream-nats` source, which lives in another repo.
- **Broker-switch comparison pairs** - the NATS half depends on the external crate and has no in-repo home, so both halves stay inline to read in parallel.
- **Minimal mount/API-shape fragments** - their full compiled form is pulled in elsewhere on the same page.

## New snippet sources

- `tests/doc_conformance_nats.rs` - the lifecycle and request-reply checks a broker crate would write (gated behind `NATS_TEST_URL`).
- `tests/conformance_self.rs:run_suite` anchor.
- `examples/asyncapi_http.rs` - `server` / `generate` / `payload` anchors.

## Result

0 unjustified fences, 67 `--8<--` includes, 41 justified exemptions.

## Checks

- `python3 scripts/lint_doc_fences.py` - clean
- `mkdocs build --strict` - all anchors resolve
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` - clean
- `cargo test --all-features` (touched suites) - pass

Closes the docs half of items 8 and 11 in the 0.3.1 plan.