### PR TITLE
feat: post-settle hooks via ctx.after(outcome).then(fut)

### DIFF
--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -50,6 +50,8 @@ What the context exposes:
 | `headers_mut()` | `&mut Headers` | the same copy, for middleware to enrich |
 | `get::<T>()` | `Option<&T>` | shared application state |
 | `publisher(name)` | `Option<ScopedPublisher>` | a [named publisher](publishing.md#publishing-from-inside-a-handler) |
+| `after(outcome).then(fut)` | `()` | a [post-settle hook](#post-settle-hooks) gated on the settlement outcome |
+| `after_ack(fut)` / `after_settle(fut)` | `()` | post-settle hook sugar (after an ack / after any settlement) |
 
 Closure handlers (the manual `typed(codec, |msg, ctx| ...)` form) always take the context as their
 second argument.
@@ -94,6 +96,37 @@ in the pipeline:
 A closure handler cannot return a future that borrows the context across `.await`; publish from a
 `#[subscriber]` handler or a struct handler with `async fn handle`, both of which own the borrow.
 See [Publishing](publishing.md#publishing-from-inside-a-handler).
+
+## Post-settle hooks
+
+Sometimes a handler needs a side effect to fire *after* the message has been settled - a
+non-critical notification, slow follow-up work - without it gating the ack decision or affecting
+redelivery. Register one on the context:
+
+```rust
+--8<-- "examples/context.rs:handler"
+```
+
+The handler above ends with `ctx.after_ack(..)`: the continuation runs only once the broker has
+acked the message, off the delivery path, so it never delays the ack or the next delivery.
+
+Three forms, all additive:
+
+- `ctx.after(outcome).then(fut)` - runs only if the message settles by `outcome`, matched **by
+  variant**: `Ack`, `Nack`, or `NackAfter`. Both `HandlerResult::drop()` and
+  `HandlerResult::retry()` are `Nack`, so a gate on either fires on the other; `retry_after` gates
+  on `NackAfter` regardless of the delay.
+- `ctx.after_ack(fut)` - sugar for `ctx.after(HandlerResult::Ack).then(fut)`.
+- `ctx.after_settle(fut)` - runs after the message settles, whatever the outcome.
+
+Multiple registrations accumulate and every matching one runs. The semantics are **at-most-once**:
+the message is already settled before any hook runs, so a hook that panics, or that is lost when the
+process crashes, never causes a redelivery. A graceful shutdown drains in-flight hooks (bounded by
+`shutdown_timeout`); an aborted shutdown may drop them.
+
+On the batch path a `Context` is one per *batch*, so a hook runs after the whole batch has settled.
+Because a batch has per-element outcomes, the outcome gate is ill-defined there: only
+`after_settle` hooks fire (the gated `after(..)` / `after_ack` forms are ignored on a batch).
 
 ## Context in middleware
 

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -113,9 +113,9 @@ acked the message, off the delivery path, so it never delays the ack or the next
 Three forms, all additive:
 
 - `ctx.after(outcome).then(fut)` - runs only if the message settles by `outcome`, matched **by
-  variant**: `Ack`, `Nack`, or `NackAfter`. Both `HandlerResult::drop()` and
-  `HandlerResult::retry()` are `Nack`, so a gate on either fires on the other; `retry_after` gates
-  on `NackAfter` regardless of the delay.
+  kind**. The four kinds are distinct: `Ack`, `drop()` (nack, no requeue), `retry()` (nack,
+  requeue), and `retry_after()` (matched regardless of the delay). Drop and retry are separate
+  mechanics, so a hook gated on `drop()` does not fire on a `retry()` settlement, and vice versa.
 - `ctx.after_ack(fut)` - sugar for `ctx.after(HandlerResult::Ack).then(fut)`.
 - `ctx.after_settle(fut)` - runs after the message settles, whatever the outcome.
 

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -46,6 +46,15 @@ async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
     if config.reject_zero_ids && order.id == 0 {
         return HandlerResult::drop();
     }
+
+    // 4. A post-settle hook: fires after the broker has acked this message, off the delivery
+    //    path, so slow follow-up work never gates the ack or the next delivery. At-most-once:
+    //    a lost hook does not redeliver.
+    let id = order.id;
+    ctx.after_ack(async move {
+        println!("order {id} acked; sending the confirmation");
+    });
+
     HandlerResult::Ack
 }
 // --8<-- [end:handler]

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -8,11 +8,46 @@
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::Headers;
 
 use super::dispatch::Delivery;
+use super::handler::HandlerResult;
 use super::publish::ScopedPublisher;
+
+/// A post-settle continuation: a boxed `Send` future the dispatcher runs after the message (or
+/// batch) has been settled.
+type Continuation = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// The settlement variant a post-settle hook is gated on, matched by variant only (not by the
+/// `Nack { requeue }` flag or the `NackAfter { delay }` value): `drop()` and `retry()` both gate
+/// on [`OutcomeKind::Nack`], `retry_after` on [`OutcomeKind::NackAfter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutcomeKind {
+    Ack,
+    Nack,
+    NackAfter,
+}
+
+impl OutcomeKind {
+    /// The variant of `outcome`, discarding the carried `requeue` / `delay` payload.
+    fn of(outcome: HandlerResult) -> Self {
+        match outcome {
+            HandlerResult::Ack => Self::Ack,
+            HandlerResult::Nack { .. } => Self::Nack,
+            HandlerResult::NackAfter { .. } => Self::NackAfter,
+        }
+    }
+}
+
+/// One registered post-settle hook: the future to run, and the outcome variant it is gated on
+/// (`None` means it runs regardless of how the message settled).
+struct AfterHook {
+    gate: Option<OutcomeKind>,
+    fut: Continuation,
+}
 
 /// App-level shared state: a type-map holding one value per type.
 ///
@@ -53,13 +88,22 @@ impl std::fmt::Debug for State {
 /// [`publisher`](Self::publisher)s for publishing from inside a handler. The copy is made lazily
 /// on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit it:
 /// replies and manual publishes start from fresh headers, shaped by the publish pipeline.
-#[derive(Debug)]
 pub struct Context<'a> {
     name: &'a str,
     original: &'a Headers,
     modified: Option<Headers>,
     state: &'a State,
     delivery: &'a Delivery,
+    after: Vec<AfterHook>,
+}
+
+impl std::fmt::Debug for Context<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("name", &self.name)
+            .field("after_hooks", &self.after.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> Context<'a> {
@@ -76,6 +120,7 @@ impl<'a> Context<'a> {
             modified: None,
             state,
             delivery,
+            after: Vec::new(),
         }
     }
 
@@ -117,13 +162,286 @@ impl<'a> Context<'a> {
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
         self.state.get::<T>()
     }
+
+    /// Begins registering a post-settle hook gated on `outcome`.
+    ///
+    /// The returned builder's [`then`](After::then) registers a future that the dispatcher runs
+    /// once the message has been settled, but only if the actual settlement matches `outcome` by
+    /// variant: `Ack`, `Nack`, or `NackAfter`. Both [`HandlerResult::drop`] and
+    /// [`HandlerResult::retry`] are `Nack`, so either gates on a `Nack` settlement regardless of
+    /// the `requeue` flag; [`HandlerResult::retry_after`] gates on `NackAfter` regardless of the
+    /// delay. Multiple hooks accumulate and every matching one runs.
+    ///
+    /// The hook is scoped to the whole delivery. On the batch path a `Context` is one per batch,
+    /// so a hook registered here runs after the entire batch settles; because a batch has
+    /// per-element outcomes, the outcome gate is ignored there and only [`after_settle`](Self::after_settle)
+    /// hooks (which run regardless) fire (see that method).
+    ///
+    /// # Cancel safety
+    ///
+    /// Post-settle hooks are at-most-once: the message is already settled before any hook runs, so
+    /// a hook that panics, or that is lost when the process crashes, never causes a redelivery and
+    /// never blocks the next delivery. A graceful shutdown drains in-flight hooks (bounded by the
+    /// app's [`shutdown_timeout`](super::RustStream::shutdown_timeout)); an aborted shutdown may
+    /// drop them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, Handler, HandlerResult};
+    ///
+    /// fn use_after<M: IncomingMessage + 'static>() {
+    ///     let _handler = |_msg: &M, ctx: &mut Context| {
+    ///         ctx.after(HandlerResult::Ack)
+    ///             .then(async move { /* runs only after this message is acked */ });
+    ///         async { HandlerResult::Ack }
+    ///     };
+    /// }
+    /// ```
+    pub fn after(&mut self, outcome: HandlerResult) -> After<'_, 'a> {
+        After {
+            ctx: self,
+            gate: Some(OutcomeKind::of(outcome)),
+        }
+    }
+
+    /// Registers a post-settle hook that runs only after the message is acked.
+    ///
+    /// Sugar for `self.after(HandlerResult::Ack).then(fut)`; see [`after`](Self::after) for the
+    /// gating and cancel-safety semantics.
+    ///
+    /// # Cancel safety
+    ///
+    /// At-most-once, as for [`after`](Self::after): the ack has already happened, so a lost hook
+    /// never redelivers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// fn use_after_ack<M: IncomingMessage + 'static>() {
+    ///     let _handler = |_msg: &M, ctx: &mut Context| {
+    ///         ctx.after_ack(async move { /* fire-and-forget once acked */ });
+    ///         async { HandlerResult::Ack }
+    ///     };
+    /// }
+    /// ```
+    pub fn after_ack(&mut self, fut: impl Future<Output = ()> + Send + 'static) {
+        self.after.push(AfterHook {
+            gate: Some(OutcomeKind::Ack),
+            fut: Box::pin(fut),
+        });
+    }
+
+    /// Registers a post-settle hook that runs after the message settles, whatever the outcome.
+    ///
+    /// Unlike [`after`](Self::after) this has no outcome gate, so it fires on `Ack`, `Nack`, and
+    /// `NackAfter` alike. It is the only post-settle form honoured on the batch path, where the
+    /// per-element outcomes make an outcome gate ill-defined; there it runs once after the whole
+    /// batch has been settled.
+    ///
+    /// # Cancel safety
+    ///
+    /// At-most-once, as for [`after`](Self::after).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// fn use_after_settle<M: IncomingMessage + 'static>() {
+    ///     let _handler = |_msg: &M, ctx: &mut Context| {
+    ///         ctx.after_settle(async move { /* runs once the message is settled, any outcome */ });
+    ///         async { HandlerResult::retry() }
+    ///     };
+    /// }
+    /// ```
+    pub fn after_settle(&mut self, fut: impl Future<Output = ()> + Send + 'static) {
+        self.after.push(AfterHook {
+            gate: None,
+            fut: Box::pin(fut),
+        });
+    }
+
+    /// Drains the registered hooks whose gate matches `outcome` (and the ungated ones), in
+    /// registration order. Used by the single-message dispatch path after it settles the message.
+    pub(crate) fn take_hooks_for(&mut self, outcome: HandlerResult) -> Vec<Continuation> {
+        let kind = OutcomeKind::of(outcome);
+        let mut runnable = Vec::new();
+        let mut kept = Vec::new();
+        for hook in self.after.drain(..) {
+            if hook.gate.is_none_or(|gate| gate == kind) {
+                runnable.push(hook.fut);
+            } else {
+                kept.push(hook);
+            }
+        }
+        self.after = kept;
+        runnable
+    }
+
+    /// Drains the ungated hooks (registered via [`after_settle`](Self::after_settle)), in
+    /// registration order. Used by the batch dispatch path, where per-element outcomes make the
+    /// outcome gate ill-defined, so only ungated hooks run.
+    pub(crate) fn take_settle_hooks(&mut self) -> Vec<Continuation> {
+        let mut runnable = Vec::new();
+        let mut kept = Vec::new();
+        for hook in self.after.drain(..) {
+            if hook.gate.is_none() {
+                runnable.push(hook.fut);
+            } else {
+                kept.push(hook);
+            }
+        }
+        self.after = kept;
+        runnable
+    }
+}
+
+/// A builder for an outcome-gated post-settle hook, returned by [`Context::after`].
+///
+/// Call [`then`](Self::then) to register the continuation. Holding it without calling `then`
+/// registers nothing.
+#[must_use = "call `.then(fut)` to register the post-settle hook"]
+pub struct After<'ctx, 'a> {
+    ctx: &'ctx mut Context<'a>,
+    gate: Option<OutcomeKind>,
+}
+
+impl std::fmt::Debug for After<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("After").field("gate", &self.gate).finish()
+    }
+}
+
+impl After<'_, '_> {
+    /// Registers `fut` to run after the message settles, if the settlement matches the gate this
+    /// builder was created with (see [`Context::after`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// fn use_then<M: IncomingMessage + 'static>() {
+    ///     let _handler = |_msg: &M, ctx: &mut Context| {
+    ///         ctx.after(HandlerResult::drop())
+    ///             .then(async move { /* runs only if the message is dropped or retried */ });
+    ///         async { HandlerResult::drop() }
+    ///     };
+    /// }
+    /// ```
+    pub fn then(self, fut: impl Future<Output = ()> + Send + 'static) {
+        self.ctx.after.push(AfterHook {
+            gate: self.gate,
+            fut: Box::pin(fut),
+        });
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use futures::future::join_all;
+
     use super::{Context, State};
     use crate::Headers;
     use crate::runtime::dispatch::Delivery;
+    use crate::runtime::handler::HandlerResult;
+
+    fn run_all(continuations: Vec<super::Continuation>) {
+        futures::executor::block_on(async {
+            join_all(continuations).await;
+        });
+    }
+
+    #[test]
+    fn outcome_kind_matches_by_variant_not_value() {
+        use super::OutcomeKind;
+        assert_eq!(OutcomeKind::of(HandlerResult::Ack), OutcomeKind::Ack);
+        // drop() and retry() are both Nack: a gate on either matches the other.
+        assert_eq!(
+            OutcomeKind::of(HandlerResult::drop()),
+            OutcomeKind::of(HandlerResult::retry()),
+        );
+        assert_eq!(OutcomeKind::of(HandlerResult::drop()), OutcomeKind::Nack);
+        // NackAfter gates regardless of the delay value.
+        assert_eq!(
+            OutcomeKind::of(HandlerResult::retry_after(Duration::from_secs(1))),
+            OutcomeKind::of(HandlerResult::retry_after(Duration::from_secs(9))),
+        );
+        assert_eq!(
+            OutcomeKind::of(HandlerResult::retry_after(Duration::ZERO)),
+            OutcomeKind::NackAfter,
+        );
+    }
+
+    #[test]
+    fn take_hooks_runs_only_the_matching_gate() {
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("t", &headers, &state, &delivery);
+
+        let acked = Arc::new(AtomicU32::new(0));
+        let nacked = Arc::new(AtomicU32::new(0));
+        let settled = Arc::new(AtomicU32::new(0));
+
+        let bump = |c: &Arc<AtomicU32>| {
+            let c = Arc::clone(c);
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+            }
+        };
+
+        ctx.after(HandlerResult::Ack).then(bump(&acked));
+        ctx.after(HandlerResult::drop()).then(bump(&nacked));
+        ctx.after_ack(bump(&acked));
+        ctx.after_settle(bump(&settled));
+
+        // Settling with Ack runs both ack-gated hooks and the ungated one, not the Nack one.
+        run_all(ctx.take_hooks_for(HandlerResult::Ack));
+        assert_eq!(acked.load(Ordering::SeqCst), 2);
+        assert_eq!(settled.load(Ordering::SeqCst), 1);
+        assert_eq!(nacked.load(Ordering::SeqCst), 0);
+
+        // The Nack-gated hook is still registered: a later Nack settle runs it.
+        run_all(ctx.take_hooks_for(HandlerResult::retry()));
+        assert_eq!(nacked.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn take_settle_hooks_drops_outcome_gated_ones() {
+        let state = State::default();
+        let delivery = Delivery::empty();
+        let headers = Headers::new();
+        let mut ctx = Context::new("t", &headers, &state, &delivery);
+
+        let gated = Arc::new(AtomicU32::new(0));
+        let ungated = Arc::new(AtomicU32::new(0));
+
+        let gated_clone = Arc::clone(&gated);
+        ctx.after(HandlerResult::Ack).then(async move {
+            gated_clone.fetch_add(1, Ordering::SeqCst);
+        });
+        let ungated_clone = Arc::clone(&ungated);
+        ctx.after_settle(async move {
+            ungated_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        // The batch path drops outcome-gated hooks (per-element outcomes), keeps ungated ones.
+        run_all(ctx.take_settle_hooks());
+        assert_eq!(ungated.load(Ordering::SeqCst), 1);
+        assert_eq!(gated.load(Ordering::SeqCst), 0);
+    }
 
     #[test]
     fn headers_clone_only_on_first_mutation() {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -21,23 +21,28 @@ use super::publish::ScopedPublisher;
 /// batch) has been settled.
 type Continuation = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
-/// The settlement variant a post-settle hook is gated on, matched by variant only (not by the
-/// `Nack { requeue }` flag or the `NackAfter { delay }` value): `drop()` and `retry()` both gate
-/// on [`OutcomeKind::Nack`], `retry_after` on [`OutcomeKind::NackAfter`].
+/// The settlement kind a post-settle hook is gated on. Drop and retry are distinct settlements
+/// (`nack` without vs with requeue), so they gate separately: [`HandlerResult::drop`] gates on
+/// [`Drop`](Self::Drop), [`HandlerResult::retry`] on [`Retry`](Self::Retry), and
+/// [`HandlerResult::retry_after`] on [`RetryAfter`](Self::RetryAfter) regardless of the delay
+/// value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OutcomeKind {
     Ack,
-    Nack,
-    NackAfter,
+    Drop,
+    Retry,
+    RetryAfter,
 }
 
 impl OutcomeKind {
-    /// The variant of `outcome`, discarding the carried `requeue` / `delay` payload.
+    /// The settlement kind of `outcome`: the `requeue` flag splits a `Nack` into drop vs retry; the
+    /// `NackAfter` delay value is discarded.
     fn of(outcome: HandlerResult) -> Self {
         match outcome {
             HandlerResult::Ack => Self::Ack,
-            HandlerResult::Nack { .. } => Self::Nack,
-            HandlerResult::NackAfter { .. } => Self::NackAfter,
+            HandlerResult::Nack { requeue: false } => Self::Drop,
+            HandlerResult::Nack { requeue: true } => Self::Retry,
+            HandlerResult::NackAfter { .. } => Self::RetryAfter,
         }
     }
 }
@@ -167,10 +172,11 @@ impl<'a> Context<'a> {
     ///
     /// The returned builder's [`then`](After::then) registers a future that the dispatcher runs
     /// once the message has been settled, but only if the actual settlement matches `outcome` by
-    /// variant: `Ack`, `Nack`, or `NackAfter`. Both [`HandlerResult::drop`] and
-    /// [`HandlerResult::retry`] are `Nack`, so either gates on a `Nack` settlement regardless of
-    /// the `requeue` flag; [`HandlerResult::retry_after`] gates on `NackAfter` regardless of the
-    /// delay. Multiple hooks accumulate and every matching one runs.
+    /// kind. The four kinds are distinct: [`HandlerResult::Ack`], [`HandlerResult::drop`] (nack
+    /// without requeue), [`HandlerResult::retry`] (nack with requeue), and
+    /// [`HandlerResult::retry_after`] (which matches regardless of the delay). So a hook gated on
+    /// `drop()` does not fire on a `retry()` settlement, and vice versa. Multiple hooks accumulate
+    /// and every matching one runs.
     ///
     /// The hook is scoped to the whole delivery. On the batch path a `Context` is one per batch,
     /// so a hook registered here runs after the entire batch settles; because a batch has
@@ -238,8 +244,8 @@ impl<'a> Context<'a> {
 
     /// Registers a post-settle hook that runs after the message settles, whatever the outcome.
     ///
-    /// Unlike [`after`](Self::after) this has no outcome gate, so it fires on `Ack`, `Nack`, and
-    /// `NackAfter` alike. It is the only post-settle form honoured on the batch path, where the
+    /// Unlike [`after`](Self::after) this has no outcome gate, so it fires on `Ack`, `Drop`,
+    /// `Retry`, and `RetryAfter` alike. It is the only post-settle form honoured on the batch path, where the
     /// per-element outcomes make an outcome gate ill-defined; there it runs once after the whole
     /// batch has been settled.
     ///
@@ -331,7 +337,7 @@ impl After<'_, '_> {
     /// fn use_then<M: IncomingMessage + 'static>() {
     ///     let _handler = |_msg: &M, ctx: &mut Context| {
     ///         ctx.after(HandlerResult::drop())
-    ///             .then(async move { /* runs only if the message is dropped or retried */ });
+    ///             .then(async move { /* runs only if the message is dropped (nack, no requeue) */ });
     ///         async { HandlerResult::drop() }
     ///     };
     /// }
@@ -364,23 +370,28 @@ mod tests {
     }
 
     #[test]
-    fn outcome_kind_matches_by_variant_not_value() {
+    fn outcome_kind_distinguishes_drop_retry_and_retry_after() {
         use super::OutcomeKind;
         assert_eq!(OutcomeKind::of(HandlerResult::Ack), OutcomeKind::Ack);
-        // drop() and retry() are both Nack: a gate on either matches the other.
-        assert_eq!(
+        // drop (nack, no requeue) and retry (nack, requeue) are distinct kinds.
+        assert_eq!(OutcomeKind::of(HandlerResult::drop()), OutcomeKind::Drop);
+        assert_eq!(OutcomeKind::of(HandlerResult::retry()), OutcomeKind::Retry);
+        assert_ne!(
             OutcomeKind::of(HandlerResult::drop()),
             OutcomeKind::of(HandlerResult::retry()),
         );
-        assert_eq!(OutcomeKind::of(HandlerResult::drop()), OutcomeKind::Nack);
-        // NackAfter gates regardless of the delay value.
+        // retry_after is its own kind, distinct from retry, and matches regardless of the delay.
+        assert_eq!(
+            OutcomeKind::of(HandlerResult::retry_after(Duration::from_secs(1))),
+            OutcomeKind::RetryAfter,
+        );
+        assert_ne!(
+            OutcomeKind::of(HandlerResult::retry_after(Duration::ZERO)),
+            OutcomeKind::of(HandlerResult::retry()),
+        );
         assert_eq!(
             OutcomeKind::of(HandlerResult::retry_after(Duration::from_secs(1))),
             OutcomeKind::of(HandlerResult::retry_after(Duration::from_secs(9))),
-        );
-        assert_eq!(
-            OutcomeKind::of(HandlerResult::retry_after(Duration::ZERO)),
-            OutcomeKind::NackAfter,
         );
     }
 
@@ -392,7 +403,8 @@ mod tests {
         let mut ctx = Context::new("t", &headers, &state, &delivery);
 
         let acked = Arc::new(AtomicU32::new(0));
-        let nacked = Arc::new(AtomicU32::new(0));
+        let dropped = Arc::new(AtomicU32::new(0));
+        let retried = Arc::new(AtomicU32::new(0));
         let settled = Arc::new(AtomicU32::new(0));
 
         let bump = |c: &Arc<AtomicU32>| {
@@ -403,19 +415,27 @@ mod tests {
         };
 
         ctx.after(HandlerResult::Ack).then(bump(&acked));
-        ctx.after(HandlerResult::drop()).then(bump(&nacked));
+        ctx.after(HandlerResult::drop()).then(bump(&dropped));
+        ctx.after(HandlerResult::retry()).then(bump(&retried));
         ctx.after_ack(bump(&acked));
         ctx.after_settle(bump(&settled));
 
-        // Settling with Ack runs both ack-gated hooks and the ungated one, not the Nack one.
+        // Settling with Ack runs both ack-gated hooks and the ungated one, not drop or retry.
         run_all(ctx.take_hooks_for(HandlerResult::Ack));
         assert_eq!(acked.load(Ordering::SeqCst), 2);
         assert_eq!(settled.load(Ordering::SeqCst), 1);
-        assert_eq!(nacked.load(Ordering::SeqCst), 0);
+        assert_eq!(dropped.load(Ordering::SeqCst), 0);
+        assert_eq!(retried.load(Ordering::SeqCst), 0);
 
-        // The Nack-gated hook is still registered: a later Nack settle runs it.
+        // A retry settle runs only the retry-gated hook: drop and retry are distinct mechanics.
         run_all(ctx.take_hooks_for(HandlerResult::retry()));
-        assert_eq!(nacked.load(Ordering::SeqCst), 1);
+        assert_eq!(retried.load(Ordering::SeqCst), 1);
+        assert_eq!(dropped.load(Ordering::SeqCst), 0);
+
+        // The drop-gated hook is still registered: a later drop settle runs it.
+        run_all(ctx.take_hooks_for(HandlerResult::drop()));
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        assert_eq!(retried.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -10,6 +10,7 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, error, warn};
 
 use crate::{BatchSubscriber, Headers, IncomingMessage, Subscriber};
@@ -126,12 +127,15 @@ where
     H: Handler<S::Message> + 'static,
 {
     tokio::spawn(async move {
+        let hooks = TaskTracker::new();
         let mut stream = std::pin::pin!(subscriber.stream());
         loop {
             tokio::select! {
                 () = shutdown.cancelled() => break,
                 next = stream.next() => match next {
-                    Some(Ok(msg)) => dispatch(&*handler, msg, &name, &state, &delivery).await,
+                    Some(Ok(msg)) => {
+                        dispatch(&*handler, msg, &name, &state, &delivery, &hooks).await;
+                    }
                     Some(Err(err)) => {
                         error!(
                             target: "ruststream::dispatch",
@@ -150,7 +154,16 @@ where
                 }
             }
         }
+        drain_hooks(hooks).await;
     })
+}
+
+/// Closes a hook tracker to new spawns and waits for the in-flight post-settle continuations to
+/// finish. Called once the dispatch loop exits; bounded from the outside by the app's
+/// `shutdown_timeout`, which aborts the whole dispatch task (and these hooks with it) on timeout.
+async fn drain_hooks(hooks: TaskTracker) {
+    hooks.close();
+    hooks.wait().await;
 }
 
 /// Spawns a task that drives `subscriber` through `handler` with a bounded worker pool: up to
@@ -203,6 +216,7 @@ where
     H: Handler<S::Message> + 'static,
 {
     tokio::spawn(async move {
+        let hooks = TaskTracker::new();
         let mut stream = std::pin::pin!(subscriber.stream());
         let mut tasks = JoinSet::new();
         loop {
@@ -218,8 +232,9 @@ where
                         let name = Arc::clone(&name);
                         let state = Arc::clone(&state);
                         let delivery = Arc::clone(&delivery);
+                        let hooks = hooks.clone();
                         tasks.spawn(async move {
-                            dispatch(&*handler, msg, &name, &state, &delivery).await;
+                            dispatch(&*handler, msg, &name, &state, &delivery, &hooks).await;
                         });
                     }
                     Some(Err(err)) => {
@@ -243,6 +258,7 @@ where
         while let Some(joined) = tasks.join_next().await {
             log_worker_exit(joined);
         }
+        drain_hooks(hooks).await;
     })
 }
 
@@ -264,6 +280,7 @@ where
         // One sequential worker per lane, fed by a capacity-1 channel: a keyed delivery always
         // lands in the lane its key hashes to, so per-key order is preserved. In-flight cap is
         // one processing plus one queued delivery per lane.
+        let hooks = TaskTracker::new();
         let mut lanes = Vec::with_capacity(workers.count);
         let mut tasks = JoinSet::new();
         for _ in 0..workers.count {
@@ -272,9 +289,10 @@ where
             let name = Arc::clone(&name);
             let state = Arc::clone(&state);
             let delivery = Arc::clone(&delivery);
+            let hooks = hooks.clone();
             tasks.spawn(async move {
                 while let Some(msg) = rx.recv().await {
-                    dispatch(&*handler, msg, &name, &state, &delivery).await;
+                    dispatch(&*handler, msg, &name, &state, &delivery, &hooks).await;
                 }
             });
             lanes.push(tx);
@@ -330,6 +348,7 @@ where
         while let Some(joined) = tasks.join_next().await {
             log_worker_exit(joined);
         }
+        drain_hooks(hooks).await;
     })
 }
 
@@ -371,6 +390,7 @@ where
     H: BatchHandler<S::Message> + 'static,
 {
     tokio::spawn(async move {
+        let hooks = TaskTracker::new();
         let mut stream = std::pin::pin!(subscriber.batches());
         let mut tasks = JoinSet::new();
         loop {
@@ -390,15 +410,24 @@ where
                             let empty = Headers::new();
                             let mut ctx = Context::new(&name, &empty, &state, &delivery);
                             handler.handle_batch(batch, &mut ctx).await;
+                            // Per-element outcomes make an outcome gate ill-defined on a batch, so
+                            // only ungated `after_settle` hooks run, once the batch has settled.
+                            for fut in ctx.take_settle_hooks() {
+                                hooks.spawn(fut);
+                            }
                         } else {
                             let handler = Arc::clone(&handler);
                             let name = Arc::clone(&name);
                             let state = Arc::clone(&state);
                             let delivery = Arc::clone(&delivery);
+                            let hooks = hooks.clone();
                             tasks.spawn(async move {
                                 let empty = Headers::new();
                                 let mut ctx = Context::new(&name, &empty, &state, &delivery);
                                 handler.handle_batch(batch, &mut ctx).await;
+                                for fut in ctx.take_settle_hooks() {
+                                    hooks.spawn(fut);
+                                }
                             });
                         }
                     }
@@ -423,16 +452,26 @@ where
         while let Some(joined) = tasks.join_next().await {
             log_worker_exit(joined);
         }
+        drain_hooks(hooks).await;
     })
 }
 
-async fn dispatch<H, M>(handler: &H, msg: M, name: &str, state: &State, delivery: &Delivery)
-where
+async fn dispatch<H, M>(
+    handler: &H,
+    msg: M,
+    name: &str,
+    state: &State,
+    delivery: &Delivery,
+    hooks: &TaskTracker,
+) where
     H: Handler<M>,
     M: IncomingMessage,
 {
     let mut ctx = Context::new(name, msg.headers(), state, delivery);
     let outcome = handler.handle(&msg, &mut ctx).await;
+    // Drain the matching hooks before settling: `ctx` borrows `msg`'s headers, and settling
+    // consumes `msg`. The futures own their captures, so they outlive the borrow.
+    let continuations = ctx.take_hooks_for(outcome);
     let ack_result = match outcome {
         HandlerResult::Ack => msg.ack().await,
         HandlerResult::Nack { requeue } => msg.nack(requeue).await,
@@ -445,5 +484,10 @@ where
             error = %err,
             "ack / nack failed",
         );
+    }
+    // Hooks run after the message is settled: at-most-once, off the delivery path. Tracked so a
+    // graceful shutdown drains them rather than dropping them mid-flight.
+    for fut in continuations {
+        hooks.spawn(fut);
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,7 +21,7 @@ mod typed;
 pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
 pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};
-pub use context::{Context, State};
+pub use context::{After, Context, State};
 pub use dispatch::Workers;
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
 pub use handler::{Handler, HandlerResult, IntoHandlerResult};

--- a/tests/post_settle_hooks.rs
+++ b/tests/post_settle_hooks.rs
@@ -1,0 +1,236 @@
+//! Integration tests for post-settle hooks (`ctx.after(..).then(..)`, `after_ack`,
+//! `after_settle`) on the single-message and batch dispatch paths, driven through the
+//! `#[subscriber]` macro over `MemoryBroker`.
+#![cfg(all(feature = "macros", feature = "memory", feature = "json"))]
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
+    let result = tokio::time::timeout(timeout, async {
+        while !cond() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "condition not met within {timeout:?}");
+}
+
+// Shared counters keyed by a static so the macro handler (a free fn) can reach them.
+#[derive(Clone, Default)]
+struct Counters {
+    ack: Arc<AtomicU32>,
+    nack: Arc<AtomicU32>,
+    settle: Arc<AtomicU32>,
+    handled: Arc<AtomicU32>,
+}
+
+/// Odd ids ack, even ids drop; each registers an ack-gated, a nack-gated and an ungated hook.
+#[subscriber("orders")]
+async fn handle_order(order: &Order, ctx: &mut Context) -> HandlerResult {
+    let c = ctx.get::<Counters>().expect("counters in state").clone();
+    let outcome = if order.id % 2 == 1 {
+        HandlerResult::Ack
+    } else {
+        HandlerResult::drop()
+    };
+
+    let ack = Arc::clone(&c.ack);
+    ctx.after(HandlerResult::Ack).then(async move {
+        ack.fetch_add(1, Ordering::SeqCst);
+    });
+    let nack = Arc::clone(&c.nack);
+    ctx.after(HandlerResult::drop()).then(async move {
+        nack.fetch_add(1, Ordering::SeqCst);
+    });
+    let settle = Arc::clone(&c.settle);
+    ctx.after_settle(async move {
+        settle.fetch_add(1, Ordering::SeqCst);
+    });
+
+    c.handled.fetch_add(1, Ordering::SeqCst);
+    outcome
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn outcome_gated_and_ungated_hooks_fire_per_settlement() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let counters = Counters::default();
+
+    let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .insert_state(counters.clone())
+        .with_broker(broker, |b| b.include(handle_order));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    // The macro subscription opens inside run(); retry until both deliveries land.
+    let publish = |id: u32| {
+        let publisher = &publisher;
+        async move {
+            let _ = publisher
+                .publish(OutgoingMessage::new("orders", &order_bytes(id)))
+                .await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            publish(1).await;
+            publish(2).await;
+            if counters.handled.load(Ordering::SeqCst) >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deliveries within deadline");
+
+    // One ack-gated, one nack-gated; both settle hooks ran. Use >= since the retry loop may
+    // publish extra copies before the first pair is handled.
+    wait_for(
+        || {
+            counters.ack.load(Ordering::SeqCst) >= 1
+                && counters.nack.load(Ordering::SeqCst) >= 1
+                && counters.settle.load(Ordering::SeqCst) >= 2
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+static SLOW_DONE: AtomicU32 = AtomicU32::new(0);
+static SLOW_HANDLED: Notify = Notify::const_new();
+
+/// A handler whose after-ack hook yields before completing, to prove graceful shutdown drains it.
+#[subscriber("slow")]
+async fn handle_slow(_order: &Order, ctx: &mut Context) -> HandlerResult {
+    ctx.after_ack(async {
+        tokio::task::yield_now().await;
+        SLOW_DONE.fetch_add(1, Ordering::SeqCst);
+    });
+    SLOW_HANDLED.notify_one();
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hooks_drain_on_graceful_shutdown() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("slow", "0.1.0"))
+        .with_broker(broker, |b| b.include(handle_slow));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let _ = publisher
+                .publish(OutgoingMessage::new("slow", &order_bytes(1)))
+                .await;
+            tokio::select! {
+                () = SLOW_HANDLED.notified() => break,
+                () = tokio::task::yield_now() => {}
+            }
+        }
+    })
+    .await
+    .expect("delivery within deadline");
+
+    // Request shutdown immediately; the in-flight hook must still be drained.
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+    assert!(
+        SLOW_DONE.load(Ordering::SeqCst) >= 1,
+        "hook was not drained"
+    );
+}
+
+static BATCH_SETTLE: AtomicU32 = AtomicU32::new(0);
+static BATCH_GATED: AtomicU32 = AtomicU32::new(0);
+static BATCH_NOTIFY: Notify = Notify::const_new();
+
+/// A batch handler: the ungated after_settle hook fires once per batch; the outcome-gated one is
+/// dropped on the batch path (per-element outcomes make a single gate ill-defined).
+#[subscriber(batch("batched"))]
+async fn handle_batch(orders: &[Order], ctx: &mut Context) -> HandlerResult {
+    let _ = orders.len();
+    ctx.after_settle(async {
+        BATCH_SETTLE.fetch_add(1, Ordering::SeqCst);
+        BATCH_NOTIFY.notify_one();
+    });
+    ctx.after(HandlerResult::Ack).then(async {
+        BATCH_GATED.fetch_add(1, Ordering::SeqCst);
+    });
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_runs_after_settle_drops_outcome_gated() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("batched", "0.1.0"))
+        .with_broker(broker, |b| b.include_batch(handle_batch));
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            for id in 0..3u32 {
+                let _ = publisher
+                    .publish(OutgoingMessage::new("batched", &order_bytes(id)))
+                    .await;
+            }
+            tokio::select! {
+                () = BATCH_NOTIFY.notified() => break,
+                () = tokio::task::yield_now() => {}
+            }
+            if BATCH_SETTLE.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("batch settled within deadline");
+
+    // Let any (incorrect) outcome-gated hook run before asserting it did not.
+    tokio::task::yield_now().await;
+    assert_eq!(
+        BATCH_GATED.load(Ordering::SeqCst),
+        0,
+        "outcome-gated hooks must not run on the batch path",
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}

--- a/tests/post_settle_hooks.rs
+++ b/tests/post_settle_hooks.rs
@@ -40,12 +40,15 @@ async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
 #[derive(Clone, Default)]
 struct Counters {
     ack: Arc<AtomicU32>,
-    nack: Arc<AtomicU32>,
+    dropped: Arc<AtomicU32>,
+    retried: Arc<AtomicU32>,
     settle: Arc<AtomicU32>,
     handled: Arc<AtomicU32>,
 }
 
-/// Odd ids ack, even ids drop; each registers an ack-gated, a nack-gated and an ungated hook.
+/// Odd ids ack, even ids drop (never retry); each registers an ack-gated, a drop-gated, a
+/// retry-gated, and an ungated hook. The retry-gated one must never fire, proving drop and retry
+/// are distinct mechanics.
 #[subscriber("orders")]
 async fn handle_order(order: &Order, ctx: &mut Context) -> HandlerResult {
     let c = ctx.get::<Counters>().expect("counters in state").clone();
@@ -59,9 +62,13 @@ async fn handle_order(order: &Order, ctx: &mut Context) -> HandlerResult {
     ctx.after(HandlerResult::Ack).then(async move {
         ack.fetch_add(1, Ordering::SeqCst);
     });
-    let nack = Arc::clone(&c.nack);
+    let dropped = Arc::clone(&c.dropped);
     ctx.after(HandlerResult::drop()).then(async move {
-        nack.fetch_add(1, Ordering::SeqCst);
+        dropped.fetch_add(1, Ordering::SeqCst);
+    });
+    let retried = Arc::clone(&c.retried);
+    ctx.after(HandlerResult::retry()).then(async move {
+        retried.fetch_add(1, Ordering::SeqCst);
     });
     let settle = Arc::clone(&c.settle);
     ctx.after_settle(async move {
@@ -108,17 +115,24 @@ async fn outcome_gated_and_ungated_hooks_fire_per_settlement() {
     .await
     .expect("deliveries within deadline");
 
-    // One ack-gated, one nack-gated; both settle hooks ran. Use >= since the retry loop may
+    // One ack-gated, one drop-gated; both settle hooks ran. Use >= since the retry loop may
     // publish extra copies before the first pair is handled.
     wait_for(
         || {
             counters.ack.load(Ordering::SeqCst) >= 1
-                && counters.nack.load(Ordering::SeqCst) >= 1
+                && counters.dropped.load(Ordering::SeqCst) >= 1
                 && counters.settle.load(Ordering::SeqCst) >= 2
         },
         Duration::from_secs(5),
     )
     .await;
+
+    // Nothing ever retried, so the retry-gated hook never fired: drop does not trigger a retry hook.
+    assert_eq!(
+        counters.retried.load(Ordering::SeqCst),
+        0,
+        "a retry-gated hook must not fire when messages are dropped",
+    );
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();


### PR DESCRIPTION
# Description

Adds an additive post-settle hook API on the per-delivery `Context`. After a handler returns and the dispatcher settles the message, registered continuations whose registered outcome matches the actual settlement (matched by variant: `Ack` / `Nack` / `NackAfter`) run off the delivery path. This is the non-breaking, per-message / per-batch subset of the post-settle problem (the breaking per-element variant stays in #68).

New `Context` methods:

- `after(outcome).then(fut)` - registers a continuation gated on `outcome`, matched by variant only (`drop()` and `retry()` both gate on `Nack`; `retry_after` gates on `NackAfter` regardless of delay), via a small `After` builder.
- `after_ack(fut)` - sugar for the ack case.
- `after_settle(fut)` - runs after settlement regardless of outcome.

Multiple registrations accumulate and every matching one runs. `HandlerResult`, `Handler`, `SliceHandler`, `BatchResult`, and middleware signatures are untouched, so this is purely additive and ships in 0.3.x.

## Execution and cancel safety

Continuations run in a per-dispatch-loop `tokio_util::task::TaskTracker` rather than being awaited inline (inline would delay the next delivery on the sequential path). The dispatch loop drains its tracker before returning, so a graceful shutdown (bounded by `shutdown_timeout`) drains in-flight hooks. Semantics are at-most-once: the message is already settled before any hook runs, so a lost or panicking continuation never causes a redelivery. Documented under `# Cancel safety`.

## Batch path decision

A `Context` is one per batch, so a hook runs after the whole batch settles. Because a batch has per-element outcomes, an outcome gate is ill-defined there: the batch path runs only the ungated `after_settle` hooks (the gated `after(..)` / `after_ack` forms are ignored on a batch). This is documented on the methods and in the context guide, and covered by a test.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable

Fixes #70