### PR TITLE
release: bump crate version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/ruststream-macros"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -195,7 +195,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
-ruststream-macros = { version = "0.3", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "0.4", path = "crates/ruststream-macros", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the framework.
 
 ```toml
 [dependencies]
-ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "1"
 ```

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -11,7 +11,7 @@ subscribe -> publish -> ack -> `shutdown` works on the real transport.
 
 ```toml
 [dev-dependencies]
-ruststream = { version = "0.3", features = ["conformance"] }
+ruststream = { version = "0.4", features = ["conformance"] }
 ```
 
 Enable your crate's own `testing` feature alongside it, since `run_suite` drives the `TestClient` you

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -21,7 +21,7 @@ default = []
 testing = ["ruststream/conformance"]
 
 [dependencies]
-ruststream = { version = "0.3", default-features = false }
+ruststream = { version = "0.4", default-features = false }
 async-nats = "0.46"
 bytes = "1"
 futures = "0.3"

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -6,7 +6,7 @@ any other broker:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.3", default-features = false }
+ruststream = { version = "0.4", default-features = false }
 ```
 
 This page is the contract. Implement the required traits, expose your own `Config`, add capability

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -5,7 +5,7 @@ which makes it ideal for examples, unit tests, and prototypes; the CLI scaffold 
 so a fresh project runs with zero dependencies.
 
 ```toml
-ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "json"] }
 ```
 
 <!-- inline-rust: two-line constructor sketch; the broker in context is exercised by every memory-feature example (e.g. quickstart.rs:app) -->

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ features. Add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.3", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -43,7 +43,7 @@ Codec features are mutually compatible; enable as many as you need (see
 
 ```toml
 [dependencies]
-ruststream = { version = "0.3", default-features = false }
+ruststream = { version = "0.4", default-features = false }
 ```
 
 ## The CLI

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -18,7 +18,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.3", features = ["macros", "memory", "json", "asyncapi"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "json", "asyncapi"] }
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -5,7 +5,7 @@ document from the application's handlers: each subscriber becomes a channel and 
 operation, and payload types contribute schemas.
 
 ```toml
-ruststream = { version = "0.3", features = ["macros", "memory", "asyncapi"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "asyncapi"] }
 ```
 
 ## Generating the document

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -15,7 +15,7 @@ When the `logging` feature is enabled, the `#[ruststream::app]` CLI calls the lo
 `run` command, so a scaffolded service logs out of the box:
 
 ```toml
-ruststream = { version = "0.3", features = ["macros", "memory", "json", "logging"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "json", "logging"] }
 ```
 
 ```bash

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -4,7 +4,7 @@ The `metrics` feature collects Prometheus metrics for consumed and published mes
 the `prometheus` crate directly and exposes the data in the Prometheus exposition format.
 
 ```toml
-ruststream = { version = "0.3", features = ["macros", "memory", "metrics"] }
+ruststream = { version = "0.4", features = ["macros", "memory", "metrics"] }
 ```
 
 ## Wiring it up


### PR DESCRIPTION
# Description

Bump the workspace version from 0.3.1 to 0.4.0 for the 0.4 minor release.

The in-workspace `ruststream-macros` dependency range is bumped from 0.3 to
0.4 to match. All `ruststream = { version = "0.3", ... }` references in
`docs/` and `README.md` are updated to 0.4. Cross-repo `ruststream-nats`
references stay at 0.3 (that crate is bumped separately).

## Type of change

- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes)
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally (`just test`)