### PR TITLE
test: cover the non-default codecs end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,15 @@ jobs:
       - name: cargo check (all features)
         run: cargo check --workspace --all-targets --all-features
 
+      # The `DefaultCodec` fallback aliases (cbor, then msgpack) are cfg'd out whenever `json` is
+      # on, so neither the all-features build nor the all-features tests ever compile them. Build
+      # each single-codec configuration so the alias and its default-codec call sites stay valid.
+      - name: cargo check (single-codec default fallbacks)
+        if: matrix.toolchain == 'stable'
+        run: |
+          cargo check --no-default-features --features cbor,memory,macros
+          cargo check --no-default-features --features msgpack,memory,macros
+
       # The intermediate toolchains exist to prove the build (the two checks
       # above); the full suite runs at the edges of the range only.
       - name: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ name = "batch_subscriber"
 required-features = ["macros", "memory", "json"]
 
 [[test]]
+name = "codecs"
+required-features = ["macros", "memory", "cbor", "msgpack"]
+
+[[test]]
 name = "composition_rules"
 required-features = ["macros", "memory", "json"]
 

--- a/tests/codecs.rs
+++ b/tests/codecs.rs
@@ -1,0 +1,100 @@
+//! Integration coverage for the non-default codecs through the real router include path.
+//!
+//! The codec unit tests in `src/codec/*` prove each codec round-trips in isolation; this drives a
+//! `CborCodec` and a `MsgpackCodec` end to end - named on a router with `with_codec`, mounted on a
+//! live app, fed wire bytes that codec produced, and decoded back into a typed handler argument.
+//! Without this, only the default `json` codec ever travelled the dispatch path.
+#![cfg(all(feature = "macros", feature = "cbor", feature = "msgpack"))]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use common::handler_signal;
+use ruststream::codec::{CborCodec, Codec, MsgpackCodec};
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+static CBOR_SEEN: AtomicUsize = AtomicUsize::new(0);
+static MSGPACK_SEEN: AtomicUsize = AtomicUsize::new(0);
+static NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("orders-cbor")]
+async fn cbor_order(order: &Order) -> HandlerResult {
+    assert_eq!(order.id, 7);
+    CBOR_SEEN.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("orders-msgpack")]
+async fn msgpack_order(order: &Order) -> HandlerResult {
+    assert_eq!(order.id, 7);
+    MSGPACK_SEEN.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// A `cbor` router and a `msgpack` router share one app: each decodes payloads its own codec
+/// encoded, proving the router-scope codec selection works for the non-default codecs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_default_codecs_dispatch_through_the_router() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let cbor_router = Router::<MemoryBroker>::new()
+        .with_codec(CborCodec)
+        .include(cbor_order);
+    let msgpack_router = Router::<MemoryBroker>::new()
+        .with_codec(MsgpackCodec)
+        .include(msgpack_order);
+
+    let app = RustStream::new(AppInfo::new("codecs", "0.1.0")).with_broker(broker, |b| {
+        b.include_router(cbor_router);
+        b.include_router(msgpack_router);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let cbor_bytes = CborCodec.encode(&Order { id: 7 }).unwrap();
+    let msgpack_bytes = MsgpackCodec.encode(&Order { id: 7 }).unwrap();
+
+    let driven = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("orders-cbor", &cbor_bytes))
+                .await;
+            let _ = publisher
+                .publish(OutgoingMessage::new("orders-msgpack", &msgpack_bytes))
+                .await;
+            handler_signal(&NOTIFY).await;
+            if CBOR_SEEN.load(Ordering::SeqCst) >= 1 && MSGPACK_SEEN.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        driven.is_ok(),
+        "a non-default codec handler never dispatched"
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
# Description

The feature/test/docs audit (the DoD gate "every runtime feature and feature combination has a
test AND a docs section") turned up one real gap. `msgpack` and `cbor` were only exercised by
their own round-trip unit tests, while every integration test ran on the default `json` codec. And
the `DefaultCodec` fallback aliases (`cbor`, then `msgpack`) are cfg'd out whenever `json` is on,
so the all-features build never compiled them at all.

This closes both:

- `tests/codecs.rs` drives a `CborCodec` router and a `MsgpackCodec` router through a live app,
  feeding each handler wire bytes its own codec produced, so the router-scope codec selection is
  proven for the non-default codecs.
- A stable-only CI step builds the single-codec configurations
  (`--no-default-features --features cbor,memory,macros` and the `msgpack` twin), so the
  `DefaultCodec` fallback aliases and their default-codec call sites stay valid.

The rest of the matrix already holds: every runtime feature (asyncapi, metrics, logging, codecs,
conformance, cli) has both a guide under `docs/` (all linked in `mkdocs.yml`) and a test. This was
the only missing leg.

## Type of change

- [x] New feature (a non-breaking change that adds functionality): test + CI only, no public API change

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)