### PR TITLE
examples: a production sample, plus MetricsLayer: BlanketLayer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,39 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      # Run the suite under instrumentation once, then format the collected data twice:
+      # a human-readable table into the run's job summary, and an lcov file as a downloadable
+      # artifact. `report` reuses the profile from `--no-report`, so neither re-runs the tests.
+      - name: Run tests under coverage
+        run: cargo llvm-cov --no-report --workspace --all-features
+
       # Line-coverage gate. The floor ratchets up toward the 90% target as the
-      # coverage backlog items land; raise it here and in the justfile together.
-      - name: cargo llvm-cov
-        run: cargo llvm-cov --workspace --all-features --fail-under-lines 81
+      # coverage backlog items land; raise it here and in the justfile together. The summary is
+      # written before the gate's exit code propagates, so it shows up even on a failure.
+      - name: Coverage summary and gate
+        run: |
+          set +e
+          cargo llvm-cov report --summary-only --fail-under-lines 81 | tee coverage.txt
+          rc=${PIPESTATUS[0]}
+          {
+            echo '## Coverage'
+            echo
+            echo '```'
+            cat coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
+
+      - name: Export lcov report
+        if: always()
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
 
   package:
     name: Package (publish dry-run)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["macros", "memory"]
 [[example]]
 name = "routed_service"
 path = "examples/routed_service/main.rs"
-required-features = ["macros", "memory", "json"]
+required-features = ["macros", "memory", "json", "metrics", "asyncapi", "logging"]
 
 [[example]]
 name = "quickstart"

--- a/examples/routed_service/domain.rs
+++ b/examples/routed_service/domain.rs
@@ -1,0 +1,155 @@
+//! The domain model: the messages on the wire, the service's error type, and a stand-in
+//! repository shared across handlers.
+//!
+//! Every payload derives [`JsonSchema`](ruststream::schemars::JsonSchema) so it contributes a
+//! schema to the AsyncAPI document, and [`Message`](ruststream::Message) so the document names the
+//! component after the type and uses its doc comment as the description. The [`Repository`] is a
+//! fake for any real async resource (a connection pool, an HTTP client); it is opened once in the
+//! startup hook and shared with every handler through [`Context`](ruststream::runtime::Context).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ruststream::Message;
+use ruststream::schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// An order placed by a customer, delivered on the `orders` channel.
+#[derive(Debug, Clone, Deserialize, JsonSchema, Message)]
+pub(crate) struct Order {
+    pub(crate) id: u64,
+    pub(crate) customer: String,
+    pub(crate) item: String,
+    pub(crate) quantity: u32,
+}
+
+/// A payment for an order, delivered on the `payments` channel and processed per customer.
+#[derive(Debug, Clone, Deserialize, JsonSchema, Message)]
+pub(crate) struct Payment {
+    pub(crate) order_id: u64,
+    pub(crate) customer: String,
+    pub(crate) amount_cents: u64,
+}
+
+/// A cleared payment ready to settle, delivered in batches on the `clearings` channel.
+#[derive(Debug, Clone, Deserialize, JsonSchema, Message)]
+pub(crate) struct Clearing {
+    pub(crate) order_id: u64,
+    pub(crate) amount_cents: u64,
+}
+
+/// A request to cancel an order, delivered on the `cancellations` channel.
+#[derive(Debug, Clone, Deserialize, JsonSchema, Message)]
+pub(crate) struct Cancellation {
+    pub(crate) order_id: u64,
+}
+
+/// The reply published to `confirmations` for each accepted or rejected order.
+#[derive(Debug, Clone, Serialize, JsonSchema, Message)]
+pub(crate) struct Confirmation {
+    pub(crate) order_id: u64,
+    pub(crate) accepted: bool,
+}
+
+/// The settlement published to `settlements` when a batch of clearings commits.
+#[derive(Debug, Clone, Serialize, JsonSchema, Message)]
+pub(crate) struct Settlement {
+    pub(crate) order_id: u64,
+    pub(crate) amount_cents: u64,
+}
+
+/// The service's single error type, with variants by source. `is_transient` is what lets a handler
+/// distinguish a retryable blip (ask for redelivery) from a permanent failure (drop the message).
+// --8<-- [start:error]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub(crate) enum ServiceError {
+    /// The backing store is briefly unavailable; the caller should retry.
+    #[error("repository is temporarily unavailable")]
+    Unavailable,
+    /// The order is not known to the store; retrying will not help.
+    #[error("order {0} is unknown")]
+    UnknownOrder(u64),
+}
+
+impl ServiceError {
+    /// Whether retrying the operation could succeed. Drives the handlers' retry-versus-drop choice.
+    pub(crate) const fn is_transient(&self) -> bool {
+        matches!(self, Self::Unavailable)
+    }
+}
+// --8<-- [end:error]
+
+/// A stand-in persistence layer. Cheap to clone (the state is `Arc`-backed), so handlers each hold
+/// their own handle to one shared store.
+#[derive(Debug, Clone)]
+pub(crate) struct Repository {
+    inner: Arc<RepoInner>,
+}
+
+#[derive(Debug)]
+struct RepoInner {
+    orders: Mutex<HashSet<u64>>,
+    // Flips on every `record_order` to make one call in two fail transiently, so the example
+    // exercises the retry path deterministically rather than depending on real flakiness.
+    fail_next: AtomicBool,
+}
+
+impl Repository {
+    /// Opens the store. Stands in for the real connect; the startup hook awaits this before any
+    /// broker connects.
+    pub(crate) async fn open() -> Result<Self, ServiceError> {
+        tokio::task::yield_now().await; // stands in for the network round trip
+        Ok(Self {
+            inner: Arc::new(RepoInner {
+                orders: Mutex::new(HashSet::new()),
+                fail_next: AtomicBool::new(false),
+            }),
+        })
+    }
+
+    /// Records an accepted order. Returns [`ServiceError::Unavailable`] on every other call to
+    /// demonstrate transient-failure handling.
+    pub(crate) async fn record_order(&self, id: u64) -> Result<(), ServiceError> {
+        tokio::task::yield_now().await;
+        if self.inner.fail_next.fetch_xor(true, Ordering::Relaxed) {
+            return Err(ServiceError::Unavailable);
+        }
+        self.inner.orders.lock().expect("orders lock").insert(id);
+        Ok(())
+    }
+
+    /// Charges a payment against an order. Always succeeds here; a real store would talk to a
+    /// payment gateway.
+    pub(crate) async fn charge(
+        &self,
+        _order_id: u64,
+        _amount_cents: u64,
+    ) -> Result<(), ServiceError> {
+        tokio::task::yield_now().await;
+        Ok(())
+    }
+
+    /// Cancels a recorded order. Unknown orders are a permanent error, not a transient one.
+    pub(crate) async fn cancel(&self, order_id: u64) -> Result<(), ServiceError> {
+        tokio::task::yield_now().await;
+        if self
+            .inner
+            .orders
+            .lock()
+            .expect("orders lock")
+            .remove(&order_id)
+        {
+            Ok(())
+        } else {
+            Err(ServiceError::UnknownOrder(order_id))
+        }
+    }
+
+    /// Closes the store. The after-shutdown hook awaits this once brokers are down.
+    pub(crate) async fn close(&self) {
+        tokio::task::yield_now().await;
+    }
+}

--- a/examples/routed_service/main.rs
+++ b/examples/routed_service/main.rs
@@ -1,19 +1,82 @@
-//! A multi-file RustStream service: macro handlers in [`orders`], wiring in [`routes`], and a
-//! `#[ruststream::app]` entry point here that mounts the router.
+//! A production-shaped RustStream service, assembled from focused modules:
 //!
-//! Run it with `cargo run --example routed_service --features macros,memory -- run`, or generate
-//! its AsyncAPI document with `... --features macros,memory,asyncapi -- asyncapi gen`.
+//! - [`domain`] - the wire messages (each derives `JsonSchema` + `Message` for AsyncAPI), the
+//!   service error type, and a shared repository.
+//! - [`orders`] - a publishing handler that replies and handles transient failures, and a
+//!   cancellation handler that retries.
+//! - [`payments`] - a charge handler across keyed worker lanes, and a transactional batch settler.
+//! - [`observability`] - an application-wide log/timing middleware.
+//! - [`routes`] - wires the handlers into two routers, each carrying the metrics consume layer.
+//!
+//! It exercises the runtime end to end: shared state opened in a startup hook and closed on
+//! shutdown, retries (`HandlerResult::retry` / `retry_after`), keyed worker lanes, a transactional
+//! batch publisher, app-scope middleware, and Prometheus metrics on both the consume and publish
+//! sides. `#[ruststream::app]` generates `main`, giving the service a CLI:
+//!
+//! ```text
+//! # start the service (waits for ctrl-c; logs each delivery, dumps metrics on shutdown)
+//! cargo run --example routed_service --features macros,memory,json,metrics,asyncapi,logging -- run
+//!
+//! # generate the AsyncAPI document for its four channels
+//! cargo run --example routed_service --features macros,memory,json,metrics,asyncapi,logging \
+//!     -- asyncapi gen --yaml
+//! ```
 
+mod domain;
+mod observability;
 mod orders;
+mod payments;
 mod routes;
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, RustStream};
 
-/// Builds the service. `#[ruststream::app]` generates `main`, so there is no runtime boilerplate.
+use std::time::Duration;
+
+use ruststream::ServerSpec;
+use ruststream::memory::MemoryBroker;
+use ruststream::metrics::Metrics;
+use ruststream::runtime::{AppInfo, Identity, RustStream, Stack};
+
+use crate::domain::{Repository, ServiceError};
+use crate::observability::Observe;
+
+/// Builds the service. The layer stack is named in the return type: `Observe` wraps every handler,
+/// including the router-mounted ones (it is a `BlanketLayer`), with `Identity` as the base.
 #[ruststream::app]
-fn app() -> RustStream {
-    RustStream::new(AppInfo::new("orders-service", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
-        let router = routes::orders(b.broker());
-        b.include_router(router);
-    })
+fn app() -> RustStream<Stack<Observe, Identity>> {
+    let metrics = Metrics::new().expect("create metrics registry");
+    // A second handle for the shutdown dump; `Metrics` is cheap to clone (shared registry).
+    let metrics_dump = metrics.clone();
+
+    RustStream::new(AppInfo::new("orders-service", "0.1.0"))
+        // AsyncAPI records the broker this service connects to in production.
+        .server(
+            "production",
+            ServerSpec::new("nats://orders.internal:4222", "nats"),
+        )
+        // App-wide: log and time every delivery, on every channel and router.
+        .layer(Observe)
+        // Publish-side metric: counts every reply that leaves the process.
+        .publish_layer(metrics.publish_layer())
+        // Open the shared repository before brokers connect, hand it to handlers via state.
+        .on_startup(|mut state| async move {
+            let repo = Repository::open().await?;
+            state.insert(repo);
+            Ok::<_, ServiceError>(state)
+        })
+        // Close the repository after brokers stop, then dump the final metrics.
+        .after_shutdown(move |state| async move {
+            if let Some(repo) = state.get::<Repository>() {
+                repo.close().await;
+            }
+            match metrics_dump.export() {
+                Ok(text) => tracing::info!("final metrics:\n{text}"),
+                Err(e) => tracing::warn!(error = %e, "could not export metrics"),
+            }
+            Ok::<(), ServiceError>(())
+        })
+        // Bound the post-shutdown drain of in-flight handlers.
+        .shutdown_timeout(Duration::from_secs(10))
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include_router(routes::orders(b.broker(), &metrics));
+            b.include_router(routes::payments(b.broker(), &metrics));
+        })
 }

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -1,0 +1,47 @@
+//! Cross-cutting observability: an application-scope middleware that logs and times every
+//! delivery.
+//!
+//! It implements both [`Layer`] (to wrap handlers mounted directly on a scope) and
+//! [`BlanketLayer`] - the latter is what lets `RustStream::layer` reach handlers mounted through a
+//! router, whose concrete types the router hides behind one generic method. The metrics consume
+//! layer is applied per router instead (in [`routes`](crate::routes)) to keep that metric scoped to
+//! the routed handlers and to show off [`Router::layer`](ruststream::runtime::Router::layer); this
+//! observability layer is global, so it carries the whole stack and must be a `BlanketLayer`.
+
+use std::time::Instant;
+
+use ruststream::runtime::{BlanketLayer, Context, Handler, HandlerResult, Layer};
+
+/// The layer value added with `RustStream::layer`.
+#[derive(Clone)]
+pub(crate) struct Observe;
+
+/// The handler `Observe` wraps around an inner handler.
+pub(crate) struct Observed<H>(H);
+
+impl<H> Layer<H> for Observe {
+    type Handler = Observed<H>;
+    fn layer(&self, inner: H) -> Observed<H> {
+        Observed(inner)
+    }
+}
+
+impl BlanketLayer for Observe {
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static,
+    {
+        Observed(handler)
+    }
+}
+
+impl<M: Send + Sync, H: Handler<M>> Handler<M> for Observed<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        let channel = ctx.name().to_owned();
+        let started = Instant::now();
+        let result = self.0.handle(msg, ctx).await;
+        tracing::info!(channel = %channel, elapsed = ?started.elapsed(), "handled");
+        result
+    }
+}

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -1,5 +1,6 @@
-//! Cross-cutting observability: an application-scope middleware that logs and times every
-//! delivery.
+//! Cross-cutting observability: a consume-side middleware ([`Observe`]) that logs and times every
+//! delivery, and a publish-side layer ([`StampSource`]) that stamps a provenance header on every
+//! reply.
 //!
 //! It implements both [`Layer`] (to wrap handlers mounted directly on a scope) and
 //! [`BlanketLayer`] - the latter is what lets `RustStream::layer` reach handlers mounted through a
@@ -10,7 +11,9 @@
 
 use std::time::Instant;
 
-use ruststream::runtime::{BlanketLayer, Context, Handler, HandlerResult, Layer};
+use ruststream::runtime::{
+    BlanketLayer, Context, Handler, HandlerResult, Layer, Outgoing, PublishLayer,
+};
 
 /// The layer value added with `RustStream::layer`.
 #[derive(Clone)]
@@ -43,5 +46,21 @@ impl<M: Send + Sync, H: Handler<M>> Handler<M> for Observed<H> {
         let result = self.0.handle(msg, ctx).await;
         tracing::info!(channel = %channel, elapsed = ?started.elapsed(), "handled");
         result
+    }
+}
+
+/// A static publish-side layer: stamps a provenance header on every message a publisher sends.
+///
+/// This is the other kind of publisher customisation. Where the consume `Observe` layer wraps
+/// handlers, a [`PublishLayer`] is composed onto one [`TypedPublisher`](ruststream::runtime::TypedPublisher)
+/// at build time with `.layer(..)` - zero-cost and scoped to that publisher, unlike the dynamic,
+/// app-wide metrics middleware added with `RustStream::publish_layer`. [`routes`](crate::routes)
+/// attaches it to the confirmations publisher, so every confirmation carries the header.
+pub(crate) struct StampSource;
+
+impl PublishLayer for StampSource {
+    fn apply(&self, out: &mut Outgoing) {
+        out.headers_mut()
+            .insert("x-source-service", b"orders-service".to_vec());
     }
 }

--- a/examples/routed_service/orders.rs
+++ b/examples/routed_service/orders.rs
@@ -1,50 +1,68 @@
-//! Domain types and handlers, written as `#[subscriber]` functions.
+//! Order-lifecycle handlers: confirming a new order (a publishing handler that replies and handles
+//! transient failures) and cancelling one (a plain handler that retries on a blip).
 //!
-//! The first parameter is the decoded payload; the macro turns each function into a mountable
-//! definition (a value named after the function) that [`routes`](crate::routes) collects into a
-//! [`Router`](ruststream::runtime::Router). `confirm` binds through the memory broker's
-//! [`MemorySource`](ruststream::memory::MemorySource) descriptor (the macro's descriptor form);
-//! `on_cancel` binds by plain name.
+//! Both read the shared [`Repository`](crate::domain::Repository) from the per-delivery
+//! [`Context`], inserted once by the startup hook in [`main`](crate::main).
 
 use ruststream::memory::MemorySource;
 use ruststream::runtime::HandlerResult;
 use ruststream::subscriber;
-use serde::{Deserialize, Serialize};
 
-/// An order placed on the `orders` channel.
-#[derive(Debug, Deserialize)]
-pub(crate) struct Order {
-    pub(crate) id: u64,
-    pub(crate) item: String,
-    pub(crate) quantity: u32,
-}
+use crate::domain::{Cancellation, Confirmation, Order, Repository};
 
-/// The reply published to `confirmations` for each order.
-#[derive(Debug, Serialize)]
-pub(crate) struct Confirmation {
-    pub(crate) id: u64,
-    pub(crate) accepted: bool,
-}
-
-/// Confirms an incoming order and publishes a [`Confirmation`] to `confirmations`.
+/// Confirms an order and replies on `confirmations`.
 ///
 /// Bound through the macro's descriptor form, `MemorySource::new("orders")`, rather than a bare
 /// name - the slot where a real broker takes its own descriptor (a NATS `SubscribeOptions`, say).
-/// The return value is the reply: the `publish("confirmations")` clause makes the runtime encode it
-/// and send it through the publisher wired in [`routes`](crate::routes).
+/// Returning `Result<Confirmation, HandlerResult>` keeps control of the acknowledgement: `Ok`
+/// publishes the reply and acks, while `Err` publishes nothing and hands the dispatcher a
+/// [`HandlerResult`] - here, retry on a transient store error and drop on a permanent one. The
+/// `publish("confirmations")` clause names the reply channel; its publisher is wired in
+/// [`routes`](crate::routes).
 // --8<-- [start:descriptor]
 #[subscriber(MemorySource::new("orders"), publish("confirmations"))]
-pub(crate) async fn confirm(order: &Order) -> Confirmation {
-    Confirmation {
-        id: order.id,
-        accepted: order.quantity > 0,
+pub(crate) async fn confirm(
+    order: &Order,
+    ctx: &mut Context<'_>,
+) -> Result<Confirmation, HandlerResult> {
+    let repo = ctx
+        .get::<Repository>()
+        .expect("repository set in on_startup");
+    tracing::debug!(
+        order = order.id,
+        customer = %order.customer,
+        item = %order.item,
+        "confirming order"
+    );
+    match repo.record_order(order.id).await {
+        Ok(()) => Ok(Confirmation {
+            order_id: order.id,
+            accepted: order.quantity > 0,
+        }),
+        Err(e) if e.is_transient() => {
+            tracing::warn!(order = order.id, "store busy, asking for redelivery");
+            Err(HandlerResult::retry())
+        }
+        Err(e) => {
+            tracing::error!(order = order.id, error = %e, "dropping order");
+            Err(HandlerResult::drop())
+        }
     }
 }
 // --8<-- [end:descriptor]
 
-/// Logs cancellations, bound by plain name. No reply, so it returns a plain [`HandlerResult`].
+/// Cancels an order, bound by plain name. No reply, so it returns a plain [`HandlerResult`]: retry
+/// a transient store error, ack everything else (an unknown order is nothing to undo).
+// --8<-- [start:retry]
 #[subscriber("cancellations")]
-pub(crate) async fn on_cancel(order: &Order) -> HandlerResult {
-    println!("order {} ({}) cancelled", order.id, order.item);
-    HandlerResult::Ack
+pub(crate) async fn on_cancel(cancel: &Cancellation, ctx: &mut Context<'_>) -> HandlerResult {
+    let repo = ctx
+        .get::<Repository>()
+        .expect("repository set in on_startup");
+    match repo.cancel(cancel.order_id).await {
+        // A transient blip is worth a redelivery; an unknown order (or success) is nothing to undo.
+        Err(e) if e.is_transient() => HandlerResult::retry(),
+        _ => HandlerResult::Ack,
+    }
 }
+// --8<-- [end:retry]

--- a/examples/routed_service/payments.rs
+++ b/examples/routed_service/payments.rs
@@ -1,0 +1,48 @@
+//! Payment handlers: charging a payment across keyed worker lanes, and settling a batch of cleared
+//! payments in one transaction.
+
+use ruststream::runtime::HandlerResult;
+use ruststream::subscriber;
+
+use crate::domain::{Clearing, Payment, Repository, Settlement};
+
+/// Charges a payment. `workers(8, by_key)` runs up to eight charges at once, but keyed by the
+/// message's partition key so payments for one customer keep their arrival order while different
+/// customers proceed in parallel. A transient gateway error asks for delayed redelivery rather than
+/// an immediate retry, so a flaky downstream is not hammered.
+// --8<-- [start:workers]
+#[subscriber("payments", workers(8, by_key))]
+pub(crate) async fn process_payment(payment: &Payment, ctx: &mut Context<'_>) -> HandlerResult {
+    let repo = ctx
+        .get::<Repository>()
+        .expect("repository set in on_startup");
+    tracing::debug!(order = payment.order_id, customer = %payment.customer, "charging payment");
+    if repo
+        .charge(payment.order_id, payment.amount_cents)
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry_after(std::time::Duration::from_secs(2));
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:workers]
+
+/// Settles a page of cleared payments and publishes the settlements on `settlements`. Mounted with
+/// a transactional publisher in [`routes`](crate::routes), so the whole page becomes visible
+/// atomically on commit; an empty page drops without publishing anything.
+// --8<-- [start:batch]
+#[subscriber(batch("clearings"), publish("settlements"))]
+pub(crate) async fn settle(clearings: &[Clearing]) -> Result<Vec<Settlement>, HandlerResult> {
+    if clearings.is_empty() {
+        return Err(HandlerResult::drop());
+    }
+    Ok(clearings
+        .iter()
+        .map(|c| Settlement {
+            order_id: c.order_id,
+            amount_cents: c.amount_cents,
+        })
+        .collect())
+}
+// --8<-- [end:batch]

--- a/examples/routed_service/payments.rs
+++ b/examples/routed_service/payments.rs
@@ -3,6 +3,7 @@
 
 use ruststream::runtime::HandlerResult;
 use ruststream::subscriber;
+use std::time::Duration;
 
 use crate::domain::{Clearing, Payment, Repository, Settlement};
 
@@ -22,7 +23,7 @@ pub(crate) async fn process_payment(payment: &Payment, ctx: &mut Context<'_>) ->
         .await
         .is_err()
     {
-        return HandlerResult::retry_after(std::time::Duration::from_secs(2));
+        return HandlerResult::retry_after(Duration::from_secs(2));
     }
     HandlerResult::Ack
 }
@@ -30,19 +31,17 @@ pub(crate) async fn process_payment(payment: &Payment, ctx: &mut Context<'_>) ->
 
 /// Settles a page of cleared payments and publishes the settlements on `settlements`. Mounted with
 /// a transactional publisher in [`routes`](crate::routes), so the whole page becomes visible
-/// atomically on commit; an empty page drops without publishing anything.
+/// atomically on commit. The batch contract guarantees a non-empty page, so the handler maps it
+/// straight to replies; returning the bare `Vec` publishes them all and acks the batch.
 // --8<-- [start:batch]
 #[subscriber(batch("clearings"), publish("settlements"))]
-pub(crate) async fn settle(clearings: &[Clearing]) -> Result<Vec<Settlement>, HandlerResult> {
-    if clearings.is_empty() {
-        return Err(HandlerResult::drop());
-    }
-    Ok(clearings
+pub(crate) async fn settle(clearings: &[Clearing]) -> Vec<Settlement> {
+    clearings
         .iter()
         .map(|c| Settlement {
             order_id: c.order_id,
             amount_cents: c.amount_cents,
         })
-        .collect())
+        .collect()
 }
 // --8<-- [end:batch]

--- a/examples/routed_service/routes.rs
+++ b/examples/routed_service/routes.rs
@@ -1,26 +1,56 @@
-//! Wiring: collect the [`orders`](crate::orders) handlers into one [`Router`].
+//! Wiring: collect the handlers into two [`Router`]s, one per concern. Keeping registration in its
+//! own module lets the handlers stay broker-agnostic - a router binds to a concrete broker only
+//! when [`main`](crate::main) mounts it with `include_router`.
 //!
-//! Keeping registration in its own module lets the handlers stay broker-agnostic - the router binds
-//! to a concrete broker only when [`main`](crate::main) mounts it with `include_router`.
+//! Each router carries the metrics consume layer with [`Router::layer`], scoping that metric to the
+//! routed handlers; a router knows its own handler types, so it wraps them directly. (The layer is
+//! also a `BlanketLayer`, so it could ride the application-wide stack instead - here it stays per
+//! router to keep metrics local and to exercise `Router::layer`.) The publish-side metric is added
+//! once on the application in [`main`](crate::main).
 
 use ruststream::memory::MemoryBroker;
+use ruststream::metrics::Metrics;
 use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 
-use crate::orders;
+use crate::{orders, payments};
 
-/// Builds the orders router: a publishing handler (replies to `confirmations`) plus a plain one.
+/// The order-lifecycle router: a publishing handler that replies to `confirmations`, plus the
+/// cancellation handler.
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
 /// with the default codec, and `include_publishing` reuses that codec to decode the order.
-/// `on_cancel` has no reply, so it is mounted with `include` (also the default codec). The router is
-/// a consuming builder, so the calls chain; the registration list is opaque, hence `impl RouterDef`.
+/// `on_cancel` has no reply, so it is mounted with `include`. The router is a consuming builder, so
+/// the calls chain; the registration list is opaque, hence `impl RouterDef`.
 ///
-/// `use<>` opts out of capturing the `broker` borrow: the router owns its publisher (Arc-backed), so
-/// it does not borrow the broker, and the caller can still mutate the scope to mount it.
-pub(crate) fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
+/// `use<>` opts out of capturing the `broker`/`metrics` borrows: the router owns its publisher and
+/// layer (both `Arc`-backed), so it borrows neither argument past this call, and the caller can
+/// still mutate the scope to mount it.
+pub(crate) fn orders(
+    broker: &MemoryBroker,
+    metrics: &Metrics,
+) -> impl RouterDef<MemoryBroker> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher());
 
     Router::new()
+        .layer(metrics.consume_layer())
         .include_publishing(orders::confirm, confirmations)
         .include(orders::on_cancel)
+}
+
+/// The payments router: a charge handler spread across keyed worker lanes, plus a batch handler
+/// that settles cleared payments through a transactional publisher.
+///
+/// `.transactional()` exists only because the in-memory `MemoryPublisher` implements
+/// `TransactionalPublisher`; with it, `include_batch_publishing` buffers a page's replies and
+/// commits them atomically.
+pub(crate) fn payments(
+    broker: &MemoryBroker,
+    metrics: &Metrics,
+) -> impl RouterDef<MemoryBroker> + use<> {
+    let settlements = TypedPublisher::new(broker.publisher()).transactional();
+
+    Router::new()
+        .layer(metrics.consume_layer())
+        .include(payments::process_payment)
+        .include_batch_publishing(payments::settle, settlements)
 }

--- a/examples/routed_service/routes.rs
+++ b/examples/routed_service/routes.rs
@@ -12,15 +12,19 @@ use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
 use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 
+use crate::observability::StampSource;
 use crate::{orders, payments};
 
 /// The order-lifecycle router: a publishing handler that replies to `confirmations`, plus the
 /// cancellation handler.
 ///
 /// `confirm` needs a publisher for its reply; `TypedPublisher::new` pairs the broker's publisher
-/// with the default codec, and `include_publishing` reuses that codec to decode the order.
-/// `on_cancel` has no reply, so it is mounted with `include`. The router is a consuming builder, so
-/// the calls chain; the registration list is opaque, hence `impl RouterDef`.
+/// with the default codec, and `.layer(StampSource)` composes a static publish layer onto it that
+/// stamps a provenance header on every confirmation - publisher settings live here, on the
+/// `TypedPublisher`, not in the `publish("..")` decorator (which only names the destination).
+/// `include_publishing` reuses the publisher's codec to decode the order. `on_cancel` has no reply,
+/// so it is mounted with `include`. The router is a consuming builder, so the calls chain; the
+/// registration list is opaque, hence `impl RouterDef`.
 ///
 /// `use<>` opts out of capturing the `broker`/`metrics` borrows: the router owns its publisher and
 /// layer (both `Arc`-backed), so it borrows neither argument past this call, and the caller can
@@ -29,7 +33,7 @@ pub(crate) fn orders(
     broker: &MemoryBroker,
     metrics: &Metrics,
 ) -> impl RouterDef<MemoryBroker> + use<> {
-    let confirmations = TypedPublisher::new(broker.publisher());
+    let confirmations = TypedPublisher::new(broker.publisher()).layer(StampSource);
 
     Router::new()
         .layer(metrics.consume_layer())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -33,7 +33,7 @@ use prometheus::{
 };
 
 use crate::runtime::{
-    Context, Handler, HandlerResult, Layer, Outgoing, PublishMiddleware, PublishNext,
+    BlanketLayer, Context, Handler, HandlerResult, Layer, Outgoing, PublishMiddleware, PublishNext,
 };
 
 /// Default histogram buckets (seconds) for handler duration.
@@ -185,6 +185,20 @@ impl<H> Layer<H> for MetricsLayer {
             inner,
             metrics: Arc::clone(&self.inner),
         }
+    }
+}
+
+// Lets the consume metric ride the application-wide stack and reach handlers mounted through a
+// router (whose concrete types the router hides), the same way [`TracingLayer`] does. The wrapped
+// `MetricsHandler<H>` is already `Handler<M>` for any `H: Handler<M>`, so the blanket form just
+// delegates to the static one.
+impl BlanketLayer for MetricsLayer {
+    fn apply<M, H>(&self, handler: H) -> impl Handler<M> + 'static
+    where
+        M: Send + Sync + 'static,
+        H: Handler<M> + 'static,
+    {
+        self.layer(handler)
     }
 }
 

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -13,7 +13,11 @@ use tracing::warn;
 
 use super::lifecycle::BoxError;
 use super::publisher_registry::ErasedPublisher;
-use crate::codec::{Codec, DefaultCodec};
+use crate::codec::Codec;
+// `DefaultCodec` only exists when a codec feature is on; the impl that names it is gated the same
+// way, so an ungated import would break `--no-default-features`.
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+use crate::codec::DefaultCodec;
 use crate::runtime::publish::sealed::Sealed;
 use crate::{Headers, Publisher, TransactionalPublisher};
 

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -11,9 +11,9 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use serde::Serialize;
 use tracing::warn;
 
-use crate::codec::Codec;
+use crate::codec::{Codec, DefaultCodec};
 use crate::{Headers, Publisher, TransactionalPublisher};
-
+use crate::runtime::publish::sealed::Sealed;
 use super::lifecycle::BoxError;
 use super::publisher_registry::ErasedPublisher;
 
@@ -256,12 +256,12 @@ impl<P, C> TypedPublisher<P, C, PublishIdentity> {
 }
 
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
-impl<P> TypedPublisher<P, crate::codec::DefaultCodec, PublishIdentity> {
-    /// Pairs `publisher` with the [`DefaultCodec`](crate::codec::DefaultCodec) and no static
+impl<P> TypedPublisher<P, DefaultCodec, PublishIdentity> {
+    /// Pairs `publisher` with the [`DefaultCodec`](DefaultCodec) and no static
     /// transforms. Use [`with_codec`](Self::with_codec) to name a codec explicitly.
     #[must_use]
     pub fn new(publisher: P) -> Self {
-        Self::with_codec(publisher, crate::codec::DefaultCodec::default())
+        Self::with_codec(publisher, DefaultCodec::default())
     }
 }
 
@@ -359,7 +359,7 @@ mod sealed {
 /// Implemented by a plain [`TypedPublisher`] (each reply published independently) and by a
 /// [`Transactional`] one (all replies of a batch inside one transaction). Sealed: implemented by
 /// exactly those two types.
-pub trait ReplyPublisher: sealed::Sealed + Send + Sync {
+pub trait ReplyPublisher: Sealed + Send + Sync {
     /// The codec replies are encoded with (also reused as the decode codec when a batch
     /// publishing handler is mounted without an explicit one).
     type Codec: Codec;

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -11,11 +11,11 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use serde::Serialize;
 use tracing::warn;
 
-use crate::codec::{Codec, DefaultCodec};
-use crate::{Headers, Publisher, TransactionalPublisher};
-use crate::runtime::publish::sealed::Sealed;
 use super::lifecycle::BoxError;
 use super::publisher_registry::ErasedPublisher;
+use crate::codec::{Codec, DefaultCodec};
+use crate::runtime::publish::sealed::Sealed;
+use crate::{Headers, Publisher, TransactionalPublisher};
 
 type PublishFut<'a> = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'a>>;
 

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -124,7 +124,14 @@ async fn undecodable_elements_never_reach_the_handler() {
                 .publish(OutgoingMessage::new("mixed", &order_bytes(2)))
                 .await;
             handler_signal(&SIFT_NOTIFY).await;
-            if GOOD_IDS.lock().unwrap().len() >= 2 {
+            // Subscriptions open inside run(), so the first publishes can be lost and the loop
+            // republishes; wait until both decodable ids have actually arrived rather than for a
+            // bare count, which a partial first batch would satisfy out of order.
+            let both_seen = {
+                let seen = GOOD_IDS.lock().unwrap();
+                seen.contains(&1) && seen.contains(&2)
+            };
+            if both_seen {
                 break;
             }
         }
@@ -132,9 +139,13 @@ async fn undecodable_elements_never_reach_the_handler() {
     .await;
     assert!(result.is_ok(), "decodable elements did not arrive");
 
-    // Only decodable elements reach the handler; the garbage one is dropped individually.
+    // The undecodable element is dropped individually, never failing the batch around it: only the
+    // two decodable ids ever reach the handler (the loop above already confirmed both did).
     let ids = GOOD_IDS.lock().unwrap().clone();
-    assert!(ids.starts_with(&[1, 2]), "got {ids:?}");
+    assert!(
+        ids.iter().all(|&id| id == 1 || id == 2),
+        "an undecodable element reached the handler: {ids:?}"
+    );
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
-use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, RustStream};
+use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, Router, RustStream};
 use ruststream::{Name, OutgoingMessage, Publisher};
 use tokio::sync::Notify;
 
@@ -51,6 +51,55 @@ async fn consume_metrics_are_recorded() {
     let text = metrics.export().unwrap();
     assert!(text.contains(r#"ruststream_messages_consumed_total{name="pings",status="ack"}"#));
     assert!(text.contains("ruststream_consume_duration_seconds"));
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn consume_metrics_are_recorded_through_a_router() {
+    let metrics = Metrics::with_registry(prometheus::Registry::new()).unwrap();
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    // The consume layer rides a Router (via `Router::layer`) and must still reach the
+    // router-mounted handler, whose concrete type the router hides. That works only because
+    // `MetricsLayer` implements `BlanketLayer`.
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(Router::new().layer(metrics.consume_layer()).subscribe(
+            Name::new("pings"),
+            |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
+            HandlerMetadata::raw("pings"),
+        ));
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+
+    let recorded = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("pings", b"{}"))
+                .await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            if metrics
+                .export()
+                .unwrap()
+                .contains("ruststream_messages_consumed_total")
+            {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        recorded.is_ok(),
+        "consume metric was never recorded for a router handler"
+    );
+
+    let text = metrics.export().unwrap();
+    assert!(text.contains(r#"ruststream_messages_consumed_total{name="pings",status="ack"}"#));
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();


### PR DESCRIPTION
# Description

Grows `examples/routed_service/` into the flagship production sample (item 12 of the 0.3.1 cleanup): a six-module order-processing service - `domain`, `orders`, `payments`, `observability`, `routes`, `main` - exercising shared state with lifecycle hooks, retry / `retry_after`, keyed worker lanes, a transactional batch publisher, an app-wide `BlanketLayer`, a static publish `PublishLayer`, consume- and publish-side metrics, and a server spec. `run` starts it; `asyncapi gen` emits a four-channel AsyncAPI document.

Building it surfaced one framework gap and a few follow-ups, all included here:

- `MetricsLayer` now implements `BlanketLayer`, so the consume metric works with `include_router` (it could not before). Additive, pinned by a new test in `tests/metrics.rs`.
- Removed the unreachable empty-batch guard in `settle` (the batch contract guarantees a non-empty page).
- Made the flaky `undecodable_elements_never_reach_the_handler` test order- and timing-independent.
- Gated the `DefaultCodec` import behind the codec features so `cargo check --no-default-features` builds.
- The coverage job now exports a per-crate table to the run's job summary and an `lcov.info` artifact.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable