### PR TITLE
docs: resolve the nine rustdoc link warnings

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -47,7 +47,7 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns [`Self::Error`] when the broker refuses to start a transaction, for example
+    /// Returns `Self::Error` when the broker refuses to start a transaction, for example
     /// because transactions are already in progress or the broker is misconfigured.
     ///
     /// [`commit`]: Self::commit
@@ -58,7 +58,7 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns [`Self::Error`] when the broker rejects the commit. The transaction state after
+    /// Returns `Self::Error` when the broker rejects the commit. The transaction state after
     /// a failed commit is implementation-defined; implementors must document it.
     fn commit(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
@@ -66,7 +66,7 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns [`Self::Error`] when the broker rejects the abort.
+    /// Returns `Self::Error` when the broker rejects the abort.
     fn abort(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
@@ -83,7 +83,7 @@ pub trait RequestReply: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns [`Self::Error`] when the broker rejects the publish, the reply times out, or
+    /// Returns `Self::Error` when the broker rejects the publish, the reply times out, or
     /// the underlying transport fails before a reply arrives.
     fn request(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use ruststream_macros::subscriber;
 /// Attribute macro that generates a `main` entry point from a `RustStream` builder function.
 ///
 /// Available with the `macros` feature. See [`ruststream_macros::app`] and
-/// [`runtime::cli`](crate::runtime::cli).
+/// [`runtime::cli`].
 #[cfg(feature = "macros")]
 pub use ruststream_macros::app;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-//! Colorful, environment-driven console logging built on [`tracing-subscriber`].
+//! Colorful, environment-driven console logging built on [`tracing_subscriber`].
 //!
 //! RustStream emits structured [`tracing`] events throughout dispatch, publishing and the service
 //! lifecycle, but - like any well-behaved library - installs no subscriber on its own. That choice

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Prometheus metrics for consume and publish paths.
 //!
-//! A single [`Metrics`] object owns the counters and the [`Registry`](prometheus::Registry) they are
+//! A single [`Metrics`] object owns the counters and the [`Registry`] they are
 //! registered in, and hands out two middleware: a static consume-side [`Layer`] and a publish-side
 //! [`PublishMiddleware`]. Both share the same registry, so one [`Metrics::export`] renders the whole
 //! picture. The registry is the global default unless you pass your own.

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -103,7 +103,7 @@ pub(crate) fn batch_publishing_metadata<D: BatchPublishingDef>(
         )
 }
 
-/// The [`BatchHandler`] built from a [`BatchPublishingDef`]: decode the batch, run the handler,
+/// The `BatchHandler` built from a [`BatchPublishingDef`]: decode the batch, run the handler,
 /// publish the replies through the [`ReplyPublisher`], then ack the batch.
 ///
 /// Elements that fail to decode are nacked individually and never reach the handler. A failed

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -223,7 +223,7 @@ impl<Inner: PublishLayer, Outer: PublishLayer> PublishLayer for PublishStack<Inn
 /// The publish-side counterpart to a typed subscriber: it carries *how* a value is encoded and the
 /// per-publisher transforms ([`layer`](Self::layer)), while *where* it goes (the destination name)
 /// is supplied per send - so one `TypedPublisher` is reused across handlers replying to different
-/// names. The [`#[subscriber(.., publish("name"))]`](macro) reply form supplies the name; the
+/// names. The `#[subscriber(.., publish("name"))]` reply form supplies the name; the
 /// `TypedPublisher` is passed at wiring.
 ///
 /// ```


### PR DESCRIPTION
# Description

`cargo doc --all-features` emitted nine pre-existing warnings. This is a documentation-only cleanup that resolves all of them:

- four `Self::Error` intra-doc links in `capability.rs` that do not resolve through the `Publisher` supertrait -> plain code spans;
- a `[...](macro)` link in `publish.rs` and a `[`tracing-subscriber`]` link in `logging.rs` that point at nothing -> a code span and the correct `tracing_subscriber` crate link;
- a doc link to the private `BatchHandler` in `batch_publishing.rs` -> a code span;
- two redundant explicit link targets (`metrics.rs`, `lib.rs`) -> the bare intra-doc link.

`cargo doc --no-deps --all-features` is now warning-free under `RUSTDOCFLAGS="-D warnings"`.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)