### PR TITLE
docs: bump ruststream-nats pin to 0.4

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,11 +64,11 @@ which re-exports what it needs from `ruststream`:
 
 ```toml
 [dependencies]
-ruststream-nats = "0.3"
+ruststream-nats = "0.4"
 
 [dev-dependencies]
 # the broker's in-memory test client, for handler tests
-ruststream-nats = { version = "0.3", features = ["testing"] }
+ruststream-nats = { version = "0.4", features = ["testing"] }
 ```
 
 Each broker crate documents its own `Config` and capabilities; the available brokers are listed

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -86,7 +86,7 @@ dev-dependencies:
 
 ```toml title="Cargo.toml"
 [dev-dependencies]
-ruststream-nats = { version = "0.3", features = ["testing"] }
+ruststream-nats = { version = "0.4", features = ["testing"] }
 ```
 
 The same pattern as above, with a wildcard subscriber that audits every order event:


### PR DESCRIPTION
# Description

`ruststream-nats` 0.4 is published (tracking the core 0.4 release), but the docs site still pinned the broker at `0.3` in two snippets. This bumps them so the install and testing examples resolve against the current release.

Changed:
- `docs/getting-started/installation.md` - the concrete-broker `[dependencies]` / `[dev-dependencies]` snippet.
- `docs/guides/testing.md` - the `[dev-dependencies]` snippet for the broker test client.

These were the only stale `ruststream-nats` pins; the core `ruststream` pins across the docs are already on `0.4`.

Fixes # (no issue)

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings