### PR TITLE
docs: link to broker docs instead of pinning broker versions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -60,17 +60,10 @@ See the [CLI guide](../guides/cli.md), or jump straight to the [quick start](qui
 ## Concrete brokers
 
 The `memory` broker is for local development and tests. For production, depend on a broker crate,
-which re-exports what it needs from `ruststream`:
+which re-exports what it needs from `ruststream`. Each broker is versioned and released
+independently, so its own documentation carries the exact dependency line (including the current
+version and the `testing` feature for handler tests) alongside its `Config` and capabilities.
 
-```toml
-[dependencies]
-ruststream-nats = "0.3"
-
-[dev-dependencies]
-# the broker's in-memory test client, for handler tests
-ruststream-nats = { version = "0.3", features = ["testing"] }
-```
-
-Each broker crate documents its own `Config` and capabilities; the available brokers are listed
-under [Brokers](../brokers/index.md). To write one yourself, see
+The available brokers are listed under [Brokers](../brokers/index.md); follow the link there to each
+broker's documentation for installation. To write one yourself, see
 [Broker authors](../broker-authors/index.md).

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -81,13 +81,9 @@ Three details carry the pattern:
 
 For a NATS service, test against the NATS-flavoured test broker instead, so subject semantics are
 the real ones: `orders.*` matches one token, `orders.>` matches the tail, queue-group names are
-accepted, and request-reply works. Enable the broker crate's `testing` feature in
-dev-dependencies:
-
-```toml title="Cargo.toml"
-[dev-dependencies]
-ruststream-nats = { version = "0.3", features = ["testing"] }
-```
+accepted, and request-reply works. Enable the broker crate's `testing` feature in your
+dev-dependencies (see the [`ruststream-nats` documentation](https://powersemmi.github.io/ruststream-nats/)
+for the dependency line and current version).
 
 The same pattern as above, with a wildcard subscriber that audits every order event:
 


### PR DESCRIPTION
# Description

The core docs are broker-agnostic, but two pages hardcoded a `ruststream-nats` version pin. Brokers are versioned and released independently, so a pin in the core docs goes stale on every broker release with nothing to catch it (it just did, on the 0.4 release). This drops the broker version pins and points readers to the broker's own documentation and the Brokers index, which carry the canonical dependency line and current version.

The dedicated [NATS page](docs/brokers/nats.md) already redirects to the broker docs; this brings the install and testing guides in line.

Changed:
- `docs/getting-started/installation.md` - the "Concrete brokers" section now delegates the dependency line to each broker's docs instead of pinning one.
- `docs/guides/testing.md` - the in-memory NATS subsection links to the `ruststream-nats` docs for the `testing` dependency line.

Fixes # (no issue)

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings