### PR TITLE
test: pin macro diagnostics with trybuild UI snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,15 @@ jobs:
 
       # The intermediate toolchains exist to prove the build (the two checks
       # above); the full suite runs at the edges of the range only.
+      #
+      # The trybuild UI snapshots in tests/ui are rustc-version-sensitive, so they
+      # run on stable only: RUN_UI_TESTS=1 opts the `ui` test in here, every other
+      # run (the 1.85 job, the coverage job, a local `cargo test`) leaves it unset
+      # and the test skips itself.
       - name: cargo test
         if: matrix.toolchain == 'stable' || matrix.toolchain == '1.85'
+        env:
+          RUN_UI_TESTS: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
         run: cargo test --workspace --all-features
 
   coverage:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
 ]
 
 [[package]]
@@ -1597,6 +1604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1777,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1931,6 +1962,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2088,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -2173,6 +2258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2353,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,10 @@ required-features = ["macros", "memory", "json"]
 name = "doc_testing_nats"
 required-features = ["macros", "json"]
 
+[[test]]
+name = "ui"
+required-features = ["macros", "memory", "json"]
+
 [package]
 name = "ruststream"
 version.workspace = true
@@ -216,6 +220,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tempfile = "3"
 axum = "0.8"
 ruststream-nats = { version = "0.3", features = ["testing"] }
+trybuild = "1"
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,24 @@
+//! Compile-fail snapshots for the `ruststream-macros` diagnostics.
+//!
+//! Each `tests/ui/*.rs` case feeds the `#[subscriber]` / `#[ruststream::app]` / `derive(Message)`
+//! macros a misuse and pins the compile error against a `.stderr` snapshot, so a regression in a
+//! macro's diagnostics (a reworded or dropped message, a shifted span) fails the build.
+//!
+//! The snapshots are rustc-version-sensitive, and CI builds a 1.85..stable matrix, so they are
+//! pinned to a single toolchain: the run sets `RUN_UI_TESTS=1` (only the stable `cargo test` job
+//! does), and every other run - the 1.85 job, a local `cargo test` without the flag - skips. To
+//! refresh the snapshots after an intentional message change, run on stable:
+//!
+//! ```text
+//! TRYBUILD=overwrite RUN_UI_TESTS=1 cargo test --test ui --features macros,memory,json
+//! ```
+
+#[test]
+fn ui() {
+    if std::env::var("RUN_UI_TESTS").as_deref() != Ok("1") {
+        eprintln!("skipping trybuild UI tests; set RUN_UI_TESTS=1 (stable toolchain) to run them");
+        return;
+    }
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/ui/app_async_builder.rs
+++ b/tests/ui/app_async_builder.rs
@@ -1,0 +1,9 @@
+use ruststream::app;
+
+// The app builder is synchronous: the runtime calls it before the async runtime is up.
+#[app]
+async fn build() -> u8 {
+    0
+}
+
+fn main() {}

--- a/tests/ui/app_async_builder.stderr
+++ b/tests/ui/app_async_builder.stderr
@@ -1,0 +1,5 @@
+error: #[ruststream::app] requires a synchronous builder returning `RustStream`
+ --> tests/ui/app_async_builder.rs:5:1
+  |
+5 | async fn build() -> u8 {
+  | ^^^^^

--- a/tests/ui/app_builder_takes_arguments.rs
+++ b/tests/ui/app_builder_takes_arguments.rs
@@ -1,0 +1,9 @@
+use ruststream::app;
+
+// The app builder takes no arguments; it just constructs and returns the application.
+#[app]
+fn build(flag: u8) -> u8 {
+    flag
+}
+
+fn main() {}

--- a/tests/ui/app_builder_takes_arguments.stderr
+++ b/tests/ui/app_builder_takes_arguments.stderr
@@ -1,0 +1,5 @@
+error: #[ruststream::app] builder must take no arguments
+ --> tests/ui/app_builder_takes_arguments.rs:5:10
+  |
+5 | fn build(flag: u8) -> u8 {
+  |          ^^^^^^^^

--- a/tests/ui/app_takes_arguments.rs
+++ b/tests/ui/app_takes_arguments.rs
@@ -1,0 +1,9 @@
+use ruststream::app;
+
+// `#[ruststream::app]` is a bare attribute; it accepts no arguments.
+#[app(something)]
+fn build() -> u8 {
+    0
+}
+
+fn main() {}

--- a/tests/ui/app_takes_arguments.stderr
+++ b/tests/ui/app_takes_arguments.stderr
@@ -1,0 +1,5 @@
+error: #[ruststream::app] takes no arguments
+ --> tests/ui/app_takes_arguments.rs:4:7
+  |
+4 | #[app(something)]
+  |       ^^^^^^^^^

--- a/tests/ui/subscriber_batch_publish_not_vec.rs
+++ b/tests/ui/subscriber_batch_publish_not_vec.rs
@@ -1,0 +1,9 @@
+use ruststream::subscriber;
+
+// A batch publishing handler replies with a `Vec`; a scalar return is rejected.
+#[subscriber(batch("orders"), publish("done"))]
+async fn handle(orders: &[u8]) -> u8 {
+    0
+}
+
+fn main() {}

--- a/tests/ui/subscriber_batch_publish_not_vec.stderr
+++ b/tests/ui/subscriber_batch_publish_not_vec.stderr
@@ -1,0 +1,5 @@
+error: a batch publishing handler returns the replies: Vec<Reply>, or Result<Vec<Reply>, HandlerResult>
+ --> tests/ui/subscriber_batch_publish_not_vec.rs:5:35
+  |
+5 | async fn handle(orders: &[u8]) -> u8 {
+  |                                   ^^

--- a/tests/ui/subscriber_batch_two_args.rs
+++ b/tests/ui/subscriber_batch_two_args.rs
@@ -1,0 +1,7 @@
+use ruststream::subscriber;
+
+// `batch(..)` wraps exactly one source; it is a marker, not a multi-argument constructor.
+#[subscriber(batch("a", "b"))]
+async fn handle(orders: &[u8]) {}
+
+fn main() {}

--- a/tests/ui/subscriber_batch_two_args.stderr
+++ b/tests/ui/subscriber_batch_two_args.stderr
@@ -1,0 +1,5 @@
+error: batch(..) takes exactly one source argument
+ --> tests/ui/subscriber_batch_two_args.rs:4:14
+  |
+4 | #[subscriber(batch("a", "b"))]
+  |              ^^^^^^^^^^^^^^^

--- a/tests/ui/subscriber_duplicate_publish.rs
+++ b/tests/ui/subscriber_duplicate_publish.rs
@@ -1,0 +1,7 @@
+use ruststream::subscriber;
+
+// A subscriber has at most one reply destination; a second `publish(..)` is rejected.
+#[subscriber("orders", publish("a"), publish("b"))]
+async fn handle(order: &u8) {}
+
+fn main() {}

--- a/tests/ui/subscriber_duplicate_publish.stderr
+++ b/tests/ui/subscriber_duplicate_publish.stderr
@@ -1,0 +1,5 @@
+error: duplicate publish(..)
+ --> tests/ui/subscriber_duplicate_publish.rs:4:38
+  |
+4 | #[subscriber("orders", publish("a"), publish("b"))]
+  |                                      ^^^^^^^

--- a/tests/ui/subscriber_publish_not_str.rs
+++ b/tests/ui/subscriber_publish_not_str.rs
@@ -1,0 +1,7 @@
+use ruststream::subscriber;
+
+// `publish(..)` takes the reply topic as a string literal; an integer is rejected.
+#[subscriber("orders", publish(123))]
+async fn handle(order: &u8) {}
+
+fn main() {}

--- a/tests/ui/subscriber_publish_not_str.stderr
+++ b/tests/ui/subscriber_publish_not_str.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+ --> tests/ui/subscriber_publish_not_str.rs:4:32
+  |
+4 | #[subscriber("orders", publish(123))]
+  |                                ^^^

--- a/tests/ui/subscriber_unknown_clause.rs
+++ b/tests/ui/subscriber_unknown_clause.rs
@@ -1,0 +1,7 @@
+use ruststream::subscriber;
+
+// Only `publish(..)` and `workers(..)` clauses follow the source; anything else is rejected.
+#[subscriber("orders", frobnicate)]
+async fn handle(order: &u8) {}
+
+fn main() {}

--- a/tests/ui/subscriber_unknown_clause.stderr
+++ b/tests/ui/subscriber_unknown_clause.stderr
@@ -1,0 +1,5 @@
+error: expected `publish("reply-topic")` or `workers(n[, by_key])`
+ --> tests/ui/subscriber_unknown_clause.rs:4:24
+  |
+4 | #[subscriber("orders", frobnicate)]
+  |                        ^^^^^^^^^^

--- a/tests/ui/subscriber_workers_bad_marker.rs
+++ b/tests/ui/subscriber_workers_bad_marker.rs
@@ -1,0 +1,7 @@
+use ruststream::subscriber;
+
+// The optional second `workers(..)` argument must be the literal `by_key` marker.
+#[subscriber("orders", workers(8, nope))]
+async fn handle(order: &u8) {}
+
+fn main() {}

--- a/tests/ui/subscriber_workers_bad_marker.stderr
+++ b/tests/ui/subscriber_workers_bad_marker.stderr
@@ -1,0 +1,5 @@
+error: expected `by_key`: workers(n) or workers(n, by_key)
+ --> tests/ui/subscriber_workers_bad_marker.rs:4:35
+  |
+4 | #[subscriber("orders", workers(8, nope))]
+  |                                   ^^^^


### PR DESCRIPTION
# Description

The `#[subscriber]` and `#[ruststream::app]` macros emit hand-written diagnostics on misuse, but
nothing guarded their wording or spans, so a reword or a span shift could regress silently. This
adds a `trybuild` compile-fail suite that snapshots them (the last open DX gate in the local
backlog).

Nine cases under `tests/ui` cover:

- the subscriber argument parser: `publish(..)` takes a string, an unknown trailing clause,
  `batch(..)` arity, the `workers(.., by_key)` marker, a duplicate `publish(..)`, and a
  batch-publishing handler with a non-`Vec` return;
- the app macro: no attribute arguments, a synchronous builder, no builder arguments.

## Version sensitivity

`trybuild` `.stderr` snapshots are rustc-version-sensitive and CI spans a 1.85..stable matrix, so
the `ui` test is opt-in. It runs only when `RUN_UI_TESTS=1`, which the stable `cargo test` job now
sets; the 1.85 job, the coverage job, and a plain local `cargo test` leave it unset and the test
skips itself. Refresh the snapshots on stable with:

```text
TRYBUILD=overwrite RUN_UI_TESTS=1 cargo test --test ui --features macros,memory,json
```

## Type of change

- [x] New feature (a non-breaking change that adds functionality): test-only, no public API change

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`; UI suite verified with `RUN_UI_TESTS=1`)