### PR TITLE
docs: document the ruststream-fred Redis broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ only, so you assert on handler behaviour, middleware, and decoding exactly as in
 
 - [`ruststream-nats`](https://github.com/powersemmi/ruststream-nats): the NATS broker (Core NATS and
   JetStream).
+- [`ruststream-fred`](https://github.com/powersemmi/ruststream-fred): the Redis broker (Redis Streams
+  with consumer groups; standalone, cluster, and sentinel topologies) via the `fred` client.
 - [`ruststream-py`](https://github.com/powersemmi/ruststream-py): Python bindings.
 
 Concrete brokers live in their own crates and pull `ruststream` from crates.io.

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -10,6 +10,7 @@ one-line change at `with_broker`.
 |---|---|---|
 | [Memory](memory.md) | `ruststream` (feature `memory`) | in-process, for development and tests |
 | [NATS](nats.md) | [`ruststream-nats`](https://github.com/powersemmi/ruststream-nats) | Core NATS and JetStream |
+| [Redis](redis.md) | [`ruststream-fred`](https://github.com/powersemmi/ruststream-fred) | Redis Streams (standalone, cluster, sentinel) |
 
 To implement a broker for another transport, see [Broker authors](../broker-authors/index.md).
 
@@ -44,6 +45,22 @@ differs by one line inside `with_broker`.
     fn app() -> RustStream {
         RustStream::new(AppInfo::new("orders", "0.1.0"))
             .with_broker(NatsBroker::new("nats://localhost:4222"), |b| {
+                b.include_router(routes::orders())
+            })
+    }
+    ```
+
+=== "Redis"
+
+    <!-- inline-rust: Redis half of the broker-switch comparison; depends on the external ruststream-fred crate, no in-repo compiled home -->
+    ```rust
+    use ruststream::runtime::{AppInfo, RustStream};
+    use ruststream_fred::RedisBroker;
+
+    #[ruststream::app]
+    fn app() -> RustStream {
+        RustStream::new(AppInfo::new("orders", "0.1.0"))
+            .with_broker(RedisBroker::standalone("redis://localhost:6379"), |b| {
                 b.include_router(routes::orders())
             })
     }

--- a/docs/brokers/redis.md
+++ b/docs/brokers/redis.md
@@ -1,0 +1,11 @@
+# Redis
+
+The Redis broker lives in its own crate and repository,
+[`ruststream-fred`](https://github.com/powersemmi/ruststream-fred) (named after its client,
+[`fred`](https://crates.io/crates/fred)). It covers Redis Streams with consumer groups across
+standalone, cluster, and sentinel topologies, authentication and TLS on every topology, and an
+in-process test broker under its `testing` feature.
+
+Its full documentation, including installation, subscription options, the acknowledgement model, and
+testing, is published at
+[powersemmi.github.io/ruststream-fred](https://powersemmi.github.io/ruststream-fred/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Two architectural commitments shape the framework:
 - :material-rocket-launch: **[Quick start](getting-started/quickstart.md)** - scaffold a service with the CLI.
 - :material-school: **[Tutorial](getting-started/tutorial.md)** - build a service step by step.
 - :material-test-tube: **[Testing](guides/testing.md)** - test handlers in-process, no server needed.
-- :material-transit-connection-variant: **[Brokers](brokers/index.md)** - the in-memory broker and NATS.
+- :material-transit-connection-variant: **[Brokers](brokers/index.md)** - the in-memory broker, NATS, and Redis.
 - :material-server-network: **[Broker authors](broker-authors/index.md)** - implement the contract and pass conformance.
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
       - brokers/index.md
       - brokers/memory.md
       - brokers/nats.md
+      - brokers/redis.md
   - Broker authors:
       - broker-authors/index.md
       - broker-authors/example-nats.md


### PR DESCRIPTION
# Description

Documents the new sibling Redis broker crate `ruststream-fred` (named after its `fred` client)
across the core docs site and the README, mirroring how the NATS broker is referenced. The core
only links out to the broker's own GitHub Pages and does not pin its version, matching the
established NATS model.

Changes:

- Add `docs/brokers/redis.md`, a short pointer page (Redis Streams with consumer groups;
  standalone, cluster, and sentinel topologies; auth and TLS; the `testing` test broker) that links
  to the broker's published docs.
- List Redis in the brokers table and add a "Redis" tab to the broker-switch example in
  `docs/brokers/index.md`.
- Mention Redis in the Brokers card on the docs home page (`docs/index.md`).
- Register `brokers/redis.md` in the `mkdocs.yml` nav.
- Add `ruststream-fred` to the Ecosystem section of `README.md`.

Fixes #74

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
