### PR TITLE
ci: skip verify in the package dry-run (patch self-ref clashes at a published version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # Trial-build the published artifacts without uploading. Both packages in one invocation
+      # Package the published artifacts without uploading. Both packages in one invocation
       # (multi-package packaging, stable since cargo 1.90): packaging strips the path from the
       # lockstep `ruststream-macros` dependency, and between a version bump and the release that
       # version does not exist on crates.io, so packaging ruststream alone cannot resolve it. The
@@ -208,12 +208,21 @@ jobs:
       # Still not `--workspace`: the dev-only `[patch.crates-io]` self-patch used by the `nats_*`
       # examples trips its checksum.
       #
+      # `--no-verify`: once a version is published, this job runs against the SAME, unchanged
+      # version on every later PR. Verify strips `[patch]` and rebuilds the extracted tarball, so
+      # the bundled `nats_*` examples pull `ruststream-nats` -> `ruststream <ver>` from the registry,
+      # whose checksum no longer matches the locally-modified `ruststream <ver>` being verified
+      # ("checksum changed between lock files"). Verifying is impossible between releases by design;
+      # packaging (manifest metadata, file list, the `[patch]` strip) is still checked here, and the
+      # full build is covered by the rust matrix. The release workflow runs with verify because it
+      # publishes a freshly bumped version that is not yet on crates.io, so the clash cannot occur.
+      #
       # CARGO_HTTP_MULTIPLEXING=false works around recurring "[16] Error in the HTTP2 framing
       # layer" curl failures on the runners when this job re-downloads registry deps.
       - name: cargo publish dry-run (no upload)
         env:
           CARGO_HTTP_MULTIPLEXING: "false"
-        run: cargo publish --dry-run -p ruststream-macros -p ruststream --all-features
+        run: cargo publish --dry-run --no-verify -p ruststream-macros -p ruststream --all-features
 
   security:
     name: Security scans


### PR DESCRIPTION
# Description

The **Package (publish dry-run)** job fails on every PR that touches packaging inputs, now that
`ruststream 0.3.1` is on crates.io. It is **not specific to any PR** - it reproduces on `main`
(confirmed locally); recent PRs only passed it before the version was published / before `main`
diverged from the published content.

`cargo publish --dry-run` verifies by stripping the dev-only `[patch.crates-io] ruststream = path`
and rebuilding the extracted tarball. With the patch gone, the bundled `nats_*` examples pull
`ruststream-nats -> ruststream 0.3.1` from the registry, whose checksum no longer matches the
locally-modified `ruststream 0.3.1` being verified, so cargo aborts with:

```
error: failed to verify package tarball
Caused by:
  checksum for `ruststream v0.3.1` changed between lock files
```

Between releases the version is unchanged and already published, so this verify is **structurally
impossible** by design (the same self-patch the repo already documents).

## Fix

Add `--no-verify` to the dry-run. Packaging itself - manifest metadata, the file list, the
`[patch]` strip, and the multi-package local overlay - is still exercised here, and the full build
is covered by the rust matrix (it builds the workspace with the patch, across all features and
toolchains). Verified locally: `cargo publish --dry-run --no-verify -p ruststream-macros -p
ruststream --all-features` succeeds.

The **release** workflow deliberately keeps verify on: it publishes a freshly bumped version that is
not yet on crates.io, so the registry/local checksum clash cannot occur there.

## Type of change

- [x] Other: CI fix (no library code or public API change)

## Checklist

- [x] I have performed a self-review of my own code
- [x] The reasoning is documented in the `ci.yml` comment