### PR TITLE
feat: post-settle continuation via HandlerResult::and_after / Settle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ name = "retry"
 required-features = ["macros", "memory", "json"]
 
 [[example]]
+name = "post_settle"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
 name = "routing"
 required-features = ["macros", "memory", "json"]
 

--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -418,8 +418,8 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
                     &self,
                     #pat: &#input_ty,
                     #ctx_param: &mut ::ruststream::runtime::Context<'_>,
-                ) -> ::ruststream::runtime::HandlerResult {
-                    ::ruststream::runtime::IntoHandlerResult::into_handler_result(
+                ) -> ::ruststream::runtime::Settle {
+                    ::ruststream::runtime::IntoSettle::into_settle(
                         (async move #block).await,
                     )
                 }

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -38,18 +38,21 @@ use parse::{SubscriberArgs, doc_description};
 /// async fn bill(orders: &[Order]) -> HandlerResult { /* settles the whole batch */ }
 /// ```
 ///
-/// Without `publish(..)` the handler returns any `IntoHandlerResult` (a `HandlerResult`, `()`, or
-/// `Result<_, E>`). With `publish(..)` it returns the reply value to publish, or
-/// `Result<Reply, HandlerResult>` to control acknowledgement: `Err(result)` publishes nothing and
-/// returns `result` to the dispatcher. The `Result` form is detected syntactically, so spell it
-/// out in the signature (a type alias is treated as a plain reply type).
+/// Without `publish(..)` the handler returns any `Into<Settle>` (a `Settle`, a `HandlerResult`,
+/// `()`, or `Result<_, E>`). Attach a post-settle continuation with `HandlerResult::ack().and_after`
+/// (any outcome works), which runs after the message is settled. With `publish(..)` it returns the
+/// reply value to publish, or `Result<Reply, HandlerResult>` to control acknowledgement:
+/// `Err(result)` publishes nothing and returns `result` to the dispatcher. The `Result` form is
+/// detected syntactically, so spell it out in the signature (a type alias is treated as a plain
+/// reply type).
 ///
 /// Wrapping the source in `batch(..)` switches the definition to a `BatchDef`: the handler takes
 /// `&[T]` and runs once per batch pulled from the broker's `BatchSubscriber` (use the `Buffered`
 /// adapter for brokers without native batching). It returns any `IntoBatchResult` - one outcome
-/// for the whole batch (`HandlerResult`, `()`, `Result<_, E>`), or `Vec<HandlerResult>` to settle
-/// element `i` of the slice with outcome `i`. The source type is recovered from the constructor
-/// path, so a generic source spells its parameters:
+/// for the whole batch (`HandlerResult`, `()`, `Result<_, E>`), or a per-element vector
+/// (`Vec<Settle>`, or `Vec<HandlerResult>`) to settle element `i` of the slice with outcome `i`,
+/// each element carrying its own optional `and_after` continuation. The source type is recovered
+/// from the constructor path, so a generic source spells its parameters:
 /// `batch(Buffered::<Name>::new(Name::new("orders")))`.
 ///
 /// Combining `batch(..)` with `publish(..)` produces a `BatchPublishingDef` (mounted with

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -34,19 +34,47 @@ access, named publishers - is covered in [Context and state](context.md).
 
 ### Acking
 
-The return type is anything that converts into a [`HandlerResult`]:
+The return type is anything that converts into a [`Settle`] (the settlement unit: an outcome plus
+an optional post-settle continuation):
 
 | Return value | Result |
 |---|---|
-| `HandlerResult::Ack` | acknowledge; the broker removes the message |
+| `HandlerResult::ack()` (or `HandlerResult::Ack`) | acknowledge; the broker removes the message |
 | `HandlerResult::retry()` | nack with requeue (redeliver later) |
 | `HandlerResult::retry_after(delay)` | nack asking for redelivery no sooner than `delay` |
 | `HandlerResult::drop()` | nack without requeue (discard or dead-letter) |
 | `()` | always `Ack` |
 | `Result<(), E>` | `Ack` on `Ok`, `drop` on `Err` |
-| `Result<HandlerResult, E>` | the inner result on `Ok`, `drop` on `Err` |
+| `Result<HandlerResult, E>` | the inner outcome on `Ok`, `drop` on `Err` |
+| `Settle` (any of the above `.and_after(..)`) | settle by the outcome, then run the continuation |
 
 On the message itself, ack consumes `self`, so the type system prevents acking twice.
+
+### Post-settle continuations
+
+`HandlerResult::ack().and_after(fut)` attaches a continuation that runs *after* the message is
+settled, without gating the ack decision or affecting redelivery - a non-critical notification,
+slow follow-up work, a cache warm-up. Any outcome works (`drop().and_after(..)` is valid; the
+neutral reading is "after settle"):
+
+```rust
+--8<-- "examples/post_settle.rs:single"
+```
+
+The continuation runs on a tracked task set that a graceful shutdown drains (bounded by
+`shutdown_timeout` when set). It is at-most-once: the message is already settled, so a continuation
+that panics or is lost on a crash never redelivers it. Do not put work whose loss must redeliver the
+message in here; settle by outcome and let the broker retry instead.
+
+In a batch each element settles individually, so the continuation rides per element - a capability
+the per-message context hook cannot offer:
+
+```rust
+--8<-- "examples/post_settle.rs:batch"
+```
+
+Batch *publishing* (`batch(..) + publish(..)`) settles all-or-nothing under one transaction, so
+per-element `and_after` does not compose there; it applies to plain batch and single forms only.
 
 ### Delayed redelivery
 

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
-    AppInfo, Context, Handler, HandlerResult, Identity, Layer, RustStream, Stack,
+    AppInfo, Context, Handler, HandlerResult, Identity, Layer, RustStream, Settle, Stack,
 };
 use ruststream::subscriber;
 use serde::Deserialize;
@@ -67,7 +67,7 @@ impl<H> Layer<H> for RequestId {
 static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
 
 impl<M: Send + Sync, H: Handler<M>> Handler<M> for WithRequestId<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         if ctx.headers().get("x-request-id").is_none() {
             let id = format!("req-{}", NEXT_REQUEST.fetch_add(1, Ordering::Relaxed));
             ctx.headers_mut().insert("x-request-id", id.into_bytes());

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use ruststream::memory::{MemoryBroker, MemoryMessage};
 use ruststream::runtime::{
     AppInfo, Context, DynMiddleware, DynStack, Handler, HandlerResult, Identity, Layer, Next,
-    RustStream, Stack,
+    RustStream, Settle, Stack,
 };
 use ruststream::subscriber;
 use serde::Deserialize;
@@ -48,11 +48,11 @@ impl<H> Layer<H> for LogLayer {
 }
 
 impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         println!("-> {}", ctx.name());
-        let result = self.0.handle(msg, ctx).await;
+        let settle = self.0.handle(msg, ctx).await;
         println!("<- {}", ctx.name());
-        result
+        settle
     }
 }
 // --8<-- [end:layer_impl]
@@ -68,7 +68,7 @@ impl<I: Send + Sync> DynMiddleware<I> for Audit {
         input: &'a I,
         ctx: &'a mut Context<'_>,
         next: Next<'a, I>,
-    ) -> Pin<Box<dyn Future<Output = HandlerResult> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Settle> + Send + 'a>> {
         Box::pin(async move {
             println!("[{}] handling {}", self.service, ctx.name());
             next.run(input, ctx).await

--- a/examples/middleware_app_scope.rs
+++ b/examples/middleware_app_scope.rs
@@ -9,7 +9,7 @@
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, BlanketLayer, Context, Handler, HandlerResult, Identity, Layer, Router, RustStream,
-    Stack,
+    Settle, Stack,
 };
 use ruststream::subscriber;
 use serde::Deserialize;
@@ -50,7 +50,7 @@ impl<H> Layer<H> for LogLayer {
 }
 
 impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         println!("app layer -> {}", ctx.name());
         self.0.handle(msg, ctx).await
     }

--- a/examples/middleware_router_scope.rs
+++ b/examples/middleware_router_scope.rs
@@ -12,6 +12,7 @@
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, BlanketLayer, Context, Handler, HandlerResult, Layer, Router, RouterDef, RustStream,
+    Settle,
 };
 use ruststream::subscriber;
 use serde::Deserialize;
@@ -63,7 +64,7 @@ impl BlanketLayer for LogLayer {
 }
 
 impl<M: Send + Sync, H: Handler<M>> Handler<M> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         println!("router layer -> {}", ctx.name());
         self.0.handle(msg, ctx).await
     }

--- a/examples/post_settle.rs
+++ b/examples/post_settle.rs
@@ -1,0 +1,59 @@
+//! Post-settle continuations from the Subscribers guide: `HandlerResult::ack().and_after(..)`
+//! attaches a side effect that runs after the message is settled, without gating the ack decision
+//! or affecting redelivery. The batch form attaches one continuation per element.
+//!
+//! ```text
+//! cargo run --example post_settle --features macros,memory,json -- run
+//! ```
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream, Settle};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    id: u64,
+}
+
+// --8<-- [start:single]
+/// Ack the order, then fire a non-critical follow-up once it is acknowledged. The continuation is
+/// at-most-once: if it is lost or panics, the already-acked order is not redelivered.
+#[subscriber("orders")]
+async fn handle(order: &Order) -> Settle {
+    let id = order.id;
+    HandlerResult::ack().and_after(async move {
+        println!("order {id} acked; notifying downstream");
+    })
+}
+// --8<-- [end:single]
+
+// --8<-- [start:batch]
+/// Per-element settlement: id 0 retries with no continuation, every other order acks and schedules
+/// its own follow-up. The continuation rides with the element, so a batch settles each message and
+/// its side effect independently.
+#[subscriber(batch("orders"))]
+async fn handle_page(orders: &[Order]) -> Vec<Settle> {
+    orders
+        .iter()
+        .map(|order| {
+            if order.id == 0 {
+                HandlerResult::retry().into()
+            } else {
+                let id = order.id;
+                HandlerResult::ack().and_after(async move {
+                    println!("order {id} acked in batch; following up");
+                })
+            }
+        })
+        .collect()
+}
+// --8<-- [end:batch]
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("post_settle", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(handle);
+        b.include_batch(handle_page);
+    })
+}

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -11,9 +11,7 @@
 
 use std::time::Instant;
 
-use ruststream::runtime::{
-    BlanketLayer, Context, Handler, HandlerResult, Layer, Outgoing, PublishLayer,
-};
+use ruststream::runtime::{BlanketLayer, Context, Handler, Layer, Outgoing, PublishLayer, Settle};
 
 /// The layer value added with `RustStream::layer`.
 #[derive(Clone)]
@@ -40,12 +38,12 @@ impl BlanketLayer for Observe {
 }
 
 impl<M: Send + Sync, H: Handler<M>> Handler<M> for Observed<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         let channel = ctx.name().to_owned();
         let started = Instant::now();
-        let result = self.0.handle(msg, ctx).await;
+        let settle = self.0.handle(msg, ctx).await;
         tracing::info!(channel = %channel, elapsed = ?started.elapsed(), "handled");
-        result
+        settle
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,6 +34,7 @@ use prometheus::{
 
 use crate::runtime::{
     BlanketLayer, Context, Handler, HandlerResult, Layer, Outgoing, PublishMiddleware, PublishNext,
+    Settle,
 };
 
 /// Default histogram buckets (seconds) for handler duration.
@@ -220,20 +221,22 @@ where
     M: Sync,
     H: Handler<M>,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send {
+    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = Settle> + Send {
         let name = ctx.name().to_owned();
         async move {
             let started = std::time::Instant::now();
-            let result = self.inner.handle(msg, ctx).await;
+            // Classify by the outcome inside the settlement; the continuation (if any) passes
+            // through untouched to the dispatcher.
+            let settle = self.inner.handle(msg, ctx).await;
             self.metrics
                 .consume_duration
                 .with_label_values(&[name.as_str()])
                 .observe(started.elapsed().as_secs_f64());
             self.metrics
                 .consumed
-                .with_label_values(&[name.as_str(), consume_status(result)])
+                .with_label_values(&[name.as_str(), consume_status(settle.outcome())])
                 .inc();
-            result
+            settle
         }
     }
 }

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -7,6 +7,7 @@ use tokio::signal::unix::{SignalKind, signal};
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, info, warn};
 
 use super::{RustStream, RustStreamError};
@@ -47,6 +48,7 @@ impl<L> RustStream<L> {
             on_shutdown,
             after_shutdown,
             shutdown_timeout,
+            continuations,
             ..
         } = self;
 
@@ -111,6 +113,11 @@ impl<L> RustStream<L> {
         debug!(target: "ruststream::lifecycle", "draining in-flight handlers");
         drain_handles(handles, shutdown_timeout).await?;
 
+        // Handlers have stopped, so no new post-settle continuations can be spawned: close the
+        // tracker and drain the in-flight ones, bounded by the same shutdown timeout. They are
+        // at-most-once, so timing one out only abandons follow-up work, never a settlement.
+        drain_continuations(continuations, shutdown_timeout).await;
+
         for broker in brokers.iter().rev() {
             broker.shutdown().await.map_err(RustStreamError::Shutdown)?;
             debug!(target: "ruststream::lifecycle", broker = broker.name(), "broker shut down");
@@ -153,6 +160,32 @@ async fn drain_handles(
         }
     }
     Ok(())
+}
+
+/// Closes the post-settle continuation tracker and waits for the in-flight continuations to finish,
+/// bounded by `timeout` when set. On timeout the remaining continuations keep running detached (the
+/// tracker does not own abort handles); they are at-most-once side effects, so abandoning them is
+/// safe.
+async fn drain_continuations(continuations: TaskTracker, timeout: Option<Duration>) {
+    continuations.close();
+    if continuations.is_empty() {
+        return;
+    }
+    debug!(target: "ruststream::lifecycle", "draining post-settle continuations");
+    match timeout {
+        Some(timeout) => {
+            if tokio::time::timeout(timeout, continuations.wait())
+                .await
+                .is_err()
+            {
+                warn!(
+                    target: "ruststream::lifecycle",
+                    "graceful shutdown timed out; abandoning in-flight continuations",
+                );
+            }
+        }
+        None => continuations.wait().await,
+    }
 }
 
 async fn wait_for_signal() {

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -11,6 +11,8 @@ use std::{
 use crate::codec::Codec;
 use crate::{Broker, Publisher, ServerSpec};
 
+use tokio_util::task::TaskTracker;
+
 use crate::runtime::context::State;
 use crate::runtime::dispatch::{Delivery, Publishers};
 use crate::runtime::lifecycle::{BoxError, BrokerLifecycle};
@@ -75,6 +77,10 @@ pub struct RustStream<L = Identity> {
     pub(super) on_shutdown: Vec<LifecycleHook>,
     pub(super) after_shutdown: Vec<LifecycleHook>,
     pub(super) shutdown_timeout: Option<Duration>,
+    /// Tracks post-settle `and_after` continuations spawned during dispatch, so a graceful
+    /// shutdown drains them after the dispatch loops stop. Shared (cloned) into every
+    /// [`Delivery`].
+    pub(super) continuations: TaskTracker,
     pub(super) global: L,
 }
 
@@ -106,6 +112,7 @@ impl RustStream<Identity> {
             on_shutdown: Vec::new(),
             after_shutdown: Vec::new(),
             shutdown_timeout: None,
+            continuations: TaskTracker::new(),
             global: Identity,
         }
     }
@@ -131,6 +138,7 @@ impl<L> RustStream<L> {
             on_shutdown: self.on_shutdown,
             after_shutdown: self.after_shutdown,
             shutdown_timeout: self.shutdown_timeout,
+            continuations: self.continuations,
             global: Stack::new(layer, self.global),
         }
     }
@@ -217,8 +225,10 @@ impl<L> RustStream<L> {
     }
 
     /// Sets how long [`run`](Self::run) waits for in-flight handlers to finish after shutdown is
-    /// triggered. After the timeout, the remaining handler tasks are aborted. Defaults to waiting
-    /// indefinitely.
+    /// triggered. After the timeout, the remaining handler tasks are aborted. The same bound then
+    /// applies to draining post-settle `and_after` continuations; on timeout they are abandoned
+    /// (they are at-most-once side effects, so this loses follow-up work, never a settlement).
+    /// Defaults to waiting indefinitely.
     #[must_use]
     pub fn shutdown_timeout(mut self, timeout: Duration) -> Self {
         self.shutdown_timeout = Some(timeout);
@@ -341,6 +351,7 @@ impl<L> RustStream<L> {
         let delivery = Arc::new(Delivery {
             publishers: self.publishers.clone(),
             pipeline: scope.pipeline.clone(),
+            tasks: self.continuations.clone(),
         });
         let (starters, handlers) = scope.sink.into_parts();
         for (bound, meta) in starters.into_iter().zip(handlers) {

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -18,7 +18,7 @@ use crate::codec::Codec;
 
 use super::context::Context;
 use super::dispatch::Workers;
-use super::handler::HandlerResult;
+use super::handler::{HandlerResult, Settle};
 use super::metadata::HandlerMetadata;
 use super::typed::DecodeFailure;
 
@@ -26,24 +26,27 @@ use super::typed::DecodeFailure;
 ///
 /// Returned by batch handlers (usually through [`IntoBatchResult`]) and applied by the
 /// dispatcher to each message's own `ack` / `nack`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Per-element [`Settle`]s carry an optional `and_after` continuation each; the uniform form is a
+/// bare outcome, since one continuation cannot fan out to every message of the batch.
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum BatchResult {
     /// One outcome settles every message of the batch.
     Uniform(HandlerResult),
-    /// Outcome `i` settles slice element `i`. A length mismatch with the dispatched batch is a
-    /// bug in the handler: the unmatched remainder is retried (an extra redelivery beats a
-    /// silently lost message) and the mismatch is logged.
-    PerElement(Vec<HandlerResult>),
+    /// Settlement `i` settles slice element `i`, each with its own optional post-settle
+    /// continuation. A length mismatch with the dispatched batch is a bug in the handler: the
+    /// unmatched remainder is retried (an extra redelivery beats a silently lost message) and the
+    /// mismatch is logged.
+    PerElement(Vec<Settle>),
 }
 
 /// Conversion into a [`BatchResult`], so `#[subscriber(batch(..))]` handlers can return a plain
 /// value.
 ///
 /// Implemented for [`BatchResult`] (identity), [`HandlerResult`] / `()` / `Result<(), E>` /
-/// `Result<HandlerResult, E>` (one outcome for the whole batch, with the same conventions as
-/// [`IntoHandlerResult`](super::IntoHandlerResult)), and `Vec<HandlerResult>` (element `i`
-/// settles slice element `i`).
+/// `Result<HandlerResult, E>` (one outcome for the whole batch), and a per-element vector
+/// (`Vec<Settle>`, or `Vec<HandlerResult>`) where element `i` settles slice element `i`.
 pub trait IntoBatchResult {
     /// Converts `self` into the settlement the dispatcher applies.
     fn into_batch_result(self) -> BatchResult;
@@ -82,9 +85,15 @@ impl<E> IntoBatchResult for Result<HandlerResult, E> {
     }
 }
 
-impl IntoBatchResult for Vec<HandlerResult> {
+impl IntoBatchResult for Vec<Settle> {
     fn into_batch_result(self) -> BatchResult {
         BatchResult::PerElement(self)
+    }
+}
+
+impl IntoBatchResult for Vec<HandlerResult> {
+    fn into_batch_result(self) -> BatchResult {
+        BatchResult::PerElement(self.into_iter().map(Settle::from).collect())
     }
 }
 
@@ -285,6 +294,7 @@ where
         if accepted.is_empty() {
             return;
         }
+        let tasks = ctx.tasks().clone();
         match self.inner.handle_slice(&values, ctx).await {
             BatchResult::Uniform(result) => {
                 for msg in accepted {
@@ -305,8 +315,17 @@ where
                 let mut results = results.into_iter();
                 for msg in accepted {
                     // An unmatched message gets retried: an extra redelivery beats losing it.
-                    let result = results.next().unwrap_or_else(HandlerResult::retry);
-                    settle(msg, result, &subscription).await;
+                    let mut result = results
+                        .next()
+                        .unwrap_or_else(|| HandlerResult::retry().into());
+                    let after = result.take_after();
+                    settle(msg, result.outcome(), &subscription).await;
+                    // The continuation runs after this element is settled, on the tracked set so a
+                    // graceful shutdown drains it. At-most-once: a lost or panicking continuation
+                    // never redelivers the already-settled message.
+                    if let Some(after) = after {
+                        tasks.spawn(after);
+                    }
                 }
             }
         }
@@ -436,6 +455,57 @@ mod tests {
         }
         let mut stream = std::pin::pin!(sub.stream());
         assert!(futures::poll!(stream.next()).is_pending());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn per_element_continuations_run_after_settle() {
+        use std::sync::Arc;
+        use tokio::sync::Notify;
+        use tokio_util::task::TaskTracker;
+
+        let broker = MemoryBroker::new();
+        let mut sub = broker.subscribe("after-batch");
+        publish_numbers(&broker, "after-batch", &[0, 1]).await;
+
+        // Element 0 acks with a continuation; element 1 retries with no continuation.
+        let ran = Arc::new(Notify::new());
+        let signal = Arc::clone(&ran);
+        let handler = typed_batch(JsonCodec, move |batch: &[u32], _ctx: &mut Context| {
+            let signal = Arc::clone(&signal);
+            let outcomes: Vec<Settle> = batch
+                .iter()
+                .map(|n| {
+                    if *n == 0 {
+                        let signal = Arc::clone(&signal);
+                        HandlerResult::ack().and_after(async move { signal.notify_one() })
+                    } else {
+                        HandlerResult::retry().into()
+                    }
+                })
+                .collect();
+            async move { outcomes }
+        });
+
+        let tasks = TaskTracker::new();
+        let state = State::default();
+        let delivery = Delivery::with_tasks(tasks.clone());
+        let headers = Headers::new();
+        let mut ctx = Context::new("after-batch", &headers, &state, &delivery);
+        let batch = pull_batch(&mut sub).await;
+        handler.handle_batch(batch, &mut ctx).await;
+
+        // The continuation for element 0 runs on the tracked set after settling.
+        ran.notified().await;
+        tasks.close();
+        tasks.wait().await;
+
+        // Element 1 (no continuation) retried and comes back; element 0 is gone.
+        let redelivered = pull_batch(&mut sub).await;
+        let payloads: Vec<&[u8]> = redelivered.iter().map(IncomingMessage::payload).collect();
+        assert_eq!(payloads, [b"1"]);
+        for msg in redelivered {
+            msg.ack().await.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -117,6 +117,12 @@ impl<'a> Context<'a> {
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
         self.state.get::<T>()
     }
+
+    /// The app-wide tracker for post-settle continuations. The batch dispatcher spawns each
+    /// element's `and_after` future onto it after settling, so a graceful shutdown drains them.
+    pub(crate) fn tasks(&self) -> &tokio_util::task::TaskTracker {
+        &self.delivery.tasks
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -10,13 +10,14 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, warn};
+use tokio_util::task::TaskTracker;
+use tracing::{debug, error};
 
 use crate::{BatchSubscriber, Headers, IncomingMessage, Subscriber};
 
 use super::batch::BatchHandler;
 use super::context::{Context, State};
-use super::handler::{Handler, HandlerResult};
+use super::handler::Handler;
 use super::publish::PublishMiddleware;
 use super::publisher_registry::ErasedPublisher;
 
@@ -83,20 +84,32 @@ impl Default for Workers {
 }
 
 /// Per-scope publish context threaded into every delivery's [`Context`]: the named-publisher
-/// registry and the scope's publish middleware pipeline. A handler resolves a publisher with
-/// [`Context::publisher`] and its sends run through `pipeline`, the same chain as a macro reply.
+/// registry, the scope's publish middleware pipeline, and the app-wide tracker for post-settle
+/// continuations. A handler resolves a publisher with [`Context::publisher`] and its sends run
+/// through `pipeline`, the same chain as a macro reply; an `and_after` continuation is spawned onto
+/// `tasks` so a graceful shutdown drains it.
 pub(crate) struct Delivery {
     pub(crate) publishers: Publishers,
     pub(crate) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
+    pub(crate) tasks: TaskTracker,
 }
 
 impl Delivery {
-    /// An empty delivery context: no publishers, no pipeline. For tests.
+    /// An empty delivery context: no publishers, no pipeline, a fresh continuation tracker. For
+    /// tests.
     #[cfg(test)]
     pub(crate) fn empty() -> Self {
+        Self::with_tasks(TaskTracker::new())
+    }
+
+    /// An empty delivery context carrying a caller-owned continuation tracker, so a test can
+    /// observe the post-settle continuations spawned through it.
+    #[cfg(test)]
+    pub(crate) fn with_tasks(tasks: TaskTracker) -> Self {
         Self {
             publishers: HashMap::new(),
             pipeline: Arc::from([]),
+            tasks,
         }
     }
 }
@@ -106,6 +119,7 @@ impl std::fmt::Debug for Delivery {
         f.debug_struct("Delivery")
             .field("publishers", &self.publishers.len())
             .field("layers", &self.pipeline.len())
+            .field("pending_continuations", &self.tasks.len())
             .finish_non_exhaustive()
     }
 }
@@ -432,18 +446,73 @@ where
     M: IncomingMessage,
 {
     let mut ctx = Context::new(name, msg.headers(), state, delivery);
-    let outcome = handler.handle(&msg, &mut ctx).await;
-    let ack_result = match outcome {
-        HandlerResult::Ack => msg.ack().await,
-        HandlerResult::Nack { requeue } => msg.nack(requeue).await,
-        HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
-    };
-    if let Err(err) = ack_result {
-        warn!(
-            target: "ruststream::dispatch",
-            subscription = %name,
-            error = %err,
-            "ack / nack failed",
-        );
+    let mut settle = handler.handle(&msg, &mut ctx).await;
+    let after = settle.take_after();
+    super::batch::settle(msg, settle.outcome(), name).await;
+    // Run the post-settle continuation on the tracked set so a graceful shutdown drains it.
+    // At-most-once: the message is already settled, so a lost or panicking continuation never
+    // redelivers it.
+    if let Some(after) = after {
+        delivery.tasks.spawn(after);
+    }
+}
+
+#[cfg(all(test, feature = "memory", feature = "json"))]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::StreamExt;
+    use tokio::sync::Notify;
+
+    use super::super::handler::{HandlerResult, Settle};
+    use super::*;
+    use crate::memory::MemoryBroker;
+    use crate::{OutgoingMessage, Publisher, Subscriber};
+
+    async fn publish_one(broker: &MemoryBroker, name: &str) {
+        broker
+            .publisher()
+            .publish(OutgoingMessage::new(
+                name,
+                &serde_json::to_vec(&1u32).unwrap(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    // After ANY settle the continuation runs: an ack with `and_after`, and a drop with `and_after`,
+    // both fire on the tracked set once the message is settled.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn single_continuation_runs_after_ack_and_after_drop() {
+        for outcome in [HandlerResult::ack(), HandlerResult::drop()] {
+            let broker = MemoryBroker::new();
+            let mut sub = broker.subscribe("after-single");
+            publish_one(&broker, "after-single").await;
+
+            let ran = Arc::new(Notify::new());
+            let signal = Arc::clone(&ran);
+            let handler = move |_msg: &crate::memory::MemoryMessage, _ctx: &mut Context| {
+                let signal = Arc::clone(&signal);
+                async move {
+                    let settle: Settle = outcome.and_after(async move { signal.notify_one() });
+                    settle
+                }
+            };
+
+            let tasks = TaskTracker::new();
+            let state = State::default();
+            let delivery = Delivery::with_tasks(tasks.clone());
+            let mut stream = std::pin::pin!(sub.stream());
+            let msg = stream.next().await.unwrap().unwrap();
+            dispatch(&handler, msg, "after-single", &state, &delivery).await;
+
+            // The continuation ran after settling, regardless of ack or drop.
+            ran.notified().await;
+            tasks.close();
+            tasks.wait().await;
+
+            // The message was settled (acked or dropped), so nothing is redelivered.
+            assert!(futures::poll!(stream.next()).is_pending());
+        }
     }
 }

--- a/src/runtime/dynstack.rs
+++ b/src/runtime/dynstack.rs
@@ -13,10 +13,10 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use super::context::Context;
-use super::handler::{Handler, HandlerResult};
+use super::handler::{Handler, Settle};
 use super::middleware::Layer;
 
-type BoxFut<'a> = Pin<Box<dyn Future<Output = HandlerResult> + Send + 'a>>;
+type BoxFut<'a> = Pin<Box<dyn Future<Output = Settle> + Send + 'a>>;
 
 /// The wrapped handler at the end of the chain, erased so [`Next`] need not carry its type.
 trait ErasedHandler<I>: Send + Sync {
@@ -144,7 +144,7 @@ where
 {
     // The returned future captures &self, so the chain and the wrapped handler are borrowed:
     // no Arc refcount traffic per message.
-    async fn handle(&self, input: &I, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, input: &I, ctx: &mut Context<'_>) -> Settle {
         let tail: &dyn ErasedHandler<I> = &self.inner;
         Next {
             rest: &self.chain,
@@ -203,7 +203,10 @@ mod tests {
         let delivery = crate::runtime::dispatch::Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("test", &headers, &state, &delivery);
-        assert_eq!(handler.handle(&Input, &mut ctx).await, HandlerResult::Ack);
+        assert_eq!(
+            handler.handle(&Input, &mut ctx).await.outcome(),
+            HandlerResult::Ack
+        );
         assert_eq!(*log.lock().expect("poisoned"), vec!["a", "b", "inner"]);
     }
 }

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -1,8 +1,13 @@
-//! Handler abstraction and the [`HandlerResult`] enum returned to the router.
+//! Handler abstraction, the [`HandlerResult`] decision enum, and the [`Settle`] settlement unit
+//! returned to the router.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use super::context::Context;
+
+/// A boxed, owned continuation run after a message is settled. Private: a [`Settle`] hands it to
+/// the dispatcher, which spawns it; it never crosses the public API by itself.
+type AfterFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 /// What the router should do with the message after the handler returns.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,6 +33,64 @@ pub enum HandlerResult {
 }
 
 impl HandlerResult {
+    /// Convenience constructor for [`Ack`](Self::Ack), for symmetry with [`retry`](Self::retry),
+    /// [`retry_after`](Self::retry_after), and [`drop`](Self::drop) - so a handler reads the same
+    /// whether it acks or nacks, and so [`and_after`](Self::and_after) chains off it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::runtime::HandlerResult;
+    ///
+    /// # fn check() -> Result<(), Box<dyn std::error::Error>> {
+    /// assert_eq!(HandlerResult::ack(), HandlerResult::Ack);
+    /// # Ok(())
+    /// # }
+    /// # check().unwrap();
+    /// ```
+    #[must_use]
+    pub const fn ack() -> Self {
+        Self::Ack
+    }
+
+    /// Attaches a post-settle continuation to this outcome, producing a [`Settle`].
+    ///
+    /// The dispatcher first settles the message by this outcome (ack / nack), then runs `fut` on a
+    /// tracked task that graceful shutdown drains. Use it for a non-critical side effect that must
+    /// not gate the settlement decision or affect redelivery: a notification, slow follow-up work,
+    /// a cache warm-up. The continuation runs after *any* settle, so `drop().and_after(..)` is
+    /// valid.
+    ///
+    /// # Cancel safety
+    ///
+    /// At-most-once: the message is already settled when `fut` runs, so a continuation that panics
+    /// or is lost on a crash never triggers redelivery. Do not put work whose loss must redeliver
+    /// the message in here; settle by outcome and let the broker retry instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::runtime::HandlerResult;
+    ///
+    /// # fn check() -> Result<(), Box<dyn std::error::Error>> {
+    /// let settle = HandlerResult::ack().and_after(async move {
+    ///     // runs after this message is acked
+    /// });
+    /// assert_eq!(settle.outcome(), HandlerResult::Ack);
+    /// # Ok(())
+    /// # }
+    /// # check().unwrap();
+    /// ```
+    pub fn and_after<F>(self, fut: F) -> Settle
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        Settle {
+            outcome: self,
+            after: Some(Box::pin(fut)),
+        }
+    }
+
     /// Convenience constructor for `Nack { requeue: true }`.
     #[must_use]
     pub const fn retry() -> Self {
@@ -49,40 +112,125 @@ impl HandlerResult {
     }
 }
 
-/// Conversion into a [`HandlerResult`], so `#[subscriber]` handlers can return a plain value
-/// instead of always constructing one.
+/// The settlement of one dispatched message: the [`HandlerResult`] outcome the dispatcher acts on,
+/// plus an optional post-settle continuation.
 ///
-/// Implemented for [`HandlerResult`] (identity), `()` (always [`Ack`](HandlerResult::Ack)), and
-/// `Result<_, E>` (`Ok` acks, `Err` drops).
-pub trait IntoHandlerResult {
-    /// Converts `self` into the outcome the dispatcher acts on.
-    fn into_handler_result(self) -> HandlerResult;
+/// `Settle` is the universal unit flowing through the handler pipeline. A single handler returns
+/// `impl Into<Settle>` and a batch handler returns `Vec<Settle>`; a plain [`HandlerResult`] return
+/// still works through [`From<HandlerResult>`](From), which leaves the continuation empty. Build one
+/// with a continuation via [`HandlerResult::and_after`].
+///
+/// The future never lives inside [`HandlerResult`], so that stays a small `Copy` decision enum
+/// (metrics, tracing, and batch settling all classify by the outcome inside `Settle`).
+///
+/// # Cancel safety
+///
+/// The continuation runs after the message is already settled, so it is at-most-once: a panic or a
+/// crash before it completes never redelivers the message. See [`HandlerResult::and_after`].
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::runtime::{HandlerResult, Settle};
+///
+/// # fn check() -> Result<(), Box<dyn std::error::Error>> {
+/// // A plain outcome converts with no continuation.
+/// let plain: Settle = HandlerResult::ack().into();
+/// assert_eq!(plain.outcome(), HandlerResult::Ack);
+///
+/// // Or carry a continuation that runs after the settle.
+/// let with_after = HandlerResult::drop().and_after(async move { /* cleanup */ });
+/// assert_eq!(with_after.outcome(), HandlerResult::drop());
+/// # Ok(())
+/// # }
+/// # check().unwrap();
+/// ```
+#[must_use]
+pub struct Settle {
+    outcome: HandlerResult,
+    after: Option<AfterFut>,
 }
 
-impl IntoHandlerResult for HandlerResult {
-    fn into_handler_result(self) -> HandlerResult {
-        self
+impl Settle {
+    /// The outcome the dispatcher settles the message by.
+    #[must_use]
+    pub const fn outcome(&self) -> HandlerResult {
+        self.outcome
+    }
+
+    /// Takes the post-settle continuation out of this settlement, leaving none. The dispatcher
+    /// calls this after settling, to spawn the continuation on its tracked task set.
+    pub(crate) fn take_after(&mut self) -> Option<AfterFut> {
+        self.after.take()
     }
 }
 
-impl IntoHandlerResult for () {
-    fn into_handler_result(self) -> HandlerResult {
-        HandlerResult::Ack
+impl std::fmt::Debug for Settle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Settle")
+            .field("outcome", &self.outcome)
+            .field("after", &self.after.is_some())
+            .finish()
     }
 }
 
-impl<E> IntoHandlerResult for Result<(), E> {
-    fn into_handler_result(self) -> HandlerResult {
-        match self {
-            Ok(()) => HandlerResult::Ack,
-            Err(_) => HandlerResult::drop(),
+impl From<HandlerResult> for Settle {
+    fn from(outcome: HandlerResult) -> Self {
+        Self {
+            outcome,
+            after: None,
         }
     }
 }
 
-impl<E> IntoHandlerResult for Result<HandlerResult, E> {
-    fn into_handler_result(self) -> HandlerResult {
-        self.unwrap_or_else(|_| HandlerResult::drop())
+/// Conversion into a [`Settle`], so `#[subscriber]` handlers can return a plain value instead of
+/// always constructing one.
+///
+/// Implemented for [`Settle`] (identity), [`HandlerResult`] (no continuation), `()` (always
+/// [`Ack`](HandlerResult::Ack)), `Result<_, E>` (`Ok` acks, `Err` drops), and `Result<Settle, E>`
+/// / `Result<HandlerResult, E>` (`Err` drops).
+pub trait IntoSettle {
+    /// Converts `self` into the settlement the dispatcher acts on.
+    fn into_settle(self) -> Settle;
+}
+
+impl IntoSettle for Settle {
+    fn into_settle(self) -> Settle {
+        self
+    }
+}
+
+impl IntoSettle for HandlerResult {
+    fn into_settle(self) -> Settle {
+        self.into()
+    }
+}
+
+impl IntoSettle for () {
+    fn into_settle(self) -> Settle {
+        HandlerResult::Ack.into()
+    }
+}
+
+impl<E> IntoSettle for Result<(), E> {
+    fn into_settle(self) -> Settle {
+        match self {
+            Ok(()) => HandlerResult::Ack,
+            Err(_) => HandlerResult::drop(),
+        }
+        .into()
+    }
+}
+
+impl<E> IntoSettle for Result<HandlerResult, E> {
+    fn into_settle(self) -> Settle {
+        self.unwrap_or_else(|_| HandlerResult::drop()).into()
+    }
+}
+
+impl<E> IntoSettle for Result<Settle, E> {
+    fn into_settle(self) -> Settle {
+        self.unwrap_or_else(|_| HandlerResult::drop().into())
     }
 }
 
@@ -108,21 +256,27 @@ impl<E> IntoHandlerResult for Result<HandlerResult, E> {
 /// }
 ///
 /// fn use_closure<M: IncomingMessage + 'static>() {
+///     // A closure may return any `Into<Settle>`, including a bare `HandlerResult`.
 ///     assert_handler::<M, _>(|_msg: &M, _ctx: &mut Context| async { HandlerResult::Ack });
 /// }
 /// ```
 pub trait Handler<M>: Send + Sync {
-    /// Handle one input, with the per-delivery [`Context`].
-    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send;
+    /// Handle one input, with the per-delivery [`Context`]. The returned [`Settle`] carries the
+    /// outcome the dispatcher settles by and any post-settle continuation.
+    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = Settle> + Send;
 }
 
 impl<M, F, Fut> Handler<M> for F
 where
     F: Fn(&M, &mut Context) -> Fut + Send + Sync,
-    Fut: Future<Output = HandlerResult> + Send,
+    Fut: Future + Send,
+    Fut::Output: IntoSettle,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send {
-        (self)(msg, ctx)
+    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = Settle> + Send {
+        // Build the inner future before the async block so it owns the closure's output and the
+        // returned future is `Settle`-valued for any `Into<Settle>` return shape.
+        let fut = (self)(msg, ctx);
+        async move { fut.await.into_settle() }
     }
 }
 
@@ -130,7 +284,7 @@ impl<M, H> Handler<M> for Arc<H>
 where
     H: Handler<M>,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send {
+    fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = Settle> + Send {
         (**self).handle(msg, ctx)
     }
 }
@@ -139,10 +293,11 @@ where
 mod tests {
     use std::time::Duration;
 
-    use super::{HandlerResult, IntoHandlerResult};
+    use super::{HandlerResult, IntoSettle, Settle};
 
     #[test]
     fn convenience_constructors_map_to_variants() {
+        assert_eq!(HandlerResult::ack(), HandlerResult::Ack);
         assert_eq!(
             HandlerResult::retry(),
             HandlerResult::Nack { requeue: true }
@@ -160,21 +315,49 @@ mod tests {
     }
 
     #[test]
-    fn into_handler_result_covers_every_return_shape() {
-        assert_eq!(HandlerResult::Ack.into_handler_result(), HandlerResult::Ack);
-        assert_eq!(().into_handler_result(), HandlerResult::Ack);
-        assert_eq!(Ok::<(), ()>(()).into_handler_result(), HandlerResult::Ack);
-        assert_eq!(
-            Err::<(), ()>(()).into_handler_result(),
-            HandlerResult::drop()
+    fn into_settle_covers_every_return_shape() {
+        // Bare outcomes and unit / Result shapes never carry a continuation.
+        assert_outcome(HandlerResult::Ack.into_settle(), HandlerResult::Ack, false);
+        assert_outcome(().into_settle(), HandlerResult::Ack, false);
+        assert_outcome(Ok::<(), ()>(()).into_settle(), HandlerResult::Ack, false);
+        assert_outcome(
+            Err::<(), ()>(()).into_settle(),
+            HandlerResult::drop(),
+            false,
         );
-        assert_eq!(
-            Ok::<HandlerResult, ()>(HandlerResult::retry()).into_handler_result(),
-            HandlerResult::retry()
+        assert_outcome(
+            Ok::<HandlerResult, ()>(HandlerResult::retry()).into_settle(),
+            HandlerResult::retry(),
+            false,
         );
-        assert_eq!(
-            Err::<HandlerResult, ()>(()).into_handler_result(),
-            HandlerResult::drop()
+        assert_outcome(
+            Err::<HandlerResult, ()>(()).into_settle(),
+            HandlerResult::drop(),
+            false,
         );
+
+        // A Settle (and a Result<Settle, E>) is the identity and keeps its continuation.
+        let with_after = HandlerResult::ack().and_after(async {});
+        assert_outcome(with_after.into_settle(), HandlerResult::Ack, true);
+        let ok: Result<Settle, ()> = Ok(HandlerResult::drop().and_after(async {}));
+        assert_outcome(ok.into_settle(), HandlerResult::drop(), true);
+        let err: Result<Settle, ()> = Err(());
+        assert_outcome(err.into_settle(), HandlerResult::drop(), false);
+    }
+
+    #[test]
+    fn and_after_carries_the_outcome_and_continuation() {
+        let settle = HandlerResult::ack().and_after(async {});
+        assert_eq!(settle.outcome(), HandlerResult::Ack);
+        assert!(format!("{settle:?}").contains("after: true"));
+
+        let plain: Settle = HandlerResult::retry().into();
+        assert_eq!(plain.outcome(), HandlerResult::retry());
+        assert!(format!("{plain:?}").contains("after: false"));
+    }
+
+    fn assert_outcome(mut settle: Settle, outcome: HandlerResult, has_after: bool) {
+        assert_eq!(settle.outcome(), outcome);
+        assert_eq!(settle.take_after().is_some(), has_after);
     }
 }

--- a/src/runtime/middleware.rs
+++ b/src/runtime/middleware.rs
@@ -19,7 +19,7 @@
 use std::future::Future;
 
 use super::context::Context;
-use super::handler::{Handler, HandlerResult};
+use super::handler::{Handler, Settle};
 
 /// A function from one handler to another. Apply with [`HandlerExt::with`].
 pub trait Layer<H> {
@@ -133,7 +133,8 @@ where
 pub mod layers {
     use tracing::{debug, info, instrument, warn};
 
-    use super::{BlanketLayer, Context, Future, Handler, HandlerResult, Layer};
+    use super::super::handler::HandlerResult;
+    use super::{BlanketLayer, Context, Future, Handler, Layer, Settle};
 
     /// Logs every delivery and its outcome via [`tracing`]. Default level is `INFO` for the
     /// outcome and `DEBUG` for arrival.
@@ -186,11 +187,12 @@ pub mod layers {
         H: Handler<M>,
     {
         #[instrument(level = "trace", skip(self, msg, ctx), fields(target = self.target))]
-        fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = HandlerResult> + Send {
+        fn handle(&self, msg: &M, ctx: &mut Context) -> impl Future<Output = Settle> + Send {
             async move {
                 debug!(target: "ruststream::dispatch", "delivery received");
-                let result = self.inner.handle(msg, ctx).await;
-                match result {
+                // Log the outcome inside the settlement; the continuation (if any) flows through.
+                let settle = self.inner.handle(msg, ctx).await;
+                match settle.outcome() {
                     HandlerResult::Ack => {
                         info!(target: "ruststream::dispatch", "handler ack");
                     }
@@ -201,7 +203,7 @@ pub mod layers {
                         warn!(target: "ruststream::dispatch", ?delay, "handler delayed nack");
                     }
                 }
-                result
+                settle
             }
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,7 +24,7 @@ pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};
 pub use context::{Context, State};
 pub use dispatch::Workers;
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
-pub use handler::{Handler, HandlerResult, IntoHandlerResult};
+pub use handler::{Handler, HandlerResult, IntoSettle, Settle};
 pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -15,7 +15,7 @@ use crate::{IncomingMessage, Publisher};
 
 use super::context::Context;
 use super::dispatch::Workers;
-use super::handler::{Handler, HandlerResult};
+use super::handler::{Handler, HandlerResult, Settle};
 use super::metadata::HandlerMetadata;
 use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
 
@@ -127,7 +127,9 @@ where
     PC: Codec,
     PL: PublishLayer,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
+        // The publishing path settles by a bare outcome (no per-element continuation): decode,
+        // run, publish the reply, then ack. It converts to `Settle` with no `and_after`.
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
             Ok(value) => value,
             Err(err) => {
@@ -138,12 +140,12 @@ where
                     error = %err,
                     "codec decode failed",
                 );
-                return HandlerResult::drop();
+                return HandlerResult::drop().into();
             }
         };
         let reply = match self.def.call(&input, ctx).await {
             Ok(reply) => reply,
-            Err(result) => return result,
+            Err(result) => return result.into(),
         };
         let name = self.def.reply_name();
         if let Err(err) = self.publisher.publish(name, &reply, &self.pipeline).await {
@@ -155,9 +157,9 @@ where
                 error = %err,
                 "reply publish failed",
             );
-            return HandlerResult::retry();
+            return HandlerResult::retry().into();
         }
-        HandlerResult::Ack
+        HandlerResult::Ack.into()
     }
 }
 

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -85,13 +85,13 @@ mod tests {
     use crate::Name;
     use crate::runtime::context::{Context, State};
     use crate::runtime::dispatch::{Delivery, Workers};
-    use crate::runtime::handler::{Handler, HandlerResult};
+    use crate::runtime::handler::{Handler, HandlerResult, Settle};
 
     struct Noop;
 
     impl Handler<u32> for Noop {
-        async fn handle(&self, _msg: &u32, _ctx: &mut Context<'_>) -> HandlerResult {
-            HandlerResult::Ack
+        async fn handle(&self, _msg: &u32, _ctx: &mut Context<'_>) -> Settle {
+            HandlerResult::Ack.into()
         }
     }
 
@@ -133,6 +133,9 @@ mod tests {
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("manual", &headers, &state, &delivery);
-        assert_eq!(handler.handle(&7u32, &mut ctx).await, HandlerResult::Ack);
+        assert_eq!(
+            handler.handle(&7u32, &mut ctx).await.outcome(),
+            HandlerResult::Ack
+        );
     }
 }

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -14,7 +14,7 @@ use serde::de::DeserializeOwned;
 use tracing::warn;
 
 use super::context::Context;
-use super::handler::{Handler, HandlerResult};
+use super::handler::{Handler, HandlerResult, Settle};
 
 /// Behaviour when [`Codec`] fails to decode a payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -81,7 +81,7 @@ where
     C: Codec,
     H: Handler<T>,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         match self.codec.decode::<T>(msg.payload()) {
             Ok(value) => self.inner.handle(&value, ctx).await,
             Err(err) => {
@@ -96,6 +96,7 @@ where
                     DecodeFailure::Drop => HandlerResult::drop(),
                     DecodeFailure::Requeue => HandlerResult::retry(),
                 }
+                .into()
             }
         }
     }
@@ -158,7 +159,10 @@ mod tests {
         let mut ctx = Context::new("typed", &headers, &state, &delivery);
 
         let msg = StubMsg(b"7".to_vec(), Headers::new());
-        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::Ack);
+        assert_eq!(
+            handler.handle(&msg, &mut ctx).await.outcome(),
+            HandlerResult::Ack
+        );
         assert_eq!(seen.load(Ordering::SeqCst), 7);
     }
 
@@ -172,7 +176,10 @@ mod tests {
         let mut ctx = Context::new("typed", &headers, &state, &delivery);
 
         let msg = StubMsg(b"not json".to_vec(), Headers::new());
-        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::drop());
+        assert_eq!(
+            handler.handle(&msg, &mut ctx).await.outcome(),
+            HandlerResult::drop()
+        );
         assert_eq!(seen.load(Ordering::SeqCst), 0, "inner must not run");
     }
 
@@ -187,7 +194,10 @@ mod tests {
         let mut ctx = Context::new("typed", &headers, &state, &delivery);
 
         let msg = StubMsg(b"not json".to_vec(), Headers::new());
-        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::retry());
+        assert_eq!(
+            handler.handle(&msg, &mut ctx).await.outcome(),
+            HandlerResult::retry()
+        );
         assert_eq!(seen.load(Ordering::SeqCst), 0, "inner must not run");
     }
 
@@ -201,7 +211,7 @@ mod tests {
         let mut ctx = Context::new("typed", &headers, &state, &delivery);
         // Drive one delivery to pin the message type, then check the Debug rendering.
         let msg = StubMsg(b"5".to_vec(), Headers::new());
-        handler.handle(&msg, &mut ctx).await;
+        let _ = handler.handle(&msg, &mut ctx).await;
         assert!(format!("{handler:?}").contains("Typed"));
 
         // Exercise the StubMsg fixture's own IncomingMessage surface.
@@ -264,7 +274,10 @@ mod tests {
         let headers = Headers::new();
         let mut ctx = Context::new("orders.inbound", &headers, &state, &delivery);
         let msg = StubMsg(b"not json".to_vec(), Headers::new());
-        assert_eq!(handler.handle(&msg, &mut ctx).await, HandlerResult::drop());
+        assert_eq!(
+            handler.handle(&msg, &mut ctx).await.outcome(),
+            HandlerResult::drop()
+        );
         drop(guard);
 
         let decode_event = {

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -12,7 +12,7 @@ use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, BlanketLayer, Context, Handler, HandlerMetadata, HandlerResult, Layer, Outgoing,
-    PublishMiddleware, PublishNext, Router, RustStream, State,
+    PublishMiddleware, PublishNext, Router, RustStream, Settle, State,
 };
 use ruststream::{Name, OutgoingMessage, Publisher};
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,7 @@ where
     M: Sync,
     H: Handler<M>,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
         self.count.fetch_add(1, Ordering::SeqCst);
         self.inner.handle(msg, ctx).await
     }
@@ -126,6 +126,108 @@ async fn app_dispatches_typed_messages() {
 
     shutdown.notify_one();
     run.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graceful_shutdown_drains_post_settle_continuations() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    // The continuation signals `parked` once it is running, then blocks on `release` until the
+    // test lets it proceed, and finally marks `drained`. The drain on shutdown must wait for it.
+    let parked = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let drained = Arc::new(AtomicU32::new(0));
+
+    let on_parked = Arc::clone(&parked);
+    let gate = Arc::clone(&release);
+    let flag = Arc::clone(&drained);
+    let handler = move |_msg: &_, _ctx: &mut Context| {
+        let on_parked = Arc::clone(&on_parked);
+        let gate = Arc::clone(&gate);
+        let flag = Arc::clone(&flag);
+        async move {
+            HandlerResult::ack().and_after(async move {
+                // Signal once the continuation is in flight, then block: the drain must await it.
+                on_parked.notify_one();
+                gate.notified().await;
+                flag.store(1, Ordering::SeqCst);
+            })
+        }
+    };
+
+    let app = RustStream::new(AppInfo::new("drain", "0.1.0")).with_broker(broker, |b| {
+        let subscriber = b.broker().subscribe("work");
+        b.handle(subscriber, handler, HandlerMetadata::raw("work"));
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    publisher
+        .publish(OutgoingMessage::new("work", b"go"))
+        .await
+        .unwrap();
+
+    // Wait until the continuation is spawned and blocked (the message is already acked).
+    parked.notified().await;
+
+    // Begin shutdown while the continuation is still in flight, then release it: the drain holds
+    // run() open until the continuation completes.
+    shutdown.notify_one();
+    release.notify_one();
+    run.await.unwrap().unwrap();
+
+    // run() returned only after the in-flight continuation finished.
+    assert_eq!(drained.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_timeout_abandons_stuck_continuations() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    // A continuation that never completes: it parks forever. With a shutdown timeout, the drain
+    // bounds its wait and returns, leaving the continuation abandoned (at-most-once).
+    let parked = Arc::new(Notify::new());
+    let finished = Arc::new(AtomicU32::new(0));
+
+    let on_parked = Arc::clone(&parked);
+    let flag = Arc::clone(&finished);
+    let handler = move |_msg: &_, _ctx: &mut Context| {
+        let on_parked = Arc::clone(&on_parked);
+        let flag = Arc::clone(&flag);
+        async move {
+            HandlerResult::ack().and_after(async move {
+                on_parked.notify_one();
+                std::future::pending::<()>().await;
+                flag.store(1, Ordering::SeqCst);
+            })
+        }
+    };
+
+    let app = RustStream::new(AppInfo::new("drain", "0.1.0"))
+        .shutdown_timeout(Duration::from_millis(50))
+        .with_broker(broker, |b| {
+            let subscriber = b.broker().subscribe("work");
+            b.handle(subscriber, handler, HandlerMetadata::raw("work"));
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+
+    publisher
+        .publish(OutgoingMessage::new("work", b"go"))
+        .await
+        .unwrap();
+    parked.notified().await;
+
+    shutdown.notify_one();
+    // The drain times out and run() returns without the continuation ever completing.
+    run.await.unwrap().unwrap();
+    assert_eq!(finished.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -551,13 +653,13 @@ impl PublishMiddleware for Tagger {
 struct Bridge;
 
 impl<M: Send + Sync> Handler<M> for Bridge {
-    async fn handle(&self, _msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
+    async fn handle(&self, _msg: &M, ctx: &mut Context<'_>) -> Settle {
         if let Some(out) = ctx.publisher("egress") {
             let _ = out
                 .publish(Outgoing::new("responses", b"reply".to_vec()))
                 .await;
         }
-        HandlerResult::Ack
+        HandlerResult::Ack.into()
     }
 }
 


### PR DESCRIPTION
# Description

Adds a post-settle continuation attached at the handler return site, per element (so it works for batch too). A handler can return a `Settle` carrying an outcome plus a continuation that runs once the message has been settled:

```rust
#[subscriber("orders")]
async fn handle(order: &Order) -> Settle {
    HandlerResult::ack().and_after(async move { /* runs after this message is acked */ })
}
```

Batch (per element):

```rust
#[subscriber(batch("orders"))]
async fn handle(orders: &[Order]) -> Vec<Settle> {
    orders.iter().map(|order| {
        if order.id == 0 { HandlerResult::retry().into() }            // no continuation
        else { HandlerResult::ack().and_after(async move { /* per-element follow-up */ }) }
    }).collect()
}
```

`HandlerResult` stays a small `Copy` decision enum. The new `Settle` struct holds the outcome plus an optional boxed continuation, so the future never lives inside `HandlerResult`. After settling a message by its outcome, the dispatcher spawns the continuation onto an app-wide `TaskTracker`, which a graceful shutdown drains (bounded by `shutdown_timeout` when set), rather than awaiting it inline. At-most-once: the message is already settled, so a continuation that panics or is lost on a crash never redelivers it (documented under `# Cancel safety`).

Batch publishing (`batch(..) + publish(..)`) settles all-or-nothing under one transaction, so per-element `and_after` does not compose there; it applies to plain batch (`Vec<Settle>`) and single forms only. That path keeps settling by a bare `HandlerResult` outcome.

Fixes #68

## Public API changes (breaking, 0.4)

- `Settle` (new): settlement unit (`outcome()` accessor, `From<HandlerResult>`, `must_use`). `IntoSettle` (new) conversion trait.
- `HandlerResult::ack()` (new, for symmetry with `retry`/`retry_after`/`drop`) and `HandlerResult::and_after(fut) -> Settle` (new).
- `Handler::handle` now returns `impl Future<Output = Settle>` (was `HandlerResult`). The closure blanket impl accepts any `Into<Settle>` return, so existing closures returning `HandlerResult` / `()` / `Result<_, E>` keep compiling.
- `BatchResult::PerElement` now holds `Vec<Settle>` (was `Vec<HandlerResult>`); the enum drops its `Copy`/`Clone`/`PartialEq`/`Eq` derives. `Vec<Settle>` and `Vec<HandlerResult>` both convert via `IntoBatchResult`.
- Middleware `Layer` outputs flow `Settle`: `DynMiddleware`/`Next` (the `BoxFut` output), the metrics consume layer, and the bundled `TracingLayer` now operate on `Settle` and classify by `settle.outcome()`.
- `IntoHandlerResult` is removed (superseded by `IntoSettle`); the `#[subscriber]` macro now lowers single-handler bodies through `IntoSettle`.

The broker-facing traits (`Broker`, `Subscriber`, `Publisher`, `IncomingMessage`, capability traits, `SubscriptionSource`, `DescribeServer`) are unchanged; `--all-features` still compiles the published `ruststream-nats` 0.3 and the `nats_*` examples (their handlers return `HandlerResult`, which converts to `Settle`).

## How the macro accepts the new return types

The single form lowers `(async move #block).await` through `IntoSettle::into_settle`, so a handler may return `Settle`, `HandlerResult`, `()`, `Result<_, E>`, `Result<HandlerResult, E>`, or `Result<Settle, E>`. The batch form keeps using `IntoBatchResult`, which now covers `Vec<Settle>` (and still `Vec<HandlerResult>`, each element `.into()`).

## How continuations are tracked / drained

A `tokio_util::task::TaskTracker` lives on `RustStream` and is cloned into every `Delivery`. The single and per-element batch dispatch paths take the continuation out of the `Settle` after settling and `spawn` it onto the tracker. On shutdown, after the dispatch tasks drain, `run` closes the tracker and waits for the in-flight continuations, bounded by `shutdown_timeout` (on timeout they are abandoned).

## Tests / docs

- `Settle`/`ack`/`and_after`/`IntoSettle` unit tests; single-handler `and_after` runs after ack and after drop; per-element batch continuations run after settle; graceful shutdown drains in-flight continuations; `shutdown_timeout` abandons stuck ones. All use `Notify`/atomics, no real sleep (except the timeout value itself, which is the mechanism under test).
- New `examples/post_settle.rs` and a "Post-settle continuations" section in the Subscribers guide.
- Coverage note: the `0.4` branch already sits below the 90% line gate (88.73% on `origin/0.4`); this change raises it to 89.0%. The new code's lines are covered.

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or raising the MSRV - a minor version bump pre-1.0)
- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/`