### PR TITLE
feat: per-delivery Context extensions; move app state behind ctx.state()

### DIFF
--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -6,7 +6,7 @@ lifetimes:
 | Level | Type | Lives for | Holds |
 |---|---|---|---|
 | Application | `State` | the whole service | shared resources: pools, clients, configuration |
-| Delivery | `Context` | one message | the channel name, a headers working copy, access to `State` and named publishers |
+| Delivery | `Context` | one message | the channel name, a headers working copy, a per-delivery `Extensions` type-map, access to `State` and named publishers |
 
 `State` is filled once, at startup. A `Context` is built fresh for every delivery and threaded as
 `&mut` through the middleware chain into the handler, so middleware and the handler observe (and
@@ -22,7 +22,7 @@ can enrich) the same per-message view.
   create (a database pool). See [Lifespan](lifespan.md) for the hook contract.
 
 Inserting a second value of the same type replaces the first. Handlers read it through the context
-with `ctx.get::<T>()`, which returns `Option<&T>` - `None` only if nothing of that type was
+with `ctx.state().get::<T>()`, which returns `Option<&T>` - `None` only if nothing of that type was
 inserted. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
 references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when
 a shared value must change at runtime.
@@ -48,13 +48,33 @@ What the context exposes:
 | `name()` | `&str` | the channel / subject the message arrived on |
 | `headers()` | `&Headers` | the working copy of the message headers |
 | `headers_mut()` | `&mut Headers` | the same copy, for middleware to enrich |
-| `get::<T>()` | `Option<&T>` | shared application state |
+| `state()` | `&State` | shared application state (then `.get::<T>()`) |
+| `get::<T>()` | `Option<&T>` | a per-delivery [extension](#per-delivery-extensions) |
+| `insert::<T>(v)` | `()` | write a per-delivery [extension](#per-delivery-extensions) |
 | `publisher(name)` | `Option<ScopedPublisher>` | a [named publisher](publishing.md#publishing-from-inside-a-handler) |
 | `after(outcome).then(fut)` | `()` | a [post-settle hook](#post-settle-hooks) gated on the settlement outcome |
 | `after_ack(fut)` / `after_settle(fut)` | `()` | post-settle hook sugar (after an ack / after any settlement) |
 
 Closure handlers (the manual `typed(codec, |msg, ctx| ...)` form) always take the context as their
 second argument.
+
+## Per-delivery extensions
+
+Beside the shared `State`, the context carries an `Extensions` type-map scoped to one delivery:
+`ctx.insert::<T>(value)` writes it, `ctx.get::<T>()` reads it back, and it is dropped when the
+handler returns, so one delivery's values never leak into the next. Use it for data that belongs to
+a single message rather than the whole service - a correlation id, an authenticated user a layer
+resolved, a tracing span.
+
+```rust
+--8<-- "examples/context.rs:extensions"
+```
+
+A broker can also seed the map: implementing `IncomingMessage::extensions` lets it hand the handler
+typed per-delivery values (native delivery metadata, a commit token, a reply-to handle) without
+serializing them into the byte-only headers. The runtime moves the broker's map into the context
+before the handler runs, and those values stay reachable through the publish pipeline, so a
+transactional publisher can read a broker-supplied commit token at commit time.
 
 ## The headers working copy
 

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -22,8 +22,10 @@ Read them from any handler or middleware through the `Context`:
 --8<-- "examples/lifespan.rs:handler"
 ```
 
-`ctx.get::<T>()` returns `Option<&T>`; it is `None` only if no value of that type was inserted.
-Inserting the same type again replaces the previous value.
+`ctx.state().get::<T>()` returns `Option<&T>`; it is `None` only if no value of that type was
+inserted. Inserting the same type again replaces the previous value. (`ctx.get::<T>()` without
+`state()` reads the per-delivery [extensions](context.md#per-delivery-extensions), a separate
+type-map scoped to one message.)
 
 A `#[subscriber]` handler opts into the context by taking a second parameter, `ctx: &mut Context`,
 after the payload. Omit it when the handler does not need state. Everything else the context

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -39,8 +39,9 @@ async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
         println!("request {}", String::from_utf8_lossy(id));
     }
 
-    // 3. App-level shared state.
+    // 3. App-level shared state, reached through state().
     let config = ctx
+        .state()
         .get::<AppConfig>()
         .expect("config inserted at build time");
     if config.reject_zero_ids && order.id == 0 {
@@ -55,6 +56,14 @@ async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
         println!("order {id} acked; sending the confirmation");
     });
 
+    // --8<-- [start:extensions]
+    // 5. Per-delivery extensions: a value scoped to this one delivery (set by middleware or a
+    // broker, then read by the handler). Distinct from the shared app state above.
+    ctx.insert(order.id);
+    if let Some(seen) = ctx.get::<u64>() {
+        println!("processing order {seen}");
+    }
+    // --8<-- [end:extensions]
     HandlerResult::Ack
 }
 // --8<-- [end:handler]

--- a/examples/lifespan.rs
+++ b/examples/lifespan.rs
@@ -51,6 +51,7 @@ impl Database {
 #[subscriber("orders")]
 async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
     let db = ctx
+        .state()
         .get::<Database>()
         .expect("database inserted in on_startup");
     if db.insert_order(order.id).await.is_err() {

--- a/examples/routed_service/orders.rs
+++ b/examples/routed_service/orders.rs
@@ -26,6 +26,7 @@ pub(crate) async fn confirm(
     ctx: &mut Context<'_>,
 ) -> Result<Confirmation, HandlerResult> {
     let repo = ctx
+        .state()
         .get::<Repository>()
         .expect("repository set in on_startup");
     tracing::debug!(
@@ -57,6 +58,7 @@ pub(crate) async fn confirm(
 #[subscriber("cancellations")]
 pub(crate) async fn on_cancel(cancel: &Cancellation, ctx: &mut Context<'_>) -> HandlerResult {
     let repo = ctx
+        .state()
         .get::<Repository>()
         .expect("repository set in on_startup");
     match repo.cancel(cancel.order_id).await {

--- a/examples/routed_service/payments.rs
+++ b/examples/routed_service/payments.rs
@@ -15,6 +15,7 @@ use crate::domain::{Clearing, Payment, Repository, Settlement};
 #[subscriber("payments", workers(8, by_key))]
 pub(crate) async fn process_payment(payment: &Payment, ctx: &mut Context<'_>) -> HandlerResult {
     let repo = ctx
+        .state()
         .get::<Repository>()
         .expect("repository set in on_startup");
     tracing::debug!(order = payment.order_id, customer = %payment.customer, "charging payment");

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,0 +1,138 @@
+//! The [`Extensions`] per-delivery type-map.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+/// A per-delivery type-map: at most one value per type, scoped to a single delivery.
+///
+/// Unlike the app-level `State` (shared, set once at build), an `Extensions` map is created fresh
+/// for each delivery and dropped when the handler returns, so one delivery's values never leak into
+/// the next. A broker contributes typed per-delivery data through
+/// [`IncomingMessage::extensions`](crate::IncomingMessage::extensions) (native delivery metadata,
+/// a commit token, a reply-to handle) without going through the byte-only headers; middleware may
+/// write entries for downstream handlers (via
+/// [`Context::insert`](crate::runtime::Context::insert)); and the values are reachable from the
+/// publish path so a transactional publisher can read a broker-supplied commit token at commit
+/// time.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::Extensions;
+///
+/// # fn run() -> Option<()> {
+/// let mut ext = Extensions::new();
+/// ext.insert(7u32);
+/// assert_eq!(*ext.get::<u32>()?, 7);
+/// # Some(())
+/// # }
+/// # run().expect("value was inserted");
+/// ```
+#[derive(Default)]
+pub struct Extensions {
+    map: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl Extensions {
+    /// Creates an empty map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::Extensions;
+    ///
+    /// let ext = Extensions::new();
+    /// assert!(ext.is_empty());
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts `value`, replacing any previous value of the same type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::Extensions;
+    ///
+    /// # fn run() -> Option<()> {
+    /// let mut ext = Extensions::new();
+    /// ext.insert("first");
+    /// ext.insert("second");
+    /// assert_eq!(*ext.get::<&str>()?, "second");
+    /// # Some(())
+    /// # }
+    /// # run().expect("value was inserted");
+    /// ```
+    pub fn insert<T: Any + Send + Sync>(&mut self, value: T) {
+        self.map.insert(TypeId::of::<T>(), Box::new(value));
+    }
+
+    /// Returns the stored value of type `T`, if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::Extensions;
+    ///
+    /// let mut ext = Extensions::new();
+    /// ext.insert(42u64);
+    /// assert_eq!(ext.get::<u64>(), Some(&42));
+    /// assert_eq!(ext.get::<i8>(), None);
+    /// ```
+    #[must_use]
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
+        self.map.get(&TypeId::of::<T>())?.downcast_ref::<T>()
+    }
+
+    /// Whether the map holds no entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::Extensions;
+    ///
+    /// let mut ext = Extensions::new();
+    /// assert!(ext.is_empty());
+    /// ext.insert(1u8);
+    /// assert!(!ext.is_empty());
+    /// ```
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+impl std::fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Extensions")
+            .field("entries", &self.map.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Extensions;
+
+    #[test]
+    fn one_value_per_type_and_distinct_types_coexist() {
+        let mut ext = Extensions::new();
+        assert!(ext.is_empty());
+        ext.insert(1u32);
+        ext.insert(2u32);
+        assert_eq!(ext.get::<u32>(), Some(&2));
+        ext.insert("tag");
+        assert_eq!(ext.get::<&str>(), Some(&"tag"));
+        assert_eq!(ext.get::<i64>(), None);
+        assert!(!ext.is_empty());
+    }
+
+    #[test]
+    fn debug_reports_entry_count() {
+        let mut ext = Extensions::new();
+        ext.insert(1u8);
+        assert!(format!("{ext:?}").contains("entries: 1"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod broker;
 mod buffered;
 mod capability;
 mod error;
+mod extensions;
 mod headers;
 mod message;
 mod publisher;
@@ -49,6 +50,7 @@ pub use capability::{
     TransactionalPublisher,
 };
 pub use error::AckError;
+pub use extensions::Extensions;
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::Publisher;

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,7 +4,7 @@ use std::{future::Future, time::Duration};
 
 use bytes::Bytes;
 
-use crate::{AckError, Headers};
+use crate::{AckError, Extensions, Headers};
 
 /// An owned snapshot of a message as it travels through the framework.
 ///
@@ -150,6 +150,50 @@ pub trait IncomingMessage: Send + Sync {
 
     /// Returns the headers attached to the message.
     fn headers(&self) -> &Headers;
+
+    /// Contributes per-delivery typed data to the handler's
+    /// [`Context`](crate::runtime::Context), built fresh for this one delivery.
+    ///
+    /// Defaulted to an empty [`Extensions`] so existing implementations keep compiling. A broker
+    /// overrides it to stash typed per-delivery values the handler (and the publish path) can read
+    /// without going through the byte-only headers: native delivery metadata (Kafka
+    /// offset/partition, a delivery handle), a transactional commit token, or a reply-to handle.
+    /// The runtime moves the returned map into the `Context` before invoking the handler, so each
+    /// delivery sees only its own values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::{Extensions, Headers, IncomingMessage};
+    /// # use ruststream::AckError;
+    ///
+    /// struct Offset(u64);
+    ///
+    /// struct KafkaLike {
+    ///     payload: Vec<u8>,
+    ///     headers: Headers,
+    ///     offset: u64,
+    /// }
+    ///
+    /// impl IncomingMessage for KafkaLike {
+    ///     fn payload(&self) -> &[u8] {
+    ///         &self.payload
+    ///     }
+    ///     fn headers(&self) -> &Headers {
+    ///         &self.headers
+    ///     }
+    ///     fn extensions(&self) -> Extensions {
+    ///         let mut ext = Extensions::new();
+    ///         ext.insert(Offset(self.offset));
+    ///         ext
+    ///     }
+    ///     # async fn ack(self) -> Result<(), AckError> { Ok(()) }
+    ///     # async fn nack(self, _requeue: bool) -> Result<(), AckError> { Ok(()) }
+    /// }
+    /// ```
+    fn extensions(&self) -> Extensions {
+        Extensions::new()
+    }
 
     /// Returns the routing key the broker partitioned this message by, or `None` when the
     /// message carries no key.

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -136,7 +136,10 @@ impl<L> RustStream<L> {
     }
 
     /// Inserts a shared application state value, readable from handlers and middleware via
-    /// [`Context::get`](crate::runtime::Context::get).
+    /// [`Context::state`](crate::runtime::Context::state) then
+    /// [`State::get`](crate::runtime::State::get). For data scoped to a single delivery, use the
+    /// per-delivery extensions ([`Context::insert`](crate::runtime::Context::insert) /
+    /// [`Context::get`](crate::runtime::Context::get)) instead.
     ///
     /// One value per type; inserting the same type again replaces it.
     #[must_use]

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -154,7 +154,7 @@ where
                 let name = self.def.reply_name();
                 match self
                     .publisher
-                    .publish_batch(name, &replies, &self.pipeline)
+                    .publish_batch(name, &replies, &self.pipeline, ctx.extensions())
                     .await
                 {
                     Ok(()) => HandlerResult::Ack,

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -2,16 +2,17 @@
 //!
 //! A `Context` is built for each delivery and threaded (as `&mut`) through the middleware chain
 //! into the handler. It carries the channel the message arrived on, a working copy of the
-//! headers (middleware may enrich them), and shared application state. The copy is lazy: the
-//! message headers are borrowed until the first [`headers_mut`](Context::headers_mut), so a
-//! delivery whose middleware never touches them pays no clone.
+//! headers (middleware may enrich them), shared application state ([`Context::state`]), and a
+//! per-delivery [`Extensions`] type-map ([`Context::get`] / [`Context::insert`]). The copy is
+//! lazy: the message headers are borrowed until the first [`headers_mut`](Context::headers_mut),
+//! so a delivery whose middleware never touches them pays no clone.
 
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::Headers;
+use crate::{Extensions, Headers};
 
 use super::dispatch::Delivery;
 use super::failure::ErrorShutdown;
@@ -59,7 +60,9 @@ struct AfterHook {
 ///
 /// Put shared resources (database pools, HTTP clients, configuration) in here with
 /// [`RustStream::insert_state`](super::RustStream::insert_state); handlers and middleware read them
-/// from the [`Context`] with [`Context::get`].
+/// from the [`Context`] with [`Context::state`] then [`State::get`]. For data scoped to a single
+/// delivery (set by a broker or middleware), use the per-delivery [`Extensions`] instead, reached
+/// with [`Context::get`] / [`Context::insert`].
 #[derive(Default)]
 pub struct State {
     map: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
@@ -90,15 +93,17 @@ impl std::fmt::Debug for State {
 ///
 /// Carries the channel ([`name`](Self::name)), a working copy of the message
 /// [`headers`](Self::headers) (middleware may enrich them for the handler; the broker message
-/// itself is untouched), shared application [state](Self::get), and access to named
-/// [`publisher`](Self::publisher)s for publishing from inside a handler. The copy is made lazily
-/// on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit it:
-/// replies and manual publishes start from fresh headers, shaped by the publish pipeline.
+/// itself is untouched), shared application [state](Self::state), a per-delivery
+/// [`Extensions`] type-map ([`get`](Self::get) / [`insert`](Self::insert)), and access to named
+/// [`publisher`](Self::publisher)s for publishing from inside a handler. The headers copy is made
+/// lazily on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit
+/// it: replies and manual publishes start from fresh headers, shaped by the publish pipeline.
 pub struct Context<'a> {
     name: &'a str,
     original: &'a Headers,
     modified: Option<Headers>,
     state: &'a State,
+    extensions: Extensions,
     delivery: &'a Delivery,
     after: Vec<AfterHook>,
     failfast: Option<&'a ErrorShutdown>,
@@ -114,11 +119,25 @@ impl std::fmt::Debug for Context<'_> {
 }
 
 impl<'a> Context<'a> {
-    /// Creates a context for one delivery, borrowing the message headers until first mutation.
+    /// Creates a context for one delivery, borrowing the message headers until first mutation,
+    /// with an empty per-delivery [`Extensions`] map.
     pub(crate) fn new(
         name: &'a str,
         headers: &'a Headers,
         state: &'a State,
+        delivery: &'a Delivery,
+    ) -> Self {
+        Self::with_extensions(name, headers, state, Extensions::new(), delivery)
+    }
+
+    /// Creates a context seeded with per-delivery `extensions`, used by the dispatch loop to carry
+    /// the broker's [`IncomingMessage::extensions`](crate::IncomingMessage::extensions) into the
+    /// handler.
+    pub(crate) fn with_extensions(
+        name: &'a str,
+        headers: &'a Headers,
+        state: &'a State,
+        extensions: Extensions,
         delivery: &'a Delivery,
     ) -> Self {
         Self {
@@ -126,6 +145,7 @@ impl<'a> Context<'a> {
             original: headers,
             modified: None,
             state,
+            extensions,
             delivery,
             after: Vec::new(),
             failfast: None,
@@ -168,6 +188,7 @@ impl<'a> Context<'a> {
         Some(ScopedPublisher::new(
             publisher.as_ref(),
             &self.delivery.pipeline,
+            &self.extensions,
         ))
     }
 
@@ -183,10 +204,75 @@ impl<'a> Context<'a> {
         self.modified.get_or_insert_with(|| self.original.clone())
     }
 
-    /// Returns shared application state of type `T`, if registered.
+    /// Returns the shared application [`State`], the type-map set once at build with
+    /// [`RustStream::insert_state`](super::RustStream::insert_state). Read a value from it with
+    /// [`State::get`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// async fn handle<M: IncomingMessage>(_msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    ///     if let Some(prefix) = ctx.state().get::<String>() {
+    ///         let _ = prefix;
+    ///     }
+    ///     HandlerResult::Ack
+    /// }
+    /// ```
+    #[must_use]
+    pub fn state(&self) -> &State {
+        self.state
+    }
+
+    /// Returns the per-delivery [`Extensions`] value of type `T`, if any.
+    ///
+    /// This reads the per-delivery type-map (broker-contributed metadata, middleware-set values),
+    /// not the app [`state`](Self::state). For shared app state use `ctx.state().get::<T>()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// async fn handle<M: IncomingMessage>(_msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    ///     if let Some(span_id) = ctx.get::<u64>() {
+    ///         let _ = span_id;
+    ///     }
+    ///     HandlerResult::Ack
+    /// }
+    /// ```
     #[must_use]
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
-        self.state.get::<T>()
+        self.extensions.get::<T>()
+    }
+
+    /// Inserts a per-delivery [`Extensions`] value, replacing any previous value of the same type.
+    ///
+    /// Middleware uses this to hand typed data to downstream handlers (an authenticated user, a
+    /// correlation id) without serializing it into the headers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::IncomingMessage;
+    /// use ruststream::runtime::{Context, HandlerResult};
+    ///
+    /// async fn handle<M: IncomingMessage>(_msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    ///     ctx.insert(123u64);
+    ///     assert_eq!(ctx.get::<u64>(), Some(&123));
+    ///     HandlerResult::Ack
+    /// }
+    /// ```
+    pub fn insert<T: Any + Send + Sync>(&mut self, value: T) {
+        self.extensions.insert(value);
+    }
+
+    /// Returns the per-delivery [`Extensions`] map, for the publish path to read at send time.
+    pub(crate) fn extensions(&self) -> &Extensions {
+        &self.extensions
     }
 
     /// Begins registering a post-settle hook gated on `outcome`.
@@ -379,7 +465,7 @@ mod tests {
 
     use futures::future::join_all;
 
-    use super::{Context, State};
+    use super::{Context, Extensions, State};
     use crate::Headers;
     use crate::runtime::dispatch::Delivery;
     use crate::runtime::handler::HandlerResult;
@@ -482,6 +568,48 @@ mod tests {
         run_all(ctx.take_settle_hooks());
         assert_eq!(ungated.load(Ordering::SeqCst), 1);
         assert_eq!(gated.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn extensions_one_value_per_type_and_isolation() {
+        let mut ext = Extensions::new();
+        assert!(ext.is_empty());
+        ext.insert(1u32);
+        ext.insert(2u32);
+        // Same type replaces, distinct types coexist.
+        assert_eq!(ext.get::<u32>(), Some(&2));
+        ext.insert("tag");
+        assert_eq!(ext.get::<&str>(), Some(&"tag"));
+        assert_eq!(ext.get::<i64>(), None);
+    }
+
+    #[test]
+    fn ctx_get_insert_hit_extensions_state_unaffected() {
+        let mut state = State::default();
+        state.insert(String::from("app"));
+        let headers = Headers::new();
+        let delivery = Delivery::empty();
+        let mut ctx = Context::new("test", &headers, &state, &delivery);
+
+        // ctx.get / ctx.insert operate on the per-delivery extensions.
+        assert_eq!(ctx.get::<u32>(), None);
+        ctx.insert(99u32);
+        assert_eq!(ctx.get::<u32>(), Some(&99));
+
+        // App state is reached only through state(); the per-delivery map does not shadow it.
+        assert_eq!(ctx.state().get::<String>().map(String::as_str), Some("app"));
+        assert_eq!(ctx.get::<String>(), None);
+    }
+
+    #[test]
+    fn seeded_extensions_reach_the_context() {
+        let state = State::default();
+        let headers = Headers::new();
+        let delivery = Delivery::empty();
+        let mut seed = Extensions::new();
+        seed.insert(7u8);
+        let ctx = Context::with_extensions("test", &headers, &state, seed, &delivery);
+        assert_eq!(ctx.get::<u8>(), Some(&7));
     }
 
     #[test]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -517,8 +517,10 @@ async fn dispatch<H, M>(
     H: Handler<M>,
     M: IncomingMessage,
 {
-    let mut ctx =
-        Context::new(name, msg.headers(), state, delivery).with_failfast(&failure.shutdown);
+    // Seed the per-delivery extensions from the broker's message, then attach the fail-fast handle.
+    let extensions = msg.extensions();
+    let mut ctx = Context::with_extensions(name, msg.headers(), state, extensions, delivery)
+        .with_failfast(&failure.shutdown);
     // Catch a panicking handler so it cannot silently kill the dispatch loop (which would stop the
     // subscriber consuming) or leave the message unsettled. AssertUnwindSafe is required because
     // the future borrows `&mut ctx`; that state is discarded with the failed delivery.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -19,6 +19,7 @@ mod router;
 mod subscriber_def;
 mod typed;
 
+pub use crate::Extensions;
 pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
 pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -20,7 +20,7 @@ use crate::codec::Codec;
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::codec::DefaultCodec;
 use crate::runtime::publish::sealed::Sealed;
-use crate::{Headers, Publisher, TransactionalPublisher};
+use crate::{Extensions, Headers, Publisher, TransactionalPublisher};
 
 type PublishFut<'a> = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'a>>;
 
@@ -104,9 +104,15 @@ pub trait PublishMiddleware: Send + Sync {
 }
 
 /// A cursor over the remaining publish middleware, ending in the broker publisher.
+///
+/// Carries the originating delivery's per-delivery [`Extensions`] (via
+/// [`extensions`](Self::extensions)), so a transactional middleware or publisher can read a
+/// broker-supplied commit token at commit time. A publish with no originating delivery (a fresh
+/// startup publish) sees an empty map.
 pub struct PublishNext<'a> {
     rest: &'a [Arc<dyn PublishMiddleware>],
     publisher: &'a dyn ErasedPublisher,
+    extensions: &'a Extensions,
 }
 
 impl<'a> PublishNext<'a> {
@@ -119,12 +125,20 @@ impl<'a> PublishNext<'a> {
                 PublishNext {
                     rest,
                     publisher: self.publisher,
+                    extensions: self.extensions,
                 },
             ),
             None => self
                 .publisher
                 .publish_message(out.name(), out.payload(), out.headers()),
         }
+    }
+
+    /// The originating delivery's per-delivery [`Extensions`], for a transactional middleware to
+    /// read a broker-supplied commit token. Empty for a publish with no originating delivery.
+    #[must_use]
+    pub fn extensions(&self) -> &Extensions {
+        self.extensions
     }
 }
 
@@ -136,15 +150,18 @@ impl std::fmt::Debug for PublishNext<'_> {
     }
 }
 
-/// Runs `out` through `pipeline`, then publishes it via `publisher`.
+/// Runs `out` through `pipeline`, then publishes it via `publisher`, carrying the originating
+/// delivery's `extensions` for any transactional middleware to read.
 pub(crate) fn run_publish<'a>(
     pipeline: &'a [Arc<dyn PublishMiddleware>],
     publisher: &'a dyn ErasedPublisher,
     out: &'a mut Outgoing<'a>,
+    extensions: &'a Extensions,
 ) -> PublishFut<'a> {
     PublishNext {
         rest: pipeline,
         publisher,
+        extensions,
     }
     .run(out)
 }
@@ -158,26 +175,30 @@ pub(crate) fn run_publish<'a>(
 pub struct ScopedPublisher<'a> {
     publisher: &'a dyn ErasedPublisher,
     pipeline: &'a [Arc<dyn PublishMiddleware>],
+    extensions: &'a Extensions,
 }
 
 impl<'a> ScopedPublisher<'a> {
     pub(crate) fn new(
         publisher: &'a dyn ErasedPublisher,
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        extensions: &'a Extensions,
     ) -> Self {
         Self {
             publisher,
             pipeline,
+            extensions,
         }
     }
 
-    /// Sends `out` through the publish pipeline to the broker.
+    /// Sends `out` through the publish pipeline to the broker, carrying the originating delivery's
+    /// per-delivery extensions for any transactional middleware to read.
     ///
     /// # Errors
     ///
     /// Returns the boxed error from a middleware or the broker publish if either fails.
     pub async fn publish(&self, mut out: Outgoing<'_>) -> Result<(), BoxError> {
-        run_publish(self.pipeline, self.publisher, &mut out).await
+        run_publish(self.pipeline, self.publisher, &mut out, self.extensions).await
     }
 }
 
@@ -319,12 +340,14 @@ impl<P, C, PL> TypedPublisher<P, C, PL> {
 }
 
 impl<P: Publisher, C: Codec, PL: PublishLayer> TypedPublisher<P, C, PL> {
-    /// Encodes `value`, applies the static transforms, then publishes to `name` through `pipeline`.
+    /// Encodes `value`, applies the static transforms, then publishes to `name` through `pipeline`,
+    /// carrying the originating delivery's `extensions` for any transactional middleware to read.
     pub(crate) async fn publish<T: Serialize + Sync>(
         &self,
         name: &str,
         value: &T,
         pipeline: &[Arc<dyn PublishMiddleware>],
+        extensions: &Extensions,
     ) -> Result<(), BoxError> {
         let payload = self
             .codec
@@ -332,7 +355,7 @@ impl<P: Publisher, C: Codec, PL: PublishLayer> TypedPublisher<P, C, PL> {
             .map_err(|e| Box::new(e) as BoxError)?;
         let mut out = Outgoing::new(name, payload);
         self.layers.apply(&mut out);
-        run_publish(pipeline, &self.publisher, &mut out).await
+        run_publish(pipeline, &self.publisher, &mut out, extensions).await
     }
 }
 
@@ -381,13 +404,15 @@ pub trait ReplyPublisher: Sealed + Send + Sync {
     #[doc(hidden)]
     fn reply_codec(&self) -> &Self::Codec;
 
-    /// Publishes one batch's replies to `name` through `pipeline`.
+    /// Publishes one batch's replies to `name` through `pipeline`, carrying the originating
+    /// delivery's `extensions` for a transactional publisher to read at commit time.
     #[doc(hidden)]
     fn publish_batch<'a, T>(
         &'a self,
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        extensions: &'a Extensions,
     ) -> impl Future<Output = Result<(), BoxError>> + Send
     where
         T: Serialize + Sync;
@@ -412,12 +437,13 @@ where
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        extensions: &'a Extensions,
     ) -> Result<(), BoxError>
     where
         T: Serialize + Sync,
     {
         for reply in replies {
-            self.publish(name, reply, pipeline).await?;
+            self.publish(name, reply, pipeline, extensions).await?;
         }
         Ok(())
     }
@@ -436,12 +462,15 @@ where
     }
 
     /// All replies publish inside one transaction: begin, publish each, commit. Any failure
-    /// aborts the transaction, so none of the batch's replies become visible.
+    /// aborts the transaction, so none of the batch's replies become visible. The originating
+    /// delivery's `extensions` (for example a broker-supplied commit token) are carried through the
+    /// publish pipeline so a transactional middleware can read them at commit time.
     async fn publish_batch<'a, T>(
         &'a self,
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        extensions: &'a Extensions,
     ) -> Result<(), BoxError>
     where
         T: Serialize + Sync,
@@ -452,7 +481,7 @@ where
             .await
             .map_err(|e| Box::new(e) as BoxError)?;
         for reply in replies {
-            if let Err(err) = self.inner.publish(name, reply, pipeline).await {
+            if let Err(err) = self.inner.publish(name, reply, pipeline, extensions).await {
                 abort_quietly(publisher).await;
                 return Err(err);
             }

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -161,7 +161,10 @@ where
             Err(result) => return result,
         };
         let name = self.def.reply_name();
-        if let Err(err) = self.publisher.publish(name, &reply, &self.pipeline).await {
+        let publish = self
+            .publisher
+            .publish(name, &reply, &self.pipeline, ctx.extensions());
+        if let Err(err) = publish.await {
             warn!(
                 target: "ruststream::dispatch",
                 subscription = %ctx.name(),

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -369,7 +369,7 @@ async fn handler_reads_context_topic_and_state() {
                 subscriber,
                 move |_msg: &_, ctx: &mut Context| {
                     let name = ctx.name().to_owned();
-                    let greeting = ctx.get::<Config>().map(|c| c.greeting.clone());
+                    let greeting = ctx.state().get::<Config>().map(|c| c.greeting.clone());
                     // Middleware/handlers may enrich the working headers.
                     ctx.headers_mut().insert("x-seen", b"1".to_vec());
                     let seen = Arc::clone(&seen_clone);

--- a/tests/context_extensions.rs
+++ b/tests/context_extensions.rs
@@ -1,0 +1,301 @@
+//! Integration tests for the per-delivery `Context` extensions: isolation across deliveries, a
+//! broker-contributed extension (via the `IncomingMessage` seam) reaching the handler, a
+//! middleware-written extension reaching a downstream handler, and `ctx.state()` still reaching
+//! app state. All use the in-memory broker.
+
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures::{Stream, StreamExt};
+use ruststream::memory::{MemoryBroker, MemoryMessage, MemorySubscriber};
+use ruststream::runtime::{
+    AppInfo, Context, Handler, HandlerExt, HandlerMetadata, HandlerResult, Layer, RustStream,
+};
+use ruststream::{AckError, Extensions, Headers, IncomingMessage, OutgoingMessage, Publisher};
+use tokio::sync::Notify;
+
+/// A broker-supplied per-delivery value, the kind a real broker would stash (an offset, a commit
+/// token, a reply-to handle).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct DeliveryTag(u32);
+
+/// Wraps a `MemoryMessage` and contributes a `DeliveryTag` through the `IncomingMessage`
+/// extensions seam, standing in for a broker that attaches native per-delivery metadata.
+struct TaggedMessage {
+    inner: MemoryMessage,
+    tag: u32,
+}
+
+impl IncomingMessage for TaggedMessage {
+    fn payload(&self) -> &[u8] {
+        self.inner.payload()
+    }
+
+    fn headers(&self) -> &Headers {
+        self.inner.headers()
+    }
+
+    fn extensions(&self) -> Extensions {
+        let mut ext = Extensions::new();
+        ext.insert(DeliveryTag(self.tag));
+        ext
+    }
+
+    async fn ack(self) -> Result<(), AckError> {
+        self.inner.ack().await
+    }
+
+    async fn nack(self, requeue: bool) -> Result<(), AckError> {
+        self.inner.nack(requeue).await
+    }
+}
+
+/// A subscriber that yields `TaggedMessage`s, numbering each delivery so the contributed tag
+/// differs per message (used to prove isolation as well as delivery).
+struct TaggedSubscriber {
+    inner: MemorySubscriber,
+    next_tag: u32,
+}
+
+impl ruststream::Subscriber for TaggedSubscriber {
+    type Message = TaggedMessage;
+    type Error = Infallible;
+
+    fn stream(&mut self) -> impl Stream<Item = Result<Self::Message, Self::Error>> + Send + '_ {
+        self.inner.stream().map(|item| {
+            self.next_tag += 1;
+            item.map(|inner| TaggedMessage {
+                inner,
+                tag: self.next_tag,
+            })
+        })
+    }
+}
+
+async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
+    let result = tokio::time::timeout(timeout, async {
+        while !cond() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "condition not met within {timeout:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn broker_contributed_extension_reaches_handler() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = Arc::clone(&seen);
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        let subscriber = TaggedSubscriber {
+            inner: b.broker().subscribe("orders"),
+            next_tag: 0,
+        };
+        b.handle(
+            subscriber,
+            move |_msg: &TaggedMessage, ctx: &mut Context| {
+                // The broker-contributed extension is readable from the handler's context.
+                let tag = ctx.get::<DeliveryTag>().copied();
+                let seen = Arc::clone(&seen_clone);
+                async move {
+                    if let Some(DeliveryTag(n)) = tag {
+                        seen.lock().expect("poisoned").push(n);
+                    }
+                    HandlerResult::Ack
+                }
+            },
+            HandlerMetadata::raw("orders"),
+        );
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    publisher
+        .publish(OutgoingMessage::new("orders", b"a"))
+        .await
+        .unwrap();
+    publisher
+        .publish(OutgoingMessage::new("orders", b"b"))
+        .await
+        .unwrap();
+
+    wait_for(
+        || seen.lock().expect("poisoned").len() >= 2,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Each delivery sees its own tag: the seam delivers a fresh value per message, and one
+    // delivery's value never leaks into the next.
+    assert_eq!(*seen.lock().expect("poisoned"), vec![1, 2]);
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+/// A layer that writes a per-delivery extension before the inner handler runs, then asserts the
+/// extension it wrote is gone on the next delivery (proving per-delivery isolation through the
+/// dispatch loop, not just within one `Extensions` value).
+struct StampLayer {
+    counter: Arc<std::sync::atomic::AtomicU32>,
+}
+
+struct StampHandler<H> {
+    inner: H,
+    counter: Arc<std::sync::atomic::AtomicU32>,
+}
+
+impl<H> Layer<H> for StampLayer {
+    type Handler = StampHandler<H>;
+
+    fn layer(&self, inner: H) -> StampHandler<H> {
+        StampHandler {
+            inner,
+            counter: Arc::clone(&self.counter),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct Stamp(u32);
+
+impl<M, H> Handler<M> for StampHandler<H>
+where
+    M: Sync,
+    H: Handler<M>,
+{
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+        // No value should survive from a previous delivery: the dispatch loop builds a fresh
+        // context each time.
+        assert!(
+            ctx.get::<Stamp>().is_none(),
+            "extension leaked across deliveries"
+        );
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        ctx.insert(Stamp(n));
+        self.inner.handle(msg, ctx).await
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn middleware_written_extension_reaches_downstream_handler_and_is_isolated() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = Arc::clone(&seen);
+    let counter = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        let subscriber = b.broker().subscribe("orders");
+        let handler = {
+            let layer = StampLayer {
+                counter: Arc::clone(&counter),
+            };
+            (move |_msg: &MemoryMessage, ctx: &mut Context| {
+                // The layer ran first and wrote a per-delivery Stamp; the downstream handler reads
+                // it back from the same context.
+                let stamp = ctx.get::<Stamp>().copied();
+                let seen = Arc::clone(&seen_clone);
+                async move {
+                    if let Some(Stamp(n)) = stamp {
+                        seen.lock().expect("poisoned").push(n);
+                    }
+                    HandlerResult::Ack
+                }
+            })
+            .with(layer)
+        };
+        b.handle(subscriber, handler, HandlerMetadata::raw("orders"));
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    publisher
+        .publish(OutgoingMessage::new("orders", b"a"))
+        .await
+        .unwrap();
+    publisher
+        .publish(OutgoingMessage::new("orders", b"b"))
+        .await
+        .unwrap();
+
+    wait_for(
+        || seen.lock().expect("poisoned").len() >= 2,
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(*seen.lock().expect("poisoned"), vec![0, 1]);
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}
+
+struct AppPrefix(String);
+
+/// What the handler observed: the app-state prefix (through `state()`) and the per-delivery `u8`
+/// extension (through `get`), which is empty here.
+type Observed = Option<(Option<String>, Option<u8>)>;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn state_still_reaches_app_state_separately_from_extensions() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let seen: Arc<Mutex<Observed>> = Arc::new(Mutex::new(None));
+    let seen_clone = Arc::clone(&seen);
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .insert_state(AppPrefix("svc".to_owned()))
+        .with_broker(broker, |b| {
+            let subscriber = b.broker().subscribe("orders");
+            b.handle(
+                subscriber,
+                move |_msg: &MemoryMessage, ctx: &mut Context| {
+                    // App state through state(); the per-delivery map is empty for this type.
+                    let prefix = ctx.state().get::<AppPrefix>().map(|p| p.0.clone());
+                    // The same accessor name on the per-delivery map sees a different (empty) store.
+                    let ext = ctx.get::<u8>().copied();
+                    let seen = Arc::clone(&seen_clone);
+                    async move {
+                        *seen.lock().expect("poisoned") = Some((prefix, ext));
+                        HandlerResult::Ack
+                    }
+                },
+                HandlerMetadata::raw("orders"),
+            );
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    publisher
+        .publish(OutgoingMessage::new("orders", b"x"))
+        .await
+        .unwrap();
+
+    wait_for(
+        || seen.lock().expect("poisoned").is_some(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(
+        *seen.lock().expect("poisoned"),
+        Some((Some("svc".to_owned()), None)),
+    );
+
+    shutdown.notify_one();
+    run.await.unwrap().unwrap();
+}

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -572,7 +572,7 @@ static CTX_REPLY_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ctx-in", publish("ctx-out"))]
 async fn ctx_reply(req: &Request, ctx: &mut Context) -> Response {
-    let bump = ctx.get::<Bump>().map_or(0, |b| b.0);
+    let bump = ctx.state().get::<Bump>().map_or(0, |b| b.0);
     Response {
         doubled: req.n + bump,
     }

--- a/tests/post_settle_hooks.rs
+++ b/tests/post_settle_hooks.rs
@@ -51,7 +51,11 @@ struct Counters {
 /// are distinct mechanics.
 #[subscriber("orders")]
 async fn handle_order(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let c = ctx.get::<Counters>().expect("counters in state").clone();
+    let c = ctx
+        .state()
+        .get::<Counters>()
+        .expect("counters in state")
+        .clone();
     let outcome = if order.id % 2 == 1 {
         HandlerResult::Ack
     } else {


### PR DESCRIPTION
# Description

Adds a per-delivery type-map (`Extensions`) to `Context` and reshapes the accessors. `ctx.get::<T>()` / `ctx.insert::<T>(v)` now operate on the per-delivery extensions; the app-level `State` moves behind `ctx.state()` -> `&State` -> `.get::<T>()`. This is the seam a broker's transactional EOS commit token depends on, and it generalizes to native delivery metadata, reply-to handles, tracing spans, and middleware-set per-delivery data.

`Extensions` is a new core type (one value per type, `Send + Sync`), built fresh for each delivery so one delivery's values never leak into the next. Three sources feed it:

- A broker, through the additive `IncomingMessage::extensions` provided method (default returns an empty map, so existing broker impls keep compiling without overriding it). The dispatch loop moves the returned map into the per-delivery `Context` before invoking the handler.
- Middleware, which already receives `&mut Context`, via `ctx.insert`.
- The handler itself.

The values reach the runtime publish pipeline: `PublishNext` exposes `extensions()`, threaded through `run_publish`, `ScopedPublisher`, `TypedPublisher::publish`, and `ReplyPublisher::publish_batch`, so a transactional publisher can read a broker-supplied commit token at commit time.

No broker-facing trait signature changed. `Publisher::publish(&self, OutgoingMessage<'_>)` and the other core traits (`Broker`, `Subscriber`, `IncomingMessage` except the additive default method, capability traits, `DescribeServer`, `SubscriptionSource`) are untouched; the publish threading lives entirely in the runtime wrapper. `just check` confirms the published `ruststream-nats` 0.3 still compiles against the reshaped core.

## Migration

Breaking: `ctx.get::<T>()` that read app state becomes `ctx.state().get::<T>()`. `ctx.get::<T>()` now reads the per-delivery extensions. Migrated sites: the `routed_service` example, the `context` and `lifespan` examples, and the dispatch and macro subscriber tests. The `State`-by-value hooks (`on_startup` / `after_shutdown`, which receive a `State` directly) are unchanged.

Fixes #75

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable