### PR TITLE
docs: render icon shortcodes and fix the memory feature's deps

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,7 +29,7 @@ always compiled. Everything else is an additive, opt-in feature.
 | `json` *(default)* | serde_json | `JsonCodec` |
 | `msgpack` | rmp-serde | `MsgpackCodec` |
 | `cbor` | ciborium | `CborCodec` |
-| `memory` | tokio-stream | `MemoryBroker`, the in-memory reference broker |
+| `memory` | - | `MemoryBroker`, the in-memory reference broker |
 | `macros` | ruststream-macros | `#[subscriber]`, `#[ruststream::app]`, `#[derive(Message)]` |
 | `asyncapi` | schemars, serde_norway | AsyncAPI generation and the HTML viewer |
 | `metrics` | prometheus | Prometheus middleware and exporter |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,11 @@ markdown_extensions:
   - admonition
   - attr_list
   - md_in_html
+  # Renders :material-xxx: / :fontawesome-xxx: shortcodes (used on the home page grid) as inline
+  # SVG icons. Without it those shortcodes show up as literal text.
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
   - pymdownx.highlight:


### PR DESCRIPTION
# Description

Two doc-site fixes found while auditing the docs.

**Icon rendering bug.** The home page grid (`docs/index.md`) uses `:material-xxx:` shortcodes, but
`mkdocs.yml` never enabled `pymdownx.emoji`, so they rendered as literal `:material-download:` text
instead of icons. This adds the extension with the Material icon index/generator. A strict build now
emits inline `<svg>` icons and leaves zero literal shortcodes.

**Stale feature dependency.** The installation feature table claimed the `memory` feature pulls in
`tokio-stream`. It is `memory = []` - it adds no dependencies (the in-memory broker uses only
tokio/futures/serde, already present). Matched to the `conformance` row's `-`.

The rest of the docs audit came back clean: every documented API, macro, feature, version/MSRV,
snippet reference, and nav entry matches the code at 0.3.1.

Verified locally with `mkdocs build --strict` against `docs/requirements.txt`: the build passes and
the home page icons render as SVG.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] `mkdocs build --strict` passes