### PR TITLE
test: raise line coverage to 90% and ratchet the floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,13 @@ jobs:
       - name: Run tests under coverage
         run: cargo llvm-cov --no-report --workspace --all-features
 
-      # Line-coverage gate. The floor ratchets up toward the 90% target as the
-      # coverage backlog items land; raise it here and in the justfile together. The summary is
-      # written before the gate's exit code propagates, so it shows up even on a failure.
+      # Line-coverage gate, sitting at the 90% DoD target. Raise it here and in the justfile
+      # together if coverage climbs further. The summary is written before the gate's exit code
+      # propagates, so it shows up even on a failure.
       - name: Coverage summary and gate
         run: |
           set +e
-          cargo llvm-cov report --summary-only --fail-under-lines 81 | tee coverage.txt
+          cargo llvm-cov report --summary-only --fail-under-lines 90 | tee coverage.txt
           rc=${PIPESTATUS[0]}
           {
             echo '## Coverage'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,10 @@ name = "retry_semantics"
 required-features = ["macros", "memory", "json"]
 
 [[test]]
+name = "scope_codec"
+required-features = ["macros", "memory", "json"]
+
+[[test]]
 name = "router_include"
 required-features = ["macros", "memory", "json"]
 

--- a/justfile
+++ b/justfile
@@ -22,11 +22,11 @@ fmt:
 deny:
     cargo deny check
 
-# Line-coverage gate, same threshold as CI. The floor ratchets up toward the
-# 90% target as the coverage backlog items land; raise it here and in ci.yml
-# together. Needs cargo-llvm-cov: cargo install cargo-llvm-cov --locked
+# Line-coverage gate, same threshold as CI. The floor sits at the 90% target;
+# raise it here and in ci.yml together if coverage climbs further. Needs
+# cargo-llvm-cov: cargo install cargo-llvm-cov --locked
 cov:
-    cargo llvm-cov --workspace --all-features --fail-under-lines 81
+    cargo llvm-cov --workspace --all-features --fail-under-lines 90
 
 # HTML coverage report at target/llvm-cov/html/index.html, for finding the
 # uncovered lines the gate complains about.

--- a/src/conformance/helpers.rs
+++ b/src/conformance/helpers.rs
@@ -107,4 +107,71 @@ mod tests {
         let outcome = wait_until(|| false, Duration::from_millis(50)).await;
         assert!(!outcome);
     }
+
+    #[tokio::test]
+    async fn wait_until_async_resolves_and_times_out() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = Arc::clone(&flag);
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(20)).await;
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+        assert!(
+            wait_until_async(
+                || {
+                    let flag = Arc::clone(&flag);
+                    async move { flag.load(Ordering::SeqCst) }
+                },
+                Duration::from_millis(500),
+            )
+            .await
+        );
+        assert!(
+            !wait_until_async(|| async { false }, Duration::from_millis(50)).await,
+            "a never-true condition must time out"
+        );
+    }
+
+    #[cfg(feature = "memory")]
+    #[tokio::test]
+    async fn next_message_returns_the_next_delivery() {
+        use crate::{IncomingMessage, OutgoingMessage, Publisher, memory::MemoryBroker};
+
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("conf-next");
+        broker
+            .publisher()
+            .publish(OutgoingMessage::new("conf-next", b"hi".as_slice()))
+            .await
+            .unwrap();
+
+        let msg = next_message(&mut sub, Duration::from_secs(1)).await;
+        assert_eq!(msg.payload(), b"hi");
+        msg.ack().await.unwrap();
+    }
+
+    #[cfg(feature = "memory")]
+    #[tokio::test]
+    async fn wait_for_no_messages_distinguishes_quiet_from_delivery() {
+        use crate::{OutgoingMessage, Publisher, memory::MemoryBroker};
+
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("conf-quiet");
+
+        // No publish yet: the subscriber stays quiet within the window.
+        assert!(
+            wait_for_no_messages(&mut sub, Duration::from_millis(50))
+                .await
+                .is_ok()
+        );
+
+        broker
+            .publisher()
+            .publish(OutgoingMessage::new("conf-quiet", b"surprise".as_slice()))
+            .await
+            .unwrap();
+        // Now a delivery arrives, so the helper hands it back as an error.
+        let unexpected = wait_for_no_messages(&mut sub, Duration::from_millis(200)).await;
+        assert!(unexpected.is_err());
+    }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -279,7 +279,81 @@ impl Visit for EventVisitor {
 
 #[cfg(test)]
 mod tests {
-    use super::Logging;
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::{ColorFormatter, Logging};
+
+    /// A `MakeWriter` that appends every formatted event to a shared buffer, so a test can read
+    /// back what `ColorFormatter` rendered.
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Renders one event at every level through `ColorFormatter` and returns the captured output.
+    fn render(ansi: bool, target: bool) -> String {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::new("trace"))
+            .with_writer(BufWriter(buf.clone()))
+            .event_format(ColorFormatter { ansi, target })
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(code = 500, "boom");
+            tracing::warn!("careful");
+            tracing::info!(answer = 42, "hello");
+            tracing::debug!("trace details");
+            tracing::trace!("noisy");
+        });
+        let bytes = buf.lock().unwrap().clone();
+        String::from_utf8(bytes).unwrap()
+    }
+
+    #[test]
+    fn colored_formatter_renders_levels_message_and_fields() {
+        let out = render(true, true);
+        // Every level badge is present (exercises level_color end to end).
+        for level in ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] {
+            assert!(out.contains(level), "missing {level} in: {out:?}");
+        }
+        // ANSI escapes are emitted, the message renders, and non-message fields are appended.
+        assert!(out.contains("\x1b["));
+        assert!(out.contains("hello"));
+        assert!(out.contains("answer=42"));
+        assert!(out.contains("code=500"));
+        // The dim cyan target (this module path) is shown.
+        assert!(out.contains(module_path!()));
+    }
+
+    #[test]
+    fn plain_formatter_drops_ansi_and_target() {
+        let out = render(false, false);
+        assert!(out.contains("careful"));
+        assert!(out.contains("INFO"));
+        // No ANSI escapes and no target column when both are off.
+        assert!(!out.contains("\x1b["));
+        assert!(!out.contains(module_path!()));
+    }
 
     #[test]
     fn defaults_are_info_auto_color_with_targets() {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -478,6 +478,36 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn debug_formats_and_message_accessors() {
+        let broker = MemoryBroker::new();
+        assert!(format!("{broker:?}").contains("MemoryBroker"));
+
+        let source = MemorySource::new("orders");
+        assert_eq!(source.name(), "orders");
+
+        let publisher = broker.publisher();
+        assert!(format!("{publisher:?}").contains("MemoryPublisher"));
+
+        let mut sub = broker.subscribe("dbg");
+        assert!(format!("{sub:?}").contains("MemorySubscriber"));
+
+        publisher
+            .publish(OutgoingMessage::new("dbg", b"payload".as_slice()))
+            .await
+            .unwrap();
+
+        let mut stream = std::pin::pin!(sub.stream());
+        let msg = stream.next().await.unwrap().unwrap();
+        assert!(format!("{msg:?}").contains("MemoryMessage"));
+        assert_eq!(msg.name(), "dbg");
+
+        // into_raw consumes the delivery without acking, yielding a broker-agnostic message.
+        let raw = msg.into_raw();
+        assert_eq!(raw.name(), "dbg");
+        assert_eq!(raw.payload(), b"payload");
+    }
+
     // Paused time needs the current-thread runtime; the redelivery timer auto-advances instead
     // of sleeping for real.
     #[tokio::test(start_paused = true)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -231,4 +231,52 @@ mod tests {
         assert_eq!(msg.name(), "orders");
         assert_eq!(msg.payload(), &[1, 2, 3]);
     }
+
+    #[test]
+    fn raw_message_payload_bytes_and_headers_mut() {
+        let mut msg = RawMessage::new("n", b"data".as_slice());
+        assert_eq!(msg.payload_bytes(), Bytes::from_static(b"data"));
+        msg.headers_mut().insert("k", "v");
+        assert_eq!(msg.headers().get_str("k"), Some("v"));
+    }
+
+    #[tokio::test]
+    async fn incoming_message_defaults_apply_without_override() {
+        use crate::AckError;
+
+        // A minimal IncomingMessage that overrides nothing optional, pinning the trait defaults
+        // (the in-memory and broker impls override them).
+        struct Stub {
+            payload: Vec<u8>,
+            headers: Headers,
+        }
+
+        impl IncomingMessage for Stub {
+            fn payload(&self) -> &[u8] {
+                &self.payload
+            }
+
+            fn headers(&self) -> &Headers {
+                &self.headers
+            }
+
+            async fn ack(self) -> Result<(), AckError> {
+                Ok(())
+            }
+
+            async fn nack(self, _requeue: bool) -> Result<(), AckError> {
+                Ok(())
+            }
+        }
+
+        let stub = Stub {
+            payload: b"body".to_vec(),
+            headers: Headers::new(),
+        };
+        assert_eq!(stub.payload(), b"body");
+        // The default partition_key is None (no key).
+        assert!(stub.partition_key().is_none());
+        // The default nack_after degrades to an immediate nack(true).
+        stub.nack_after(Duration::from_secs(1)).await.unwrap();
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,3 +264,39 @@ impl PublishMiddleware for MetricsPublish {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use prometheus::Registry;
+
+    use super::{Metrics, consume_status};
+    use crate::runtime::{Context, HandlerResult, Layer};
+
+    #[test]
+    fn debug_impls_registry_and_status_mapping() {
+        let metrics = Metrics::with_registry(Registry::new()).unwrap();
+        assert!(format!("{metrics:?}").contains("Metrics"));
+        assert!(format!("{:?}", metrics.consume_layer()).contains("MetricsLayer"));
+        assert!(format!("{:?}", metrics.publish_layer()).contains("MetricsPublish"));
+
+        let handler = metrics
+            .consume_layer()
+            .layer(|_: &u32, _: &mut Context| async { HandlerResult::Ack });
+        assert!(format!("{handler:?}").contains("MetricsHandler"));
+
+        // registry() exposes the registry the three collectors were registered in: registering a
+        // duplicate name there fails, which proves it is that same registry.
+        let dup = prometheus::IntCounter::new("ruststream_messages_consumed_total", "dup").unwrap();
+        assert!(metrics.registry().register(Box::new(dup)).is_err());
+
+        // Every outcome maps to its counter label.
+        assert_eq!(consume_status(HandlerResult::Ack), "ack");
+        assert_eq!(consume_status(HandlerResult::drop()), "nack");
+        assert_eq!(
+            consume_status(HandlerResult::retry_after(Duration::from_secs(1))),
+            "nack"
+        );
+    }
+}

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -134,3 +134,47 @@ where
         (**self).handle(msg, ctx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{HandlerResult, IntoHandlerResult};
+
+    #[test]
+    fn convenience_constructors_map_to_variants() {
+        assert_eq!(
+            HandlerResult::retry(),
+            HandlerResult::Nack { requeue: true }
+        );
+        assert_eq!(
+            HandlerResult::drop(),
+            HandlerResult::Nack { requeue: false }
+        );
+        assert_eq!(
+            HandlerResult::retry_after(Duration::from_secs(2)),
+            HandlerResult::NackAfter {
+                delay: Duration::from_secs(2)
+            }
+        );
+    }
+
+    #[test]
+    fn into_handler_result_covers_every_return_shape() {
+        assert_eq!(HandlerResult::Ack.into_handler_result(), HandlerResult::Ack);
+        assert_eq!(().into_handler_result(), HandlerResult::Ack);
+        assert_eq!(Ok::<(), ()>(()).into_handler_result(), HandlerResult::Ack);
+        assert_eq!(
+            Err::<(), ()>(()).into_handler_result(),
+            HandlerResult::drop()
+        );
+        assert_eq!(
+            Ok::<HandlerResult, ()>(HandlerResult::retry()).into_handler_result(),
+            HandlerResult::retry()
+        );
+        assert_eq!(
+            Err::<HandlerResult, ()>(()).into_handler_result(),
+            HandlerResult::drop()
+        );
+    }
+}

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -147,3 +147,59 @@ where
         HandlerResult::Ack
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PublishingDef, publishing_metadata};
+    use crate::Headers;
+    use crate::Name;
+    use crate::runtime::context::{Context, State};
+    use crate::runtime::dispatch::{Delivery, Workers};
+    use crate::runtime::handler::HandlerResult;
+
+    /// A hand-written publishing def overriding nothing optional, pinning the trait defaults that
+    /// the macro always fills in.
+    struct ManualPub;
+
+    impl PublishingDef for ManualPub {
+        type Input = u32;
+        type Reply = u32;
+        type Source = Name;
+
+        fn source(&self) -> Name {
+            Name::new("in")
+        }
+
+        // The trait signature returns `&str` (tied to `&self`); the macro-generated impls do the
+        // same, so this hand-written one cannot narrow to `&'static str` without diverging.
+        #[allow(clippy::unnecessary_literal_bound)]
+        fn reply_name(&self) -> &str {
+            "out"
+        }
+
+        async fn call(&self, input: &u32, _ctx: &mut Context<'_>) -> Result<u32, HandlerResult> {
+            Ok(*input)
+        }
+    }
+
+    #[tokio::test]
+    async fn defaults_metadata_and_call() {
+        let def = ManualPub;
+        assert_eq!(def.workers(), Workers::sequential());
+        assert!(def.description().is_none());
+        assert!(def.input_schema().is_none());
+        assert!(def.message_name().is_none());
+        assert!(def.message_description().is_none());
+        assert_eq!(def.reply_name(), "out");
+        let _source = def.source();
+
+        let meta = publishing_metadata("in".to_owned(), &def);
+        assert_eq!(meta.name, "in");
+
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("in", &headers, &state, &delivery);
+        assert_eq!(def.call(&5, &mut ctx).await.unwrap(), 5);
+    }
+}

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -81,9 +81,10 @@ pub(crate) fn subscriber_metadata<D: SubscriberDef>(name: String, def: &D) -> Ha
 #[cfg(test)]
 mod tests {
     use super::{SubscriberDef, subscriber_metadata};
+    use crate::Headers;
     use crate::Name;
-    use crate::runtime::context::Context;
-    use crate::runtime::dispatch::Workers;
+    use crate::runtime::context::{Context, State};
+    use crate::runtime::dispatch::{Delivery, Workers};
     use crate::runtime::handler::{Handler, HandlerResult};
 
     struct Noop;
@@ -112,17 +113,26 @@ mod tests {
         }
     }
 
-    #[test]
-    fn defaults_omit_metadata_and_dispatch_sequentially() {
+    #[tokio::test]
+    async fn defaults_omit_metadata_and_dispatch_sequentially() {
         let def = ManualDef;
         assert_eq!(def.workers(), Workers::sequential());
         assert!(def.description().is_none());
         assert!(def.input_schema().is_none());
         assert!(def.message_name().is_none());
         assert!(def.message_description().is_none());
+        let _source = def.source();
 
         let meta = subscriber_metadata("manual".to_owned(), &def);
         assert_eq!(meta.name, "manual");
         assert_eq!(meta.input_type, "u32");
+
+        // Drive the consumed handler so source(), into_handler() and the Noop body are exercised.
+        let handler = def.into_handler();
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("manual", &headers, &state, &delivery);
+        assert_eq!(handler.handle(&7u32, &mut ctx).await, HandlerResult::Ack);
     }
 }

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -188,4 +188,27 @@ mod tests {
         assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::retry());
         assert_eq!(seen.load(Ordering::SeqCst), 0, "inner must not run");
     }
+
+    #[tokio::test]
+    async fn typed_handler_is_debug_and_stub_acks() {
+        let seen = Arc::new(AtomicU32::new(0));
+        let handler = typed(JsonCodec, counting_inner(&seen));
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("typed", &headers, &state, &delivery);
+        // Drive one delivery to pin the message type, then check the Debug rendering.
+        let msg = StubMsg(b"5".to_vec(), Headers::new());
+        handler.handle(&msg, &mut ctx).await;
+        assert!(format!("{handler:?}").contains("Typed"));
+
+        // Exercise the StubMsg fixture's own IncomingMessage surface.
+        let other = StubMsg(b"x".to_vec(), Headers::new());
+        assert!(other.headers().is_empty());
+        other.ack().await.unwrap();
+        StubMsg(Vec::new(), Headers::new())
+            .nack(true)
+            .await
+            .unwrap();
+    }
 }

--- a/tests/scope_codec.rs
+++ b/tests/scope_codec.rs
@@ -1,0 +1,284 @@
+//! Integration coverage for the `include` family on `BrokerScope`, in both codec forms.
+//!
+//! `with_broker_codec` sets a scope default codec, switching every `include*` call to the
+//! `BrokerScope<B, L, C: Codec>` impl block; the bare `with_broker` path uses the default-codec
+//! block (`C = ()`). The own-source default-codec variants are covered elsewhere; the explicit-
+//! source `_on` variants of both blocks were not. This drives every `_on` form (plus batch and
+//! batch-publishing) through one codec scope and one default-codec scope, end to end.
+#![cfg(feature = "macros")]
+
+mod common;
+
+use std::{
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use common::handler_signal;
+use ruststream::codec::JsonCodec;
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
+use ruststream::{Name, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Receipt {
+    id: u32,
+}
+
+static PLAIN_ON: AtomicUsize = AtomicUsize::new(0);
+static BATCH: AtomicUsize = AtomicUsize::new(0);
+static BATCH_ON: AtomicUsize = AtomicUsize::new(0);
+static POUT: AtomicUsize = AtomicUsize::new(0);
+static POUT_ON: AtomicUsize = AtomicUsize::new(0);
+static BPOUT: AtomicUsize = AtomicUsize::new(0);
+static BPOUT_ON: AtomicUsize = AtomicUsize::new(0);
+static NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("sc-plain-on")]
+async fn plain_on(_o: &Order) -> HandlerResult {
+    PLAIN_ON.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("sc-batch"))]
+async fn batch(orders: &[Order]) -> HandlerResult {
+    BATCH.fetch_add(orders.len(), Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("sc-batch-ignored"))]
+async fn batch_on(orders: &[Order]) -> HandlerResult {
+    BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("sc-pin", publish("sc-pout"))]
+async fn relay(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber("sc-pin-ignored", publish("sc-pout-on"))]
+async fn relay_on(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber(batch("sc-bpin"), publish("sc-bpout"))]
+async fn batch_relay(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber(batch("sc-bpin-ignored"), publish("sc-bpout-on"))]
+async fn batch_relay_on(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber("sc-pout")]
+async fn pout_check(_r: &Receipt) -> HandlerResult {
+    POUT.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("sc-pout-on")]
+async fn pout_on_check(_r: &Receipt) -> HandlerResult {
+    POUT_ON.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("sc-bpout")]
+async fn bpout_check(_r: &Receipt) -> HandlerResult {
+    BPOUT.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("sc-bpout-on")]
+async fn bpout_on_check(_r: &Receipt) -> HandlerResult {
+    BPOUT_ON.fetch_add(1, Ordering::SeqCst);
+    NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// One codec scope, every non-`include` scope-codec variant mounted: `include_on`,
+/// `include_batch`, `include_batch_on`, `include_publishing`, `include_publishing_on`,
+/// `include_batch_publishing`, and `include_batch_publishing_on`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scope_codec_include_family_dispatches() {
+    let broker = MemoryBroker::new();
+    let driver = broker.clone().publisher();
+    let reply_broker = broker.clone();
+
+    let app =
+        RustStream::new(AppInfo::new("sc", "0.1.0")).with_broker_codec(broker, JsonCodec, |b| {
+            b.include_on(Name::new("sc-plain-on"), plain_on);
+            b.include_batch(batch);
+            b.include_batch_on(Name::new("sc-batch-on"), batch_on);
+            b.include_publishing(relay, TypedPublisher::new(reply_broker.publisher()));
+            b.include_publishing_on(
+                Name::new("sc-pin-on"),
+                relay_on,
+                TypedPublisher::new(reply_broker.publisher()),
+            );
+            b.include_batch_publishing(batch_relay, TypedPublisher::new(reply_broker.publisher()));
+            b.include_batch_publishing_on(
+                Name::new("sc-bpin-on"),
+                batch_relay_on,
+                TypedPublisher::new(reply_broker.publisher()),
+            );
+            b.include(pout_check);
+            b.include(pout_on_check);
+            b.include(bpout_check);
+            b.include(bpout_on_check);
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Order { id: 1 }).unwrap();
+    let topics = [
+        "sc-plain-on",
+        "sc-batch",
+        "sc-batch-on",
+        "sc-pin",
+        "sc-pin-on",
+        "sc-bpin",
+        "sc-bpin-on",
+    ];
+    let counters: [&AtomicUsize; 7] = [
+        &PLAIN_ON, &BATCH, &BATCH_ON, &POUT, &POUT_ON, &BPOUT, &BPOUT_ON,
+    ];
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            for topic in topics {
+                let _ = driver.publish(OutgoingMessage::new(topic, &payload)).await;
+            }
+            handler_signal(&NOTIFY).await;
+            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        outcome.is_ok(),
+        "a scope-codec include variant never dispatched"
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static D_PLAIN_ON: AtomicUsize = AtomicUsize::new(0);
+static D_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
+static D_POUT_ON: AtomicUsize = AtomicUsize::new(0);
+static D_BPOUT_ON: AtomicUsize = AtomicUsize::new(0);
+static D_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("d-plain-on")]
+async fn d_plain_on(_o: &Order) -> HandlerResult {
+    D_PLAIN_ON.fetch_add(1, Ordering::SeqCst);
+    D_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber(batch("d-batch-ignored"))]
+async fn d_batch_on(orders: &[Order]) -> HandlerResult {
+    D_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
+    D_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("d-pin-ignored", publish("d-pout-on"))]
+async fn d_relay_on(o: &Order) -> Receipt {
+    Receipt { id: o.id }
+}
+
+#[subscriber(batch("d-bpin-ignored"), publish("d-bpout-on"))]
+async fn d_batch_relay_on(orders: &[Order]) -> Vec<Receipt> {
+    orders.iter().map(|o| Receipt { id: o.id }).collect()
+}
+
+#[subscriber("d-pout-on")]
+async fn d_pout_on_check(_r: &Receipt) -> HandlerResult {
+    D_POUT_ON.fetch_add(1, Ordering::SeqCst);
+    D_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+#[subscriber("d-bpout-on")]
+async fn d_bpout_on_check(_r: &Receipt) -> HandlerResult {
+    D_BPOUT_ON.fetch_add(1, Ordering::SeqCst);
+    D_NOTIFY.notify_one();
+    HandlerResult::Ack
+}
+
+/// The default-codec block's explicit-source variants: `include_on`, `include_batch_on`,
+/// `include_publishing_on`, and `include_batch_publishing_on` (the own-source forms are covered
+/// by the other integration tests).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_codec_include_on_family_dispatches() {
+    let broker = MemoryBroker::new();
+    let driver = broker.clone().publisher();
+    let reply_broker = broker.clone();
+
+    let app = RustStream::new(AppInfo::new("dsc", "0.1.0")).with_broker(broker, |b| {
+        b.include_on(Name::new("d-plain-on"), d_plain_on);
+        b.include_batch_on(Name::new("d-batch-on"), d_batch_on);
+        b.include_publishing_on(
+            Name::new("d-pin-on"),
+            d_relay_on,
+            TypedPublisher::new(reply_broker.publisher()),
+        );
+        b.include_batch_publishing_on(
+            Name::new("d-bpin-on"),
+            d_batch_relay_on,
+            TypedPublisher::new(reply_broker.publisher()),
+        );
+        b.include(d_pout_on_check);
+        b.include(d_bpout_on_check);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Order { id: 1 }).unwrap();
+    let topics = ["d-plain-on", "d-batch-on", "d-pin-on", "d-bpin-on"];
+    let counters: [&AtomicUsize; 4] = [&D_PLAIN_ON, &D_BATCH_ON, &D_POUT_ON, &D_BPOUT_ON];
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            for topic in topics {
+                let _ = driver.publish(OutgoingMessage::new(topic, &payload)).await;
+            }
+            handler_signal(&D_NOTIFY).await;
+            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(
+        outcome.is_ok(),
+        "a default-codec include_on variant never dispatched"
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}


### PR DESCRIPTION
# Description

Lifts line coverage from ~83% to 90.15% and moves the CI/justfile gate from 81 to the 90% Definition-of-Done target, with no file exclusions.

The biggest lever is the BrokerScope include family. The scope-codec impl block (reached via with_broker_codec) was exercised only for `include`, and the default-codec block's explicit-source `_on` variants were never hit; a new tests/scope_codec.rs drives every variant of both blocks end to end, taking runtime/app/include.rs to 100%.

Unit tests fill the rest, all against real production paths:
- logging: render events through ColorFormatter with a capturing writer, both ANSI/plain and every level.
- conformance helpers: wait_until_async, wait_for_no_messages, next_message.
- handler: the HandlerResult constructors and every IntoHandlerResult shape.
- metrics: the Debug impls, registry(), and consume_status mapping.
- memory: Debug impls, MemorySource::name, MemoryMessage::name / into_raw.
- message: RawMessage::payload_bytes / headers_mut and the IncomingMessage trait defaults (partition_key, nack_after).
- typed / subscriber_def / publishing: the Debug impls and the trait defaults the macro always overrides, via hand-written minimal defs.

The bin entry points (the cargo-spawning CLI glue) stay measured; the 90% is met on the library and integration surface alone.

## Type of change

Please delete options that are not relevant.

- [X] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable

> `just ci` runs the full gate (`just check` + `just test`) in one go.
