### PR TITLE
refactor: split the memory broker TestClient into its own module

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -16,6 +16,7 @@
 //! [`MemoryPublisher`], and partition keys on [`MemoryMessage`].
 
 mod capability;
+mod test_client;
 
 pub use capability::{MemoryRequester, PARTITION_KEY_HEADER, RequestError};
 
@@ -28,14 +29,11 @@ use std::{
 
 use crate::{
     AckError, Broker, Headers, IncomingMessage, OutgoingMessage, Publisher, RawMessage, Subscribe,
-    Subscriber, SubscriptionSource, testing::TestClient,
+    Subscriber, SubscriptionSource,
 };
 use bytes::Bytes;
 use futures::Stream;
-use tokio::{
-    sync::{Notify, mpsc},
-    time::timeout,
-};
+use tokio::sync::{Notify, mpsc};
 
 type Sender = mpsc::UnboundedSender<MemoryDelivery>;
 
@@ -397,78 +395,6 @@ impl IncomingMessage for MemoryMessage {
             let _ = requeue.send(delivery);
         });
         Ok(())
-    }
-}
-
-impl TestClient for MemoryBroker {
-    type Broker = Self;
-    type Subscriber = MemorySubscriber;
-    type Publisher = MemoryPublisher;
-    type Error = Infallible;
-
-    async fn start() -> Result<Self, Self::Error> {
-        Ok(Self::new())
-    }
-
-    fn broker(&self) -> &Self::Broker {
-        self
-    }
-
-    async fn publish(&self, name: &str, payload: &[u8]) -> Result<(), Self::Error> {
-        let publisher = Self::publisher(self);
-        publisher.publish(OutgoingMessage::new(name, payload)).await
-    }
-
-    async fn subscribe(&self, name: &str) -> Result<Self::Subscriber, Self::Error> {
-        Ok(Self::subscribe(self, name))
-    }
-
-    async fn publisher(&self) -> Result<Self::Publisher, Self::Error> {
-        Ok(Self::publisher(self))
-    }
-
-    async fn expect_published(
-        &self,
-        name: &str,
-        count: usize,
-        timeout_duration: Duration,
-    ) -> Result<Vec<RawMessage>, Self::Error> {
-        let name_for_wait = name.to_owned();
-        let name_for_fallback = name_for_wait.clone();
-        let state = Arc::clone(&self.state);
-
-        let wait = async move {
-            loop {
-                {
-                    let log = state
-                        .published
-                        .lock()
-                        .expect("memory broker mutex poisoned");
-                    if let Some(messages) = log.get(&name_for_wait) {
-                        if messages.len() >= count {
-                            return messages.iter().take(count).cloned().collect::<Vec<_>>();
-                        }
-                    }
-                }
-                state.notify.notified().await;
-            }
-        };
-
-        let result = timeout(timeout_duration, wait).await;
-        let messages = result.unwrap_or_else(|_| {
-            self.state
-                .published
-                .lock()
-                .expect("memory broker mutex poisoned")
-                .get(&name_for_fallback)
-                .map(|m| m.iter().take(count).cloned().collect())
-                .unwrap_or_default()
-        });
-        Ok(messages)
-    }
-
-    async fn shutdown(self) -> Result<(), Self::Error> {
-        <Self as Broker>::shutdown(&self).await
     }
 }
 

--- a/src/memory/test_client.rs
+++ b/src/memory/test_client.rs
@@ -1,0 +1,84 @@
+//! [`TestClient`] for the in-memory broker.
+//!
+//! The in-process broker doubles as its own test client: `start` is a plain constructor,
+//! `expect_published` reads the broker's published-message log, and the rest delegate to the
+//! inherent broker operations. There is no separate in-memory simulation to stand up.
+
+use std::{convert::Infallible, sync::Arc, time::Duration};
+
+use tokio::time::timeout;
+
+use super::{MemoryBroker, MemoryPublisher, MemorySubscriber};
+use crate::{Broker, OutgoingMessage, Publisher, RawMessage, testing::TestClient};
+
+impl TestClient for MemoryBroker {
+    type Broker = Self;
+    type Subscriber = MemorySubscriber;
+    type Publisher = MemoryPublisher;
+    type Error = Infallible;
+
+    async fn start() -> Result<Self, Self::Error> {
+        Ok(Self::new())
+    }
+
+    fn broker(&self) -> &Self::Broker {
+        self
+    }
+
+    async fn publish(&self, name: &str, payload: &[u8]) -> Result<(), Self::Error> {
+        let publisher = Self::publisher(self);
+        publisher.publish(OutgoingMessage::new(name, payload)).await
+    }
+
+    async fn subscribe(&self, name: &str) -> Result<Self::Subscriber, Self::Error> {
+        Ok(Self::subscribe(self, name))
+    }
+
+    async fn publisher(&self) -> Result<Self::Publisher, Self::Error> {
+        Ok(Self::publisher(self))
+    }
+
+    async fn expect_published(
+        &self,
+        name: &str,
+        count: usize,
+        timeout_duration: Duration,
+    ) -> Result<Vec<RawMessage>, Self::Error> {
+        let name_for_wait = name.to_owned();
+        let name_for_fallback = name_for_wait.clone();
+        let state = Arc::clone(&self.state);
+
+        let wait = async move {
+            loop {
+                {
+                    let log = state
+                        .published
+                        .lock()
+                        .expect("memory broker mutex poisoned");
+                    if let Some(messages) = log.get(&name_for_wait) {
+                        if messages.len() >= count {
+                            return messages.iter().take(count).cloned().collect::<Vec<_>>();
+                        }
+                    }
+                }
+                state.notify.notified().await;
+            }
+        };
+
+        let result = timeout(timeout_duration, wait).await;
+        let messages = result.unwrap_or_else(|_| {
+            self.state
+                .published
+                .lock()
+                .expect("memory broker mutex poisoned")
+                .get(&name_for_fallback)
+                .map(|m| m.iter().take(count).cloned().collect())
+                .unwrap_or_default()
+        });
+        Ok(messages)
+    }
+
+    async fn shutdown(self) -> Result<(), Self::Error> {
+        <Self as Broker>::shutdown(&self).await
+    }
+}


### PR DESCRIPTION
# Description

`src/memory/mod.rs` sat at 537 lines, over the project's ~500-line file-size guideline (the
last `src/` file clearly over it - see the file-size DoD gate in the local backlog). The
`impl TestClient for MemoryBroker` block is a self-contained concern (the in-memory broker
doubling as its own test client) and the only natural seam.

This moves that impl into a child `memory::test_client` module. A child module sees its parent's
private items, so the impl still reaches the private `MemoryState` fields (`published`, `notify`)
and `MemoryBroker::state` with no visibility changes. `mod.rs` drops to 463 lines; the `timeout`
import and the now-unused `testing::TestClient` import move with the impl.

Pure move, no behaviour change. Every public path stays byte-identical.

## Type of change

- [x] Other: internal refactor (file split, no API or behaviour change)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)