### PR TITLE
perf: zero-allocation publish path (Cow name, BytesMut payload)

### DIFF
--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -66,6 +66,7 @@ let app = RustStream::new(info)
 ```
 
 ```rust
+use ruststream::codec::{Codec, JsonCodec};
 use ruststream::runtime::{HandlerResult, Outgoing};
 
 --8<-- "examples/publishing.rs:forward"
@@ -87,7 +88,7 @@ Two kinds of transform run before a message leaves the process, and they compose
   concerns (publish metrics, a dead-letter wrapper) applied to every published message. They run
   outside the static layers, then the message is sent.
 
-A static `PublishLayer` implements `apply(&mut Outgoing)`:
+A static `PublishLayer` implements `apply(&mut Outgoing<'_>)`:
 
 ```rust
 --8<-- "examples/publishing.rs:static_layer"

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -8,6 +8,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use ruststream::codec::{Codec, JsonCodec};
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, HandlerResult, Outgoing, PublishLayer, PublishMiddleware, PublishNext, RustStream,
@@ -55,7 +56,8 @@ async fn validate(req: &Request) -> Result<Response, HandlerResult> {
 #[subscriber("ingress")]
 async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
     if let Some(publisher) = ctx.publisher("egress") {
-        let out = Outgoing::new("egress", serde_json::to_vec(event).expect("serializable"));
+        let payload = JsonCodec.encode(event).expect("serializable");
+        let out = Outgoing::new("egress", payload);
         if publisher.publish(out).await.is_err() {
             return HandlerResult::retry();
         }
@@ -69,7 +71,7 @@ async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
 struct EnvelopeLayer;
 
 impl PublishLayer for EnvelopeLayer {
-    fn apply(&self, out: &mut Outgoing) {
+    fn apply(&self, out: &mut Outgoing<'_>) {
         out.headers_mut().insert("x-envelope", b"1".to_vec());
     }
 }
@@ -82,7 +84,7 @@ struct AuditPublish;
 impl PublishMiddleware for AuditPublish {
     fn on_publish<'a>(
         &'a self,
-        out: &'a mut Outgoing,
+        out: &'a mut Outgoing<'a>,
         next: PublishNext<'a>,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -59,7 +59,7 @@ impl<M: Send + Sync, H: Handler<M>> Handler<M> for Observed<H> {
 pub(crate) struct StampSource;
 
 impl PublishLayer for StampSource {
-    fn apply(&self, out: &mut Outgoing) {
+    fn apply(&self, out: &mut Outgoing<'_>) {
         out.headers_mut()
             .insert("x-source-service", b"orders-service".to_vec());
     }

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -1,6 +1,6 @@
 //! CBOR codec backed by [`ciborium`].
 
-use bytes::Bytes;
+use bytes::{BufMut, BytesMut};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::codec::{Codec, CodecError};
@@ -10,10 +10,12 @@ use crate::codec::{Codec, CodecError};
 pub struct CborCodec;
 
 impl Codec for CborCodec {
-    fn encode<T: Serialize>(&self, value: &T) -> Result<Bytes, CodecError> {
-        let mut buf: Vec<u8> = Vec::new();
-        ciborium::into_writer(value, &mut buf).map_err(|err| CodecError::Encode(Box::new(err)))?;
-        Ok(Bytes::from(buf))
+    fn encode<T: Serialize>(&self, value: &T) -> Result<BytesMut, CodecError> {
+        // Serialize straight into the BytesMut writer: one buffer, no Vec-to-Bytes hop.
+        let mut buf = BytesMut::new();
+        ciborium::into_writer(value, (&mut buf).writer())
+            .map_err(|err| CodecError::Encode(Box::new(err)))?;
+        Ok(buf)
     }
 
     fn decode<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<T, CodecError> {

--- a/src/codec/json.rs
+++ b/src/codec/json.rs
@@ -1,6 +1,6 @@
 //! JSON codec backed by [`serde_json`].
 
-use bytes::Bytes;
+use bytes::{BufMut, BytesMut};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::codec::{Codec, CodecError};
@@ -10,10 +10,12 @@ use crate::codec::{Codec, CodecError};
 pub struct JsonCodec;
 
 impl Codec for JsonCodec {
-    fn encode<T: Serialize>(&self, value: &T) -> Result<Bytes, CodecError> {
-        serde_json::to_vec(value)
-            .map(Bytes::from)
-            .map_err(|err| CodecError::Encode(Box::new(err)))
+    fn encode<T: Serialize>(&self, value: &T) -> Result<BytesMut, CodecError> {
+        // Serialize straight into the BytesMut writer: one buffer, no Vec-to-Bytes hop.
+        let mut buf = BytesMut::new();
+        serde_json::to_writer((&mut buf).writer(), value)
+            .map_err(|err| CodecError::Encode(Box::new(err)))?;
+        Ok(buf)
     }
 
     fn decode<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<T, CodecError> {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -46,7 +46,7 @@ pub type DefaultCodec = MsgpackCodec;
 
 use std::error::Error as StdError;
 
-use bytes::Bytes;
+use bytes::BytesMut;
 use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
@@ -73,7 +73,8 @@ pub enum CodecError {
 /// # Examples
 ///
 /// ```
-/// # #[cfg(feature = "json")] {
+/// # #[cfg(feature = "json")]
+/// # fn main() -> Result<(), ruststream::codec::CodecError> {
 /// use ruststream::codec::{Codec, JsonCodec};
 /// # use serde::{Serialize, Deserialize};
 ///
@@ -81,18 +82,25 @@ pub enum CodecError {
 /// struct Order { id: u32, total: f64 }
 ///
 /// let codec = JsonCodec;
-/// let bytes = codec.encode(&Order { id: 1, total: 9.99 }).unwrap();
-/// let back: Order = codec.decode(&bytes).unwrap();
+/// let bytes = codec.encode(&Order { id: 1, total: 9.99 })?;
+/// let back: Order = codec.decode(&bytes)?;
 /// assert_eq!(back, Order { id: 1, total: 9.99 });
+/// # Ok(())
 /// # }
+/// # #[cfg(not(feature = "json"))]
+/// # fn main() {}
 /// ```
 pub trait Codec: Send + Sync {
-    /// Encodes `value` into a byte buffer.
+    /// Encodes `value` into a mutable byte buffer.
+    ///
+    /// Returning [`BytesMut`] lets the encoded buffer move into the publish pipeline (an
+    /// [`Outgoing`](crate::runtime::Outgoing) payload) without a copy, while still allowing
+    /// publish middleware to mutate it in place.
     ///
     /// # Errors
     ///
     /// Returns [`CodecError::Encode`] when the underlying serializer fails.
-    fn encode<T: Serialize>(&self, value: &T) -> Result<Bytes, CodecError>;
+    fn encode<T: Serialize>(&self, value: &T) -> Result<BytesMut, CodecError>;
 
     /// Decodes `bytes` into a Rust value of type `T`.
     ///

--- a/src/codec/msgpack.rs
+++ b/src/codec/msgpack.rs
@@ -1,6 +1,6 @@
 //! `MessagePack` codec backed by [`rmp_serde`].
 
-use bytes::Bytes;
+use bytes::{BufMut, BytesMut};
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::codec::{Codec, CodecError};
@@ -10,10 +10,12 @@ use crate::codec::{Codec, CodecError};
 pub struct MsgpackCodec;
 
 impl Codec for MsgpackCodec {
-    fn encode<T: Serialize>(&self, value: &T) -> Result<Bytes, CodecError> {
-        rmp_serde::to_vec(value)
-            .map(Bytes::from)
-            .map_err(|err| CodecError::Encode(Box::new(err)))
+    fn encode<T: Serialize>(&self, value: &T) -> Result<BytesMut, CodecError> {
+        // Serialize straight into the BytesMut writer: one buffer, no Vec-to-Bytes hop.
+        let mut buf = BytesMut::new();
+        rmp_serde::encode::write(&mut (&mut buf).writer(), value)
+            .map_err(|err| CodecError::Encode(Box::new(err)))?;
+        Ok(buf)
     }
 
     fn decode<T: DeserializeOwned>(&self, bytes: &[u8]) -> Result<T, CodecError> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -251,7 +251,11 @@ impl std::fmt::Debug for MetricsPublish {
 }
 
 impl PublishMiddleware for MetricsPublish {
-    fn on_publish<'a>(&'a self, out: &'a mut Outgoing, next: PublishNext<'a>) -> PublishFut<'a> {
+    fn on_publish<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishNext<'a>,
+    ) -> PublishFut<'a> {
         let name = out.name().to_owned();
         Box::pin(async move {
             let result = next.run(out).await;

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -6,8 +6,9 @@
 //! (content-type, schema id), or observe it (publish metrics). The chain is symmetric to the
 //! consume-side [`DynStack`](super::DynStack).
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
 
+use bytes::BytesMut;
 use serde::Serialize;
 use tracing::warn;
 
@@ -23,22 +24,29 @@ use crate::{Headers, Publisher, TransactionalPublisher};
 
 type PublishFut<'a> = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'a>>;
 
-/// An owned, mutable outgoing message flowing through the publish pipeline.
+/// A mutable outgoing message flowing through the publish pipeline.
 ///
-/// Middleware may change the [`name`](Self::name), transform the
-/// [`payload`](Self::payload_mut), and enrich the [`headers`](Self::headers_mut) before the
-/// message is sent.
+/// The [`name`](Self::name) is a [`Cow`]: the macro reply path borrows a string literal
+/// (`reply_name(&self) -> &str`), so the common case carries the destination without an
+/// allocation; a computed name moves in owned. The [`payload`](Self::payload_mut) is a
+/// [`BytesMut`]: codec output moves in directly (no copy), and middleware can still mutate it in
+/// place (for example wrapping it in an envelope). Middleware may change the name, transform the
+/// payload, and enrich the [`headers`](Self::headers_mut) before the message is sent.
 #[derive(Debug, Clone)]
-pub struct Outgoing {
-    name: String,
-    payload: Vec<u8>,
+pub struct Outgoing<'a> {
+    name: Cow<'a, str>,
+    payload: BytesMut,
     headers: Headers,
 }
 
-impl Outgoing {
+impl<'a> Outgoing<'a> {
     /// Creates an outgoing message with no headers.
+    ///
+    /// Pass a `&str` (a borrowed destination, the no-allocation case) or a `String` (a computed
+    /// owned one) for `name`; pass a [`BytesMut`] (codec output moves in) or a `&[u8]` for the
+    /// payload.
     #[must_use]
-    pub fn new(name: impl Into<String>, payload: impl Into<Vec<u8>>) -> Self {
+    pub fn new(name: impl Into<Cow<'a, str>>, payload: impl Into<BytesMut>) -> Self {
         Self {
             name: name.into(),
             payload: payload.into(),
@@ -53,7 +61,7 @@ impl Outgoing {
     }
 
     /// Sets the destination name.
-    pub fn set_name(&mut self, name: impl Into<String>) {
+    pub fn set_name(&mut self, name: impl Into<Cow<'a, str>>) {
         self.name = name.into();
     }
 
@@ -64,12 +72,12 @@ impl Outgoing {
     }
 
     /// The payload bytes, mutably (for envelope wrapping).
-    pub fn payload_mut(&mut self) -> &mut Vec<u8> {
+    pub fn payload_mut(&mut self) -> &mut BytesMut {
         &mut self.payload
     }
 
     /// Replaces the payload.
-    pub fn set_payload(&mut self, payload: impl Into<Vec<u8>>) {
+    pub fn set_payload(&mut self, payload: impl Into<BytesMut>) {
         self.payload = payload.into();
     }
 
@@ -91,7 +99,8 @@ impl Outgoing {
 /// ends in the actual broker publish.
 pub trait PublishMiddleware: Send + Sync {
     /// Handle the outgoing message, calling `next` to continue the pipeline.
-    fn on_publish<'a>(&'a self, out: &'a mut Outgoing, next: PublishNext<'a>) -> PublishFut<'a>;
+    fn on_publish<'a>(&'a self, out: &'a mut Outgoing<'a>, next: PublishNext<'a>)
+    -> PublishFut<'a>;
 }
 
 /// A cursor over the remaining publish middleware, ending in the broker publisher.
@@ -103,7 +112,7 @@ pub struct PublishNext<'a> {
 impl<'a> PublishNext<'a> {
     /// Runs the next middleware, or sends the message if the pipeline is exhausted.
     #[must_use]
-    pub fn run(self, out: &'a mut Outgoing) -> PublishFut<'a> {
+    pub fn run(self, out: &'a mut Outgoing<'a>) -> PublishFut<'a> {
         match self.rest.split_first() {
             Some((middleware, rest)) => middleware.on_publish(
                 out,
@@ -131,7 +140,7 @@ impl std::fmt::Debug for PublishNext<'_> {
 pub(crate) fn run_publish<'a>(
     pipeline: &'a [Arc<dyn PublishMiddleware>],
     publisher: &'a dyn ErasedPublisher,
-    out: &'a mut Outgoing,
+    out: &'a mut Outgoing<'a>,
 ) -> PublishFut<'a> {
     PublishNext {
         rest: pipeline,
@@ -167,7 +176,7 @@ impl<'a> ScopedPublisher<'a> {
     /// # Errors
     ///
     /// Returns the boxed error from a middleware or the broker publish if either fails.
-    pub async fn publish(&self, mut out: Outgoing) -> Result<(), BoxError> {
+    pub async fn publish(&self, mut out: Outgoing<'_>) -> Result<(), BoxError> {
         run_publish(self.pipeline, self.publisher, &mut out).await
     }
 }
@@ -191,7 +200,7 @@ impl std::fmt::Debug for ScopedPublisher<'_> {
 /// run first (closest to the value), then the dynamic pipeline, then the send.
 pub trait PublishLayer: Send + Sync {
     /// Transforms `out` in place before it is sent.
-    fn apply(&self, out: &mut Outgoing);
+    fn apply(&self, out: &mut Outgoing<'_>);
 }
 
 /// The no-op [`PublishLayer`]: the default for a [`TypedPublisher`] with no static transforms.
@@ -199,7 +208,7 @@ pub trait PublishLayer: Send + Sync {
 pub struct PublishIdentity;
 
 impl PublishLayer for PublishIdentity {
-    fn apply(&self, _out: &mut Outgoing) {}
+    fn apply(&self, _out: &mut Outgoing<'_>) {}
 }
 
 /// Composes two [`PublishLayer`]s: `inner` runs first, then `outer`. Built by
@@ -211,7 +220,7 @@ pub struct PublishStack<Inner, Outer> {
 }
 
 impl<Inner: PublishLayer, Outer: PublishLayer> PublishLayer for PublishStack<Inner, Outer> {
-    fn apply(&self, out: &mut Outgoing) {
+    fn apply(&self, out: &mut Outgoing<'_>) {
         self.inner.apply(out);
         self.outer.apply(out);
     }
@@ -317,11 +326,11 @@ impl<P: Publisher, C: Codec, PL: PublishLayer> TypedPublisher<P, C, PL> {
         value: &T,
         pipeline: &[Arc<dyn PublishMiddleware>],
     ) -> Result<(), BoxError> {
-        let bytes = self
+        let payload = self
             .codec
             .encode(value)
             .map_err(|e| Box::new(e) as BoxError)?;
-        let mut out = Outgoing::new(name.to_owned(), bytes.to_vec());
+        let mut out = Outgoing::new(name, payload);
         self.layers.apply(&mut out);
         run_publish(pipeline, &self.publisher, &mut out).await
     }
@@ -461,5 +470,47 @@ where
 async fn abort_quietly<P: TransactionalPublisher>(publisher: &P) {
     if let Err(err) = publisher.abort().await {
         warn!(target: "ruststream::dispatch", error = %err, "transaction abort failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn borrowed_name_is_not_owned() {
+        // The macro-reply hot path passes a string literal: it must stay borrowed (no alloc),
+        // which is the whole point of the Cow.
+        let out = Outgoing::new("orders.created", b"payload".as_slice());
+        assert!(matches!(out.name, Cow::Borrowed(_)));
+        assert_eq!(out.name(), "orders.created");
+        assert_eq!(out.payload(), b"payload");
+    }
+
+    #[test]
+    fn owned_name_moves_in() {
+        let computed = format!("orders.{}", 42);
+        let out = Outgoing::new(computed, BytesMut::from(&b"x"[..]));
+        assert!(matches!(out.name, Cow::Owned(_)));
+        assert_eq!(out.name(), "orders.42");
+    }
+
+    #[test]
+    fn payload_mutates_in_place() {
+        let mut out = Outgoing::new("t", BytesMut::from(&b"body"[..]));
+        out.payload_mut().extend_from_slice(b"!");
+        assert_eq!(out.payload(), b"body!");
+
+        out.set_payload(b"fresh".as_slice());
+        assert_eq!(out.payload(), b"fresh");
+    }
+
+    #[test]
+    fn set_name_and_headers() {
+        let mut out = Outgoing::new("a", b"".as_slice());
+        out.set_name("b");
+        out.headers_mut().insert("k", "v");
+        assert_eq!(out.name(), "b");
+        assert_eq!(out.headers().get_str("k"), Some("v"));
     }
 }

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -534,7 +534,7 @@ struct Tagger;
 impl PublishMiddleware for Tagger {
     fn on_publish<'a>(
         &'a self,
-        out: &'a mut Outgoing,
+        out: &'a mut Outgoing<'a>,
         next: PublishNext<'a>,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
@@ -554,7 +554,7 @@ impl<M: Send + Sync> Handler<M> for Bridge {
     async fn handle(&self, _msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
         if let Some(out) = ctx.publisher("egress") {
             let _ = out
-                .publish(Outgoing::new("responses", b"reply".to_vec()))
+                .publish(Outgoing::new("responses", b"reply".as_slice()))
                 .await;
         }
         HandlerResult::Ack

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -312,7 +312,7 @@ async fn scope_default_codec_drops_per_call_codec() {
 struct StaticEnvelope;
 
 impl PublishLayer for StaticEnvelope {
-    fn apply(&self, out: &mut Outgoing) {
+    fn apply(&self, out: &mut Outgoing<'_>) {
         out.headers_mut().insert("x-static", b"1".to_vec());
     }
 }
@@ -400,7 +400,7 @@ struct Tagger;
 impl PublishMiddleware for Tagger {
     fn on_publish<'a>(
         &'a self,
-        out: &'a mut Outgoing,
+        out: &'a mut Outgoing<'a>,
         next: PublishNext<'a>,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,


### PR DESCRIPTION
# Description

`TypedPublisher::publish` allocated twice per published message: `name.to_owned()` copied the destination (usually a macro-generated string literal from `reply_name()`) into a fresh `String`, and `bytes.to_vec()` copied the buffer the codec had just produced into a new `Vec<u8>`. `Outgoing` owned a `String` plus a `Vec<u8>`, which forced both copies.

This reworks `Outgoing` so the publish path borrows or moves instead of copying:

- `Outgoing` is now `Outgoing<'a>` holding `name: Cow<'a, str>` (the macro reply path borrows `reply_name()` with no allocation; a computed name moves in owned) and `payload: BytesMut` (codec output moves in, middleware can still mutate it in place for envelope wrapping).
- `Codec::encode` returns `BytesMut`, and each codec (`json`, `cbor`, `msgpack`) serializes straight into the `BytesMut` writer, so there is no `Vec`-to-`Bytes` hop.
- `PublishLayer::apply`, `PublishMiddleware::on_publish`, `PublishNext::run`, and `run_publish` thread the `Outgoing` lifetime through.

The broker-facing surface is untouched. `ErasedPublisher` still hands `&str` / `&[u8]` / `&Headers` to the boundary, so `OutgoingMessage` and the `Publisher` trait keep their exact signatures and external broker crates (the published `ruststream-nats` 0.3 used via the dev `[patch.crates-io]`) compile unchanged; `just check` builds `ruststream-nats v0.3.0` against the modified core.

Fixes #44

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

Public API changes (pre-1.0 minor bump, 0.4):

- `Outgoing` -> `Outgoing<'a>`.
- `Outgoing::new` and `Outgoing::set_name` take `impl Into<Cow<'a, str>>`; `Outgoing::new` and `Outgoing::set_payload` take `impl Into<BytesMut>`.
- `Outgoing::payload_mut` returns `&mut BytesMut` (was `&mut Vec<u8>`).
- `Codec::encode` returns `BytesMut` (was `Bytes`).
- `PublishLayer::apply`, `PublishMiddleware::on_publish`, `PublishNext::run` now carry the `Outgoing` lifetime (`Outgoing<'_>` / `Outgoing<'a>`).

Unchanged (broker-facing, deliberately stable): `Broker`, `Subscriber`, `Publisher`, `IncomingMessage`, `OutgoingMessage`, the capability traits, and `ErasedPublisher`.

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable