### PR TITLE
feat: name the subscription and target type in dispatch failure logs

### DIFF
--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -279,20 +279,23 @@ where
     H: SliceHandler<T>,
 {
     async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_>) {
-        let (values, accepted) = decode_batch(batch, &self.codec, self.on_decode_failure).await;
+        let subscription = ctx.name().to_owned();
+        let (values, accepted) =
+            decode_batch(batch, &self.codec, self.on_decode_failure, &subscription).await;
         if accepted.is_empty() {
             return;
         }
         match self.inner.handle_slice(&values, ctx).await {
             BatchResult::Uniform(result) => {
                 for msg in accepted {
-                    settle(msg, result).await;
+                    settle(msg, result, &subscription).await;
                 }
             }
             BatchResult::PerElement(results) => {
                 if results.len() != accepted.len() {
                     error!(
                         target: "ruststream::dispatch",
+                        subscription = %subscription,
                         expected = accepted.len(),
                         returned = results.len(),
                         "per-element outcome count does not match the batch; \
@@ -303,7 +306,7 @@ where
                 for msg in accepted {
                     // An unmatched message gets retried: an extra redelivery beats losing it.
                     let result = results.next().unwrap_or_else(HandlerResult::retry);
-                    settle(msg, result).await;
+                    settle(msg, result, &subscription).await;
                 }
             }
         }
@@ -317,6 +320,7 @@ pub(crate) async fn decode_batch<M, T, C>(
     batch: Vec<M>,
     codec: &C,
     on_decode_failure: DecodeFailure,
+    subscription: &str,
 ) -> (Vec<T>, Vec<M>)
 where
     M: IncomingMessage,
@@ -334,12 +338,19 @@ where
             Err(err) => {
                 warn!(
                     target: "ruststream::dispatch",
+                    subscription = %subscription,
+                    message_type = std::any::type_name::<T>(),
                     error = %err,
                     "codec decode failed",
                 );
                 let requeue = matches!(on_decode_failure, DecodeFailure::Requeue);
                 if let Err(err) = msg.nack(requeue).await {
-                    warn!(target: "ruststream::dispatch", error = %err, "nack failed");
+                    warn!(
+                        target: "ruststream::dispatch",
+                        subscription = %subscription,
+                        error = %err,
+                        "nack failed",
+                    );
                 }
             }
         }
@@ -348,14 +359,19 @@ where
 }
 
 /// Applies one settlement to one delivery's own `ack` / `nack`.
-pub(crate) async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult) {
+pub(crate) async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult, subscription: &str) {
     let ack_result = match result {
         HandlerResult::Ack => msg.ack().await,
         HandlerResult::Nack { requeue } => msg.nack(requeue).await,
         HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
     };
     if let Err(err) = ack_result {
-        warn!(target: "ruststream::dispatch", error = %err, "ack / nack failed");
+        warn!(
+            target: "ruststream::dispatch",
+            subscription = %subscription,
+            error = %err,
+            "ack / nack failed",
+        );
     }
 }
 

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -135,8 +135,14 @@ where
     R: ReplyPublisher,
 {
     async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_>) {
-        let (values, accepted) =
-            decode_batch::<M, D::Input, C>(batch, &self.codec, DecodeFailure::default()).await;
+        let subscription = ctx.name().to_owned();
+        let (values, accepted) = decode_batch::<M, D::Input, C>(
+            batch,
+            &self.codec,
+            DecodeFailure::default(),
+            &subscription,
+        )
+        .await;
         if accepted.is_empty() {
             return;
         }
@@ -152,6 +158,9 @@ where
                     Err(err) => {
                         warn!(
                             target: "ruststream::dispatch",
+                            subscription = %subscription,
+                            reply = %name,
+                            reply_type = std::any::type_name::<D::Reply>(),
                             error = %err,
                             "batch reply publish failed",
                         );
@@ -162,7 +171,7 @@ where
             Err(result) => result,
         };
         for msg in accepted {
-            settle(msg, outcome).await;
+            settle(msg, outcome, &subscription).await;
         }
     }
 }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -441,6 +441,7 @@ where
     if let Err(err) = ack_result {
         warn!(
             target: "ruststream::dispatch",
+            subscription = %name,
             error = %err,
             "ack / nack failed",
         );

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -131,7 +131,13 @@ where
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
             Ok(value) => value,
             Err(err) => {
-                warn!(target: "ruststream::dispatch", error = %err, "codec decode failed");
+                warn!(
+                    target: "ruststream::dispatch",
+                    subscription = %ctx.name(),
+                    message_type = std::any::type_name::<D::Input>(),
+                    error = %err,
+                    "codec decode failed",
+                );
                 return HandlerResult::drop();
             }
         };
@@ -141,7 +147,14 @@ where
         };
         let name = self.def.reply_name();
         if let Err(err) = self.publisher.publish(name, &reply, &self.pipeline).await {
-            warn!(target: "ruststream::dispatch", error = %err, "reply publish failed");
+            warn!(
+                target: "ruststream::dispatch",
+                subscription = %ctx.name(),
+                reply = %name,
+                reply_type = std::any::type_name::<D::Reply>(),
+                error = %err,
+                "reply publish failed",
+            );
             return HandlerResult::retry();
         }
         HandlerResult::Ack

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -87,6 +87,8 @@ where
             Err(err) => {
                 warn!(
                     target: "ruststream::dispatch",
+                    subscription = %ctx.name(),
+                    message_type = std::any::type_name::<T>(),
                     error = %err,
                     "codec decode failed",
                 );
@@ -210,5 +212,76 @@ mod tests {
             .nack(true)
             .await
             .unwrap();
+    }
+
+    // Captures the fields of the one event emitted on a decode failure, so the test can assert the
+    // diagnostic carries the subscription name and target type (needs a tracing subscriber, hence
+    // the `logging` feature gate).
+    #[cfg(feature = "logging")]
+    #[tokio::test]
+    async fn decode_failure_log_names_subscription_and_type() {
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt as _};
+
+        #[derive(Default)]
+        struct FieldGrab(HashMap<String, String>);
+
+        impl Visit for FieldGrab {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                self.0.insert(field.name().to_owned(), value.to_owned());
+            }
+
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                self.0
+                    .entry(field.name().to_owned())
+                    .or_insert_with(|| format!("{value:?}"));
+            }
+        }
+
+        struct Capture(Arc<Mutex<Vec<HashMap<String, String>>>>);
+
+        impl<S: tracing::Subscriber> Layer<S> for Capture {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: LayerContext<'_, S>) {
+                let mut grab = FieldGrab::default();
+                event.record(&mut grab);
+                self.0.lock().unwrap().push(grab.0);
+            }
+        }
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry().with(Capture(Arc::clone(&events))),
+        );
+
+        let seen = Arc::new(AtomicU32::new(0));
+        let handler = typed(JsonCodec, counting_inner(&seen));
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("orders.inbound", &headers, &state, &delivery);
+        let msg = StubMsg(b"not json".to_vec(), Headers::new());
+        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::drop());
+        drop(guard);
+
+        let decode_event = {
+            let captured = events.lock().unwrap();
+            captured
+                .iter()
+                .find(|f| f.get("message").is_some_and(|m| m == "codec decode failed"))
+                .cloned()
+                .expect("a codec-decode-failed event must be emitted")
+        };
+        assert_eq!(
+            decode_event.get("subscription").map(String::as_str),
+            Some("orders.inbound")
+        );
+        assert_eq!(
+            decode_event.get("message_type").map(String::as_str),
+            Some("u32")
+        );
     }
 }


### PR DESCRIPTION
# Description

A `codec decode failed` warning carried only the serde error, so with more than one subscriber it
was impossible to tell *which* handler failed or *what type* the payload was being decoded into.
The motivating case: a handler whose subject received a differently-typed message logged
`missing field 'item'` with no hint that it was a wrong subject/type pairing.

Every `ruststream::dispatch` warning now carries the subscription name, and the decode/publish ones
also carry the Rust target type:

- decode failures (single, publishing, and batch paths): `subscription` + `message_type`
- reply / batch-reply publish failures: `subscription` + `reply` + `reply_type`
- ack/nack failures (single and batch): `subscription`

So instead of:

```
WARN ruststream::dispatch codec decode failed error=decode failed: missing field `item` ...
```

you get:

```
WARN ruststream::dispatch codec decode failed subscription=cancellations message_type=app::Order error=decode failed: missing field `item` ...
```

`decode_batch` and `settle` take the subscription name as an argument; both callers already hold the
`Context`, so it is captured once per batch. A new test (gated on the `logging` feature) drives a
decode failure through a capturing subscriber and asserts the `subscription` and `message_type`
fields are present.

Log-output only: no public API or behaviour change.

## Type of change

- [x] New feature (a non-breaking change that adds functionality): richer diagnostics, log-only

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`); coverage stays above the 90 floor