### PR TITLE
feat(#94): typed application state

### DIFF
--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -37,6 +37,7 @@ struct HandlerParts<'a> {
     message_meta: TokenStream2,
     ctx_param: TokenStream2,
     ctx_ty: TokenStream2,
+    state_ty: Option<TokenStream2>,
     workers_method: TokenStream2,
     failure_method: TokenStream2,
 }
@@ -61,6 +62,34 @@ fn context_type(func: &ItemFn) -> TokenStream2 {
         }
     }
     quote!(())
+}
+
+/// The application-state type the handler named as the third generic of its
+/// `ctx: &mut Context<'_, C, St>` parameter, or `None` when it named none (only `Context` or
+/// `Context<'_, C>`). When present, the handler is bound to that state type; when absent, the
+/// generated [`Handler`] impl is generic over the state, so the handler mounts on an app with any
+/// state.
+fn state_type(func: &ItemFn) -> Option<TokenStream2> {
+    let FnArg::Typed(PatType { ty, .. }) = func.sig.inputs.get(1)? else {
+        return None;
+    };
+    // Collect the type arguments of `&mut Context<'_, C, St>` (skipping the lifetime); the second is
+    // the state type.
+    if let Type::Reference(reference) = &**ty
+        && let Type::Path(path) = &*reference.elem
+        && let Some(segment) = path.path.segments.last()
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+    {
+        let mut types = args.args.iter().filter_map(|arg| match arg {
+            syn::GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        });
+        let _context_ty = types.next();
+        if let Some(state_ty) = types.next() {
+            return Some(quote!(#state_ty));
+        }
+    }
+    None
 }
 
 /// Renders the `on_failure(..)` clause as an override of the def's defaulted `failure_policies`
@@ -211,6 +240,7 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         quote!(_ctx)
     };
     let ctx_ty = context_type(func);
+    let state_ty = state_type(func);
 
     let workers_method = workers_method(args)?;
     let failure_method = failure_method(args);
@@ -228,6 +258,7 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         message_meta,
         ctx_param,
         ctx_ty,
+        state_ty,
         workers_method,
         failure_method,
     })
@@ -251,6 +282,7 @@ fn expand_batch_publishing(
         message_meta,
         ctx_param,
         ctx_ty: _,
+        state_ty: _,
         workers_method,
         failure_method,
     } = parts;
@@ -342,6 +374,7 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
         message_meta,
         ctx_param,
         ctx_ty: _,
+        state_ty: _,
         workers_method,
         failure_method,
     } = parts;
@@ -412,9 +445,14 @@ fn expand_publishing(
         message_meta,
         ctx_param,
         ctx_ty: _,
+        state_ty,
         workers_method,
         failure_method,
     } = parts;
+
+    // A publishing handler reads the app state by naming it as the third `Context` generic; the def
+    // pins `State` to it (defaulting to `()`), so the subscriber mounts only on a matching app.
+    let state_ty = state_ty.clone().unwrap_or_else(|| quote!(()));
 
     let declared_ty = match &func.sig.output {
         ReturnType::Type(_, ty) => &**ty,
@@ -442,6 +480,7 @@ fn expand_publishing(
         impl ::ruststream::runtime::PublishingDef for #name {
             type Input = #input_ty;
             type Reply = #reply_ty;
+            type State = #state_ty;
             type Source = #source_ty;
 
             fn source(&self) -> Self::Source { #source_expr }
@@ -462,7 +501,7 @@ fn expand_publishing(
             async fn call(
                 &self,
                 #pat: &#input_ty,
-                #ctx_param: &mut ::ruststream::runtime::Context<'_>,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_ty>,
             ) -> ::core::result::Result<#reply_ty, ::ruststream::runtime::HandlerResult> {
                 #call_body
             }
@@ -484,26 +523,43 @@ fn expand_subscribing(parts: &HandlerParts<'_>) -> TokenStream2 {
         message_meta,
         ctx_param,
         ctx_ty,
+        state_ty,
         workers_method,
         failure_method,
     } = parts;
+
+    // A handler that names a state type is bound to it; one that does not is generic over the
+    // state, so it mounts on an app with any state type. Either shape satisfies the mount-site
+    // `Handler<Input, Context, St>` bound, the former only for its `St`, the latter for every `St`.
+    let (impl_generics, state_in_ctx) = match &state_ty {
+        Some(state_ty) => (quote!(), quote!(#state_ty)),
+        None => (
+            quote!(<__RsState: ::core::marker::Send + ::core::marker::Sync>),
+            quote!(__RsState),
+        ),
+    };
+    let handler_impl = quote! {
+        impl #impl_generics
+            ::ruststream::runtime::Handler<#input_ty, #ctx_ty, #state_in_ctx> for #name
+        {
+            async fn handle(
+                &self,
+                #pat: &#input_ty,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, #ctx_ty, #state_in_ctx>,
+            ) -> ::ruststream::runtime::Settle {
+                ::ruststream::runtime::IntoSettle::into_settle(
+                    (async move #block).await,
+                )
+            }
+        }
+    };
 
     quote! {
             #[derive(Clone, Copy)]
             #[allow(non_camel_case_types)]
             #vis struct #name;
 
-            impl ::ruststream::runtime::Handler<#input_ty, #ctx_ty> for #name {
-                async fn handle(
-                    &self,
-                    #pat: &#input_ty,
-                    #ctx_param: &mut ::ruststream::runtime::Context<'_, #ctx_ty>,
-                ) -> ::ruststream::runtime::Settle {
-                    ::ruststream::runtime::IntoSettle::into_settle(
-                        (async move #block).await,
-                    )
-                }
-            }
+            #handler_impl
 
             impl ::ruststream::runtime::SubscriberDef for #name {
                 type Input = #input_ty;

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -5,27 +5,29 @@ lifetimes:
 
 | Level | Type | Lives for | Holds |
 |---|---|---|---|
-| Application | `State` | the whole service | shared resources: pools, clients, configuration |
-| Delivery | `Context` | one message | the channel name, a headers working copy, the broker's typed per-delivery context (read by key), access to `State` and named publishers |
+| Application | the state type `S` | the whole service | shared resources: pools, clients, configuration |
+| Delivery | `Context<'_, C, S>` | one message | the channel name, a headers working copy, the broker's typed per-delivery context `C` (read by key), the typed shared state `S` and named publishers |
 
-`State` is filled once, at startup. A `Context` is built fresh for every delivery and threaded as
-`&mut` through the middleware chain into the handler, so middleware and the handler observe (and
-can enrich) the same per-message view.
+The state is produced once, at startup, and is a single typed value of your own choosing. A
+`Context` is built fresh for every delivery and threaded as `&mut` through the middleware chain into
+the handler, so middleware and the handler observe (and can enrich) the same per-message view.
 
-## Application level: `State`
+## Application level: typed state
 
-`State` is a type-map: one value per type, `Send + Sync`. Two ways to fill it:
+The shared application state is one typed value `S` (a struct you define, or `()` when the service
+needs none). It is produced by an `on_startup` hook - the value the hook returns becomes the state,
+fixing the app's state type:
 
-- **At build time** with `RustStream::insert_state(value)` - for values that need no async work
-  (parsed configuration, a constructed client).
-- **In an `on_startup` hook** with `state.insert(value)` - for resources that need `await` to
-  create (a database pool). See [Lifespan](lifespan.md) for the hook contract.
+```rust
+--8<-- "examples/context.rs:app"
+```
 
-Inserting a second value of the same type replaces the first. Handlers read it through the context
-with `ctx.state().get::<T>()`, which returns `Option<&T>` - `None` only if nothing of that type was
-inserted. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
-references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when
-a shared value must change at runtime.
+The state type is checked at compile time: a `#[subscriber]` handler that reads state names it as
+the third `Context` generic (`Context<'_, C, S>`), and the runtime only lets that handler mount on
+an app whose state type matches. A handler that names no state type is generic over it, so it mounts
+on any app. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
+references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when a
+shared value must change at runtime. See [Lifespan](lifespan.md) for the startup-hook contract.
 
 ```rust
 --8<-- "examples/context.rs:state"
@@ -48,7 +50,7 @@ What the context exposes:
 | `name()` | `&str` | the channel / subject the message arrived on |
 | `headers()` | `&Headers` | the working copy of the message headers |
 | `headers_mut()` | `&mut Headers` | the same copy, for middleware to enrich |
-| `state()` | `&State` | shared application state (then `.get::<T>()`) |
+| `state()` | `&S` | the typed shared application state, borrowed directly |
 | `context(KEY)` | `KEY::Value` | a [broker field](#per-delivery-context) read by compile-time key |
 | `set(KEY, v)` | `()` | write a per-delivery [scratch value](#per-delivery-context) (middleware) |
 | `publisher(name)` | `Option<ScopedPublisher>` | a [named publisher](publishing.md#publishing-from-inside-a-handler) |
@@ -60,8 +62,8 @@ second argument.
 
 ## Per-delivery context
 
-Beside the shared `State`, the context carries the broker's typed per-delivery context, read by
-**compile-time key** with no hashing, boxing, or downcasting. A key is a zero-sized selector the
+Beside the shared application state, the context carries the broker's typed per-delivery context,
+read by **compile-time key** with no hashing, boxing, or downcasting. A key is a zero-sized selector the
 broker exports; `ctx.context(KEY)` resolves it to a direct field read off the context, so a handler
 reads native delivery metadata - a stream id, an offset, a delivery handle - without the broker
 serializing it into the byte-only headers. A key implements `Field` only for the context types that

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -1,36 +1,34 @@
 # Lifespan and shared state
 
 Most services need resources that are created once at startup and shared by every handler: a
-database pool, an HTTP client, parsed configuration. RustStream gives you a shared `State` type-map
-plus lifecycle hooks that run at fixed points around the run loop.
+database pool, an HTTP client, parsed configuration. RustStream gives you one typed shared-state
+value plus lifecycle hooks that run at fixed points around the run loop.
 
 ## Shared state
 
-`State` is a type-map: one value per type. Put ready-made values in at build time with
-`insert_state` (or from a [startup hook](#lifecycle-hooks), as the `Database` below is):
+The application state is a single typed value of your own choosing (a struct, or `()` when the
+service needs none). It is produced by the `on_startup` hook - the value the hook returns becomes
+the state and fixes the app's state type:
 
-<!-- inline-rust: minimal insert_state fragment with placeholder Config; the startup-hook form is compiled in lifespan.rs:hooks, pulled in below -->
 ```rust
-RustStream::new(info)
-    .insert_state(Config::from_env())
-    .with_broker(broker, |b| b.include(handle));
+--8<-- "examples/lifespan.rs:hooks"
 ```
 
-Read them from any handler or middleware through the `Context`:
+Read it from any handler or middleware through the `Context`, which borrows it directly:
 
 ```rust
 --8<-- "examples/lifespan.rs:handler"
 ```
 
-`ctx.state().get::<T>()` returns `Option<&T>`; it is `None` only if no value of that type was
-inserted. Inserting the same type again replaces the previous value. (For data scoped to one
-message rather than the whole service, use the typed
+`ctx.state()` returns `&S`, the typed state itself - no lookup, no `Option`, no downcast. (For data
+scoped to one message rather than the whole service, use the typed
 [per-delivery context](context.md#per-delivery-context) instead.)
 
-A `#[subscriber]` handler opts into the context by taking a second parameter, `ctx: &mut Context`,
-after the payload. Omit it when the handler does not need state. Everything else the context
-carries (the headers working copy, named publishers) is covered in
-[Context and state](context.md).
+A `#[subscriber]` handler that reads state names it as the third `Context` generic
+(`ctx: &mut Context<'_, (), S>`); the runtime only lets that handler mount on an app whose state
+type matches, checked at compile time. A handler that names no state type is generic over it and
+mounts on any app. Everything else the context carries (the headers working copy, named publishers)
+is covered in [Context and state](context.md).
 
 ## Lifecycle hooks
 
@@ -38,19 +36,20 @@ Anything that needs `async` work (connecting that pool, closing it cleanly) goes
 hooks bracket the run loop:
 
 ```text
-on_startup(State) -> State       # before brokers connect; build async resources
+on_startup(prev) -> S            # before brokers connect; build async resources, produce the state
   -> brokers connect, subscriptions open
-after_startup(Arc<State>)        # handlers are live; publish a first message, signal readiness
+after_startup(Arc<S>)            # handlers are live; publish a first message, signal readiness
   ... running ...
   -> shutdown triggered (signal, or the run_until future resolves)
-on_shutdown(Arc<State>)          # brokers still connected
+on_shutdown(Arc<S>)              # brokers still connected
   -> brokers shut down, in-flight handlers drained
-after_shutdown(Arc<State>)       # final teardown
+after_shutdown(Arc<S>)           # final teardown
 ```
 
-- **`on_startup`** receives the `State` **by value** and returns it, so its future can own the state
-  across awaits - connect a resource, insert it, hand the state back. A failing `on_startup` aborts
-  startup. The later hooks receive the state as a shared `Arc<State>`.
+- **`on_startup`** receives the previous state **by value** (`()` on the first call) and returns the
+  new state, so its future can own resources across awaits - connect a pool, build the state struct,
+  return it. The returned type becomes the app's state type. A failing `on_startup` aborts startup.
+  The later hooks receive the state as a shared `Arc<S>`.
 - **`after_startup`** runs once subscriptions are open and handlers are live. Use it to publish an
   initial message or signal readiness (the [testing guide](testing.md) uses it as the "handlers are
   live" gate). A failure here also aborts startup.
@@ -70,9 +69,9 @@ slots in the same way, only its `connect` / `close` calls differ:
 --8<-- "examples/lifespan.rs:hooks"
 ```
 
-The hook's error type is inferred from the `Ok::<_, E>(..)` annotation; it only needs to implement
-`std::error::Error + Send + Sync`. The resource is `Clone` and `Send + Sync`, so every concurrent
-handler borrows the one instance from `State` - no per-message connection setup. The runnable
+The hook's error type is inferred from the returned `Result`; it only needs to implement
+`std::error::Error + Send + Sync`. The resource is `Send + Sync`, so every concurrent handler borrows
+the one shared instance through `ctx.state()` - no per-message connection setup. The runnable
 program is
 [`examples/lifespan.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/lifespan.rs).
 

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -21,7 +21,7 @@ struct Order {
 }
 
 // --8<-- [start:state]
-/// Shared configuration: inserted once at build time, read by every handler.
+/// Shared configuration: produced once at startup, read by every handler as the typed app state.
 #[derive(Debug)]
 struct AppConfig {
     reject_zero_ids: bool,
@@ -30,7 +30,7 @@ struct AppConfig {
 
 // --8<-- [start:handler]
 #[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
+async fn handle(order: &Order, ctx: &mut Context<'_, (), AppConfig>) -> HandlerResult {
     // 1. The channel the message arrived on.
     println!("received on {}", ctx.name());
 
@@ -39,11 +39,8 @@ async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
         println!("request {}", String::from_utf8_lossy(id));
     }
 
-    // 3. App-level shared state, reached through state().
-    let config = ctx
-        .state()
-        .get::<AppConfig>()
-        .expect("config inserted at build time");
+    // 3. The typed app-level shared state, borrowed through state().
+    let config = ctx.state();
     if config.reject_zero_ids && order.id == 0 {
         return HandlerResult::drop();
     }
@@ -76,8 +73,12 @@ impl<H> Layer<H> for RequestId {
 
 static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
 
-impl<M: Send + Sync, H: Handler<M>> Handler<M> for WithRequestId<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
+// The layer is state-agnostic: it threads the context `C` and state `S` through unchanged, so it
+// wraps a handler whatever typed state the app declares.
+impl<M: Send + Sync, C: Send, S: Send + Sync, H: Handler<M, C, S>> Handler<M, C, S>
+    for WithRequestId<H>
+{
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> Settle {
         if ctx.headers().get("x-request-id").is_none() {
             let id = format!("req-{}", NEXT_REQUEST.fetch_add(1, Ordering::Relaxed));
             ctx.headers_mut().insert("x-request-id", id.into_bytes());
@@ -88,11 +89,14 @@ impl<M: Send + Sync, H: Handler<M>> Handler<M> for WithRequestId<H> {
 // --8<-- [end:enrich]
 
 // --8<-- [start:app]
+// `on_startup` fixes the app's state type to `AppConfig`; `.layer` then grows the global stack.
 #[ruststream::app]
-fn app() -> RustStream<Stack<RequestId, Identity>> {
+fn app() -> RustStream<Stack<RequestId, Identity>, AppConfig> {
     RustStream::new(AppInfo::new("context", "0.1.0"))
-        .insert_state(AppConfig {
-            reject_zero_ids: true,
+        .on_startup(|()| async {
+            Ok::<_, std::convert::Infallible>(AppConfig {
+                reject_zero_ids: true,
+            })
         })
         .layer(RequestId)
         .with_broker(MemoryBroker::new(), |b| b.include(handle))

--- a/examples/lifespan.rs
+++ b/examples/lifespan.rs
@@ -1,5 +1,5 @@
 //! Shared state and lifecycle hooks from the Lifespan guide: a resource opened in `on_startup`,
-//! shared with handlers through `State`, and closed in `after_shutdown`.
+//! shared with handlers as the typed application state, and closed in `after_shutdown`.
 //!
 //! The `Database` here is a stand-in for any async resource (a `sqlx::PgPool`, an HTTP client);
 //! only its `connect` / `close` calls would differ.
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::runtime::{AppInfo, HandlerResult, Identity, RustStream};
 use ruststream::subscriber;
 use serde::Deserialize;
 
@@ -48,12 +48,11 @@ impl Database {
 }
 
 // --8<-- [start:handler]
+// The handler names the app's state type as the third `Context` generic; `ctx.state()` then borrows
+// the typed `Database` directly, with no lookup or downcast.
 #[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
-    let db = ctx
-        .state()
-        .get::<Database>()
-        .expect("database inserted in on_startup");
+async fn handle(order: &Order, ctx: &mut Context<'_, (), Database>) -> HandlerResult {
+    let db = ctx.state();
     if db.insert_order(order.id).await.is_err() {
         return HandlerResult::retry();
     }
@@ -62,20 +61,15 @@ async fn handle(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
 // --8<-- [end:handler]
 
 // --8<-- [start:hooks]
+// The builder's state type is `Database` once `on_startup` produces it, so the return type names it.
 #[ruststream::app]
-fn app() -> RustStream {
+fn app() -> RustStream<Identity, Database> {
     RustStream::new(AppInfo::new("orders", "0.1.0"))
-        // before brokers connect: open the resource and put it in shared state
-        .on_startup(|mut state| async move {
-            let db = Database::connect("postgres://localhost/orders").await?;
-            state.insert(db);
-            Ok::<_, DbError>(state)
-        })
-        // after brokers shut down: close it cleanly
-        .after_shutdown(|state| async move {
-            if let Some(db) = state.get::<Database>() {
-                db.close().await;
-            }
+        // before brokers connect: open the resource; the produced value becomes the typed app state
+        .on_startup(|()| async move { Database::connect("postgres://localhost/orders").await })
+        // after brokers shut down: close it cleanly (the state is shared as `Arc<Database>`)
+        .after_shutdown(|db: std::sync::Arc<Database>| async move {
+            db.close().await;
             Ok::<_, DbError>(())
         })
         // bound the post-shutdown drain of in-flight handlers

--- a/examples/middleware_app_scope.rs
+++ b/examples/middleware_app_scope.rs
@@ -49,8 +49,8 @@ impl<H> Layer<H> for LogLayer {
     }
 }
 
-impl<M: Send + Sync, C: Send, H: Handler<M, C>> Handler<M, C> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> Settle {
+impl<M: Send + Sync, C: Send, S: Send + Sync, H: Handler<M, C, S>> Handler<M, C, S> for Logged<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> Settle {
         println!("app layer -> {}", ctx.name());
         self.0.handle(msg, ctx).await
     }
@@ -59,11 +59,12 @@ impl<M: Send + Sync, C: Send, H: Handler<M, C>> Handler<M, C> for Logged<H> {
 // Reaching router handlers requires the layer to be a BlanketLayer: the router hides its
 // handlers' concrete types, so the wrap happens through this generic method at mount time.
 impl BlanketLayer for LogLayer {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         Logged(handler)
     }

--- a/examples/middleware_router_scope.rs
+++ b/examples/middleware_router_scope.rs
@@ -54,18 +54,19 @@ impl<H> Layer<H> for LogLayer {
 
 // A router hides its handlers' concrete types, so a router-scope layer must be a BlanketLayer.
 impl BlanketLayer for LogLayer {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         Logged(handler)
     }
 }
 
-impl<M: Send + Sync, C: Send, H: Handler<M, C>> Handler<M, C> for Logged<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> Settle {
+impl<M: Send + Sync, C: Send, S: Send + Sync, H: Handler<M, C, S>> Handler<M, C, S> for Logged<H> {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> Settle {
         println!("router layer -> {}", ctx.name());
         self.0.handle(msg, ctx).await
     }

--- a/examples/routed_service/main.rs
+++ b/examples/routed_service/main.rs
@@ -35,13 +35,16 @@ use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
 use ruststream::runtime::{AppInfo, Identity, RustStream, Stack};
 
+use std::sync::Arc;
+
 use crate::domain::{Repository, ServiceError};
 use crate::observability::Observe;
 
-/// Builds the service. The layer stack is named in the return type: `Observe` wraps every handler,
-/// including the router-mounted ones (it is a `BlanketLayer`), with `Identity` as the base.
+/// Builds the service. The layer stack and the typed application state are both named in the return
+/// type: `Observe` wraps every handler, including the router-mounted ones (it is a `BlanketLayer`),
+/// with `Identity` as the base; `Repository` is the shared state `on_startup` produces.
 #[ruststream::app]
-fn app() -> RustStream<Stack<Observe, Identity>> {
+fn app() -> RustStream<Stack<Observe, Identity>, Repository> {
     let metrics = Metrics::new().expect("create metrics registry");
     // A second handle for the shutdown dump; `Metrics` is cheap to clone (shared registry).
     let metrics_dump = metrics.clone();
@@ -56,17 +59,12 @@ fn app() -> RustStream<Stack<Observe, Identity>> {
         .layer(Observe)
         // Publish-side metric: counts every reply that leaves the process.
         .publish_layer(metrics.publish_layer())
-        // Open the shared repository before brokers connect, hand it to handlers via state.
-        .on_startup(|mut state| async move {
-            let repo = Repository::open().await?;
-            state.insert(repo);
-            Ok::<_, ServiceError>(state)
-        })
+        // Open the shared repository before brokers connect; the produced value becomes the typed
+        // app state, shared with every handler.
+        .on_startup(|()| async move { Repository::open().await })
         // Close the repository after brokers stop, then dump the final metrics.
-        .after_shutdown(move |state| async move {
-            if let Some(repo) = state.get::<Repository>() {
-                repo.close().await;
-            }
+        .after_shutdown(move |repo: Arc<Repository>| async move {
+            repo.close().await;
             match metrics_dump.export() {
                 Ok(text) => tracing::info!("final metrics:\n{text}"),
                 Err(e) => tracing::warn!(error = %e, "could not export metrics"),

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -28,18 +28,21 @@ impl<H> Layer<H> for Observe {
 }
 
 impl BlanketLayer for Observe {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         Observed(handler)
     }
 }
 
-impl<M: Send + Sync, C: Send, H: Handler<M, C>> Handler<M, C> for Observed<H> {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> Settle {
+impl<M: Send + Sync, C: Send, S: Send + Sync, H: Handler<M, C, S>> Handler<M, C, S>
+    for Observed<H>
+{
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> Settle {
         let channel = ctx.name().to_owned();
         let started = Instant::now();
         let settle = self.0.handle(msg, ctx).await;

--- a/examples/routed_service/orders.rs
+++ b/examples/routed_service/orders.rs
@@ -23,12 +23,9 @@ use crate::domain::{Cancellation, Confirmation, Order, Repository};
 #[subscriber(MemorySource::new("orders"), publish("confirmations"))]
 pub(crate) async fn confirm(
     order: &Order,
-    ctx: &mut Context<'_>,
+    ctx: &mut Context<'_, (), Repository>,
 ) -> Result<Confirmation, HandlerResult> {
-    let repo = ctx
-        .state()
-        .get::<Repository>()
-        .expect("repository set in on_startup");
+    let repo = ctx.state();
     tracing::debug!(
         order = order.id,
         customer = %order.customer,
@@ -56,11 +53,11 @@ pub(crate) async fn confirm(
 /// a transient store error, ack everything else (an unknown order is nothing to undo).
 // --8<-- [start:retry]
 #[subscriber("cancellations")]
-pub(crate) async fn on_cancel(cancel: &Cancellation, ctx: &mut Context<'_>) -> HandlerResult {
-    let repo = ctx
-        .state()
-        .get::<Repository>()
-        .expect("repository set in on_startup");
+pub(crate) async fn on_cancel(
+    cancel: &Cancellation,
+    ctx: &mut Context<'_, (), Repository>,
+) -> HandlerResult {
+    let repo = ctx.state();
     match repo.cancel(cancel.order_id).await {
         // A transient blip is worth a redelivery; an unknown order (or success) is nothing to undo.
         Err(e) if e.is_transient() => HandlerResult::retry(),

--- a/examples/routed_service/payments.rs
+++ b/examples/routed_service/payments.rs
@@ -13,11 +13,11 @@ use crate::domain::{Clearing, Payment, Repository, Settlement};
 /// an immediate retry, so a flaky downstream is not hammered.
 // --8<-- [start:workers]
 #[subscriber("payments", workers(8, by_key))]
-pub(crate) async fn process_payment(payment: &Payment, ctx: &mut Context<'_>) -> HandlerResult {
-    let repo = ctx
-        .state()
-        .get::<Repository>()
-        .expect("repository set in on_startup");
+pub(crate) async fn process_payment(
+    payment: &Payment,
+    ctx: &mut Context<'_, (), Repository>,
+) -> HandlerResult {
+    let repo = ctx.state();
     tracing::debug!(order = payment.order_id, customer = %payment.customer, "charging payment");
     if repo
         .charge(payment.order_id, payment.amount_cents)

--- a/examples/routed_service/routes.rs
+++ b/examples/routed_service/routes.rs
@@ -12,6 +12,7 @@ use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
 use ruststream::runtime::{Router, RouterDef, TypedPublisher};
 
+use crate::domain::Repository;
 use crate::observability::StampSource;
 use crate::{orders, payments};
 
@@ -32,7 +33,7 @@ use crate::{orders, payments};
 pub(crate) fn orders(
     broker: &MemoryBroker,
     metrics: &Metrics,
-) -> impl RouterDef<MemoryBroker> + use<> {
+) -> impl RouterDef<MemoryBroker, Repository> + use<> {
     let confirmations = TypedPublisher::new(broker.publisher()).layer(StampSource);
 
     Router::new()
@@ -50,7 +51,7 @@ pub(crate) fn orders(
 pub(crate) fn payments(
     broker: &MemoryBroker,
     metrics: &Metrics,
-) -> impl RouterDef<MemoryBroker> + use<> {
+) -> impl RouterDef<MemoryBroker, Repository> + use<> {
     let settlements = TypedPublisher::new(broker.publisher()).transactional();
 
     Router::new()

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -181,7 +181,7 @@ impl Reference {
 /// # }
 /// ```
 #[must_use]
-pub fn build_spec<L>(app: &RustStream<L>) -> Spec {
+pub fn build_spec<L, St>(app: &RustStream<L, St>) -> Spec {
     let info = Info {
         title: app.info().title.clone(),
         version: app.info().version.clone(),

--- a/src/field.rs
+++ b/src/field.rs
@@ -96,10 +96,6 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 /// own context type, reading the fields off its concrete message; the blanket `impl` for `()`
 /// gives the zero-field default, so a broker that exposes nothing needs no implementation.
 ///
-/// The built context is an owned value (it reads its fields out of the message rather than
-/// borrowing it), so it does not tie the handler's context type to the delivery lifetime; broker
-/// metadata is typically `Copy` (offsets, sequence numbers), so this is a stack copy.
-///
 /// # Examples
 ///
 /// ```
@@ -114,8 +110,8 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 ///     offset: u64,
 /// }
 ///
-/// impl BuildContext<Msg> for OrdersContext {
-///     fn build(msg: &Msg) -> Self {
+/// impl<'a> BuildContext<'a, Msg> for OrdersContext {
+///     fn build(msg: &'a Msg) -> Self {
 ///         Self { offset: msg.offset }
 ///     }
 /// }
@@ -124,11 +120,11 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 /// let cx = OrdersContext::build(&msg);
 /// assert_eq!(cx.offset, 9);
 /// ```
-pub trait BuildContext<M: ?Sized> {
-    /// Builds the context value by reading fields out of `msg`.
-    fn build(msg: &M) -> Self;
+pub trait BuildContext<'a, M: ?Sized + 'a> {
+    /// Builds the context value, borrowing from `msg` for `'a`.
+    fn build(msg: &'a M) -> Self;
 }
 
-impl<M: ?Sized> BuildContext<M> for () {
-    fn build(_msg: &M) -> Self {}
+impl<'a, M: ?Sized + 'a> BuildContext<'a, M> for () {
+    fn build(_msg: &'a M) -> Self {}
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -96,6 +96,10 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 /// own context type, reading the fields off its concrete message; the blanket `impl` for `()`
 /// gives the zero-field default, so a broker that exposes nothing needs no implementation.
 ///
+/// The built context is an owned value (it reads its fields out of the message rather than
+/// borrowing it), so it does not tie the handler's context type to the delivery lifetime; broker
+/// metadata is typically `Copy` (offsets, sequence numbers), so this is a stack copy.
+///
 /// # Examples
 ///
 /// ```
@@ -110,8 +114,8 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 ///     offset: u64,
 /// }
 ///
-/// impl<'a> BuildContext<'a, Msg> for OrdersContext {
-///     fn build(msg: &'a Msg) -> Self {
+/// impl BuildContext<Msg> for OrdersContext {
+///     fn build(msg: &Msg) -> Self {
 ///         Self { offset: msg.offset }
 ///     }
 /// }
@@ -120,11 +124,11 @@ pub trait FieldMut<Src: ?Sized>: Field<Src> {
 /// let cx = OrdersContext::build(&msg);
 /// assert_eq!(cx.offset, 9);
 /// ```
-pub trait BuildContext<'a, M: ?Sized + 'a> {
-    /// Builds the context value, borrowing from `msg` for `'a`.
-    fn build(msg: &'a M) -> Self;
+pub trait BuildContext<M: ?Sized> {
+    /// Builds the context value by reading fields out of `msg`.
+    fn build(msg: &M) -> Self;
 }
 
-impl<'a, M: ?Sized + 'a> BuildContext<'a, M> for () {
-    fn build(_msg: &'a M) -> Self {}
+impl<M: ?Sized> BuildContext<M> for () {
+    fn build(_msg: &M) -> Self {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ mod broker;
 mod buffered;
 mod capability;
 mod error;
-mod extensions;
 mod field;
 mod headers;
 mod message;
@@ -51,7 +50,6 @@ pub use capability::{
     TransactionalPublisher,
 };
 pub use error::AckError;
-pub use extensions::Extensions;
 pub use field::{BuildContext, Field, FieldMut};
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod broker;
 mod buffered;
 mod capability;
 mod error;
+mod extensions;
 mod field;
 mod headers;
 mod message;
@@ -50,7 +51,8 @@ pub use capability::{
     TransactionalPublisher,
 };
 pub use error::AckError;
-pub use field::{BuildContext, Field, FieldMut};
+pub use extensions::Extensions;
+pub use field::{Field, FieldMut};
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::Publisher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use capability::{
 };
 pub use error::AckError;
 pub use extensions::Extensions;
-pub use field::{Field, FieldMut};
+pub use field::{BuildContext, Field, FieldMut};
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::Publisher;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -194,11 +194,12 @@ impl<H> Layer<H> for MetricsLayer {
 // `MetricsHandler<H>` is already `Handler<M>` for any `H: Handler<M>`, so the blanket form just
 // delegates to the static one.
 impl BlanketLayer for MetricsLayer {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         self.layer(handler)
     }
@@ -217,13 +218,14 @@ impl<H> std::fmt::Debug for MetricsHandler<H> {
     }
 }
 
-impl<M, C, H> Handler<M, C> for MetricsHandler<H>
+impl<M, C, S, H> Handler<M, C, S> for MetricsHandler<H>
 where
     M: Sync,
     C: Send,
-    H: Handler<M, C>,
+    S: Send + Sync,
+    H: Handler<M, C, S>,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> impl Future<Output = Settle> + Send {
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send {
         let name = ctx.name().to_owned();
         async move {
             let started = std::time::Instant::now();

--- a/src/runtime/app/include.rs
+++ b/src/runtime/app/include.rs
@@ -18,7 +18,7 @@ use crate::runtime::typed::Typed;
 
 use super::scope::BrokerScope;
 
-impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
+impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
     /// [`DefaultCodec`](crate::codec::DefaultCodec) and wrapping the handler with the global stack.
     ///
@@ -45,6 +45,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
             > + Send
             + 'static,
+        St: Send + Sync + 'static,
         L: Layer<
             Typed<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
@@ -56,6 +57,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         L::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
+                St,
             > + 'static,
     {
         let source = def.source();
@@ -78,6 +80,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
+        St: Send + Sync + 'static,
         L: Layer<
             Typed<
                 <S::Subscriber as Subscriber>::Message,
@@ -86,7 +89,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
                 D::Handler,
             >,
         >,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         self.mount_subscriber(source, def, crate::codec::DefaultCodec::default());
     }
@@ -109,6 +112,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        St: Send + Sync + 'static,
     {
         let source = def.source();
         self.mount_batch(source, def, crate::codec::DefaultCodec::default());
@@ -125,6 +129,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         D: BatchDef,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        St: Send + Sync + 'static,
     {
         self.mount_batch(source, def, crate::codec::DefaultCodec::default());
     }
@@ -146,6 +151,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
         RP::Codec: Clone + 'static,
+        St: Send + Sync + 'static,
     {
         let codec = publisher.reply_codec().clone();
         let source = def.source();
@@ -163,6 +169,7 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
         RP::Codec: Clone + 'static,
+        St: Send + Sync + 'static,
     {
         let codec = publisher.reply_codec().clone();
         self.mount_batch_publishing(source, def, codec, publisher);
@@ -184,9 +191,13 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishLayer + 'static,
+        St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
+        L::Handler: Handler<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+                (),
+                St,
+            > + 'static,
     {
         let codec = publisher.codec().clone();
         let source = def.source();
@@ -210,15 +221,16 @@ impl<B: Broker + 'static, L> BrokerScope<B, L, ()> {
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishLayer + 'static,
+        St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
     {
         let codec = publisher.codec().clone();
         self.mount_publishing(source, def, codec, publisher);
     }
 }
 
-impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
+impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C, St> {
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
     /// scope's default codec (set by
     /// [`with_broker_codec`](crate::runtime::RustStream::with_broker_codec)).
@@ -234,6 +246,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
             > + Send
             + 'static,
+        St: Send + Sync + 'static,
         L: Layer<
             Typed<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
@@ -245,6 +258,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         L::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
+                St,
             > + 'static,
     {
         let codec = self.codec.clone();
@@ -263,8 +277,9 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
+        St: Send + Sync + 'static,
         L: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         let codec = self.codec.clone();
         self.mount_subscriber(source, def, codec);
@@ -280,6 +295,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        St: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         let source = def.source();
@@ -295,6 +311,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         D: BatchDef,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
+        St: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         self.mount_batch(source, def, codec);
@@ -311,6 +328,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
+        St: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         let source = def.source();
@@ -327,6 +345,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
+        St: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         self.mount_batch_publishing(source, def, codec, publisher);
@@ -345,9 +364,13 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishLayer + 'static,
+        St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message>
-            + 'static,
+        L::Handler: Handler<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+                (),
+                St,
+            > + 'static,
     {
         let codec = self.codec.clone();
         let source = def.source();
@@ -371,8 +394,9 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static> BrokerScope<B, L, C> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishLayer + 'static,
+        St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
     {
         let codec = self.codec.clone();
         self.mount_publishing(source, def, codec, publisher);

--- a/src/runtime/app/mod.rs
+++ b/src/runtime/app/mod.rs
@@ -15,30 +15,30 @@ use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::runtime::context::State;
 use crate::runtime::failure::ErrorShutdown;
 use crate::runtime::lifecycle::{BoxError, BoxFuture};
 
 /// A registration deferred until [`RustStream::run`]: given the app's error-shutdown handle and the
 /// shutdown token, it opens the subscription (after the broker is connected) and spawns the dispatch
 /// task. The broker, source and handler are captured and type-erased.
-type Starter = Box<
+type Starter<St> = Box<
     dyn FnOnce(
-            Arc<State>,
+            Arc<St>,
             ErrorShutdown,
             CancellationToken,
         ) -> BoxFuture<'static, Result<JoinHandle<()>, BoxError>>
         + Send,
 >;
 
-/// The `on_startup` lifespan hook: runs once before brokers connect. It receives the app [`State`]
-/// by value (so its future can own it across awaits - e.g. connect a database, then insert the
-/// pool) and returns it, populated.
-type StartupHook = Box<dyn FnOnce(State) -> BoxFuture<'static, Result<State, BoxError>> + Send>;
+/// The state initializer: produces the app state `St` once at startup (before brokers connect).
+/// The `on_startup` producer chain; a failing initializer aborts startup. The default is the unit
+/// state `()`.
+type StateInit<St> = Box<dyn FnOnce() -> BoxFuture<'static, Result<St, BoxError>> + Send>;
 
 /// A read-only lifespan hook (`after_startup` / `on_shutdown` / `after_shutdown`): runs once at the
-/// corresponding lifecycle point with a shared [`State`] handle (read via [`State::get`]).
-type LifecycleHook = Box<dyn FnOnce(Arc<State>) -> BoxFuture<'static, Result<(), BoxError>> + Send>;
+/// corresponding lifecycle point with a shared `Arc<St>` handle to the app state.
+type LifecycleHook<St> =
+    Box<dyn FnOnce(Arc<St>) -> BoxFuture<'static, Result<(), BoxError>> + Send>;
 
 /// Which read-only lifecycle hook list a hook is appended to.
 #[derive(Clone, Copy)]

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -14,7 +14,7 @@ use crate::runtime::failure::ErrorShutdown;
 
 use super::{RustStream, RustStreamError};
 
-impl<L> RustStream<L> {
+impl<L, St> RustStream<L, St> {
     /// Runs the service until an interrupt (`SIGINT` / `SIGTERM`) is received, then shuts down
     /// gracefully.
     ///
@@ -44,8 +44,7 @@ impl<L> RustStream<L> {
             brokers,
             starters,
             handlers,
-            mut state,
-            on_startup,
+            state_init,
             after_startup,
             on_shutdown,
             after_shutdown,
@@ -63,12 +62,8 @@ impl<L> RustStream<L> {
             "starting service",
         );
 
-        if !on_startup.is_empty() {
-            debug!(target: "ruststream::lifecycle", count = on_startup.len(), "running on_startup hooks");
-        }
-        for hook in on_startup {
-            state = hook(state).await.map_err(RustStreamError::Startup)?;
-        }
+        debug!(target: "ruststream::lifecycle", "producing application state");
+        let state = state_init().await.map_err(RustStreamError::Startup)?;
         let state = Arc::new(state);
 
         for broker in &brokers {

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -31,9 +31,9 @@ use crate::runtime::typed::{Typed, typed};
 /// stack `L`; registrations are collected and started later, in
 /// [`RustStream::run`](crate::runtime::RustStream::run). Each handler registered here is wrapped
 /// with `L` before it is stored.
-pub struct BrokerScope<B, L = Identity, C = ()> {
+pub struct BrokerScope<B, L = Identity, C = (), St = ()> {
     pub(super) broker: Arc<B>,
-    pub(super) sink: RouterSink<B>,
+    pub(super) sink: RouterSink<B, St>,
     pub(super) publishers: Publishers,
     pub(super) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
     pub(super) retry_publisher: Option<Arc<dyn ErasedPublisher>>,
@@ -41,7 +41,7 @@ pub struct BrokerScope<B, L = Identity, C = ()> {
     pub(super) codec: C,
 }
 
-impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
+impl<B: Broker + 'static, L, C, St> BrokerScope<B, L, C, St> {
     /// Returns the broker, for creating subscribers or publishers with its own API.
     #[must_use]
     pub fn broker(&self) -> &B {
@@ -103,10 +103,11 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
     pub fn handle<S, H, Cx>(&mut self, subscriber: S, handler: H, meta: HandlerMetadata)
     where
         S: Subscriber + Send + 'static,
+        St: Send + Sync + 'static,
         Cx: crate::BuildContext<S::Message> + Send + 'static,
-        H: Handler<S::Message, Cx> + 'static,
+        H: Handler<S::Message, Cx, St> + 'static,
         L: Layer<H>,
-        L::Handler: Handler<S::Message, Cx> + 'static,
+        L::Handler: Handler<S::Message, Cx, St> + 'static,
     {
         let handler = self.global.layer(handler);
         self.sink
@@ -120,10 +121,11 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
+        St: Send + Sync + 'static,
         Cx: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
-        H: Handler<<S::Subscriber as Subscriber>::Message, Cx> + 'static,
+        H: Handler<<S::Subscriber as Subscriber>::Message, Cx, St> + 'static,
         L: Layer<H>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, Cx> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, Cx, St> + 'static,
     {
         let handler = self.global.layer(handler);
         self.sink
@@ -139,14 +141,15 @@ impl<B: Broker + 'static, L, C> BrokerScope<B, L, C> {
     /// bundled layer and any [`Stack`](crate::runtime::Stack) of them satisfies.
     pub fn include_router<R>(&mut self, router: R)
     where
-        R: RouterDef<B>,
+        R: RouterDef<B, St>,
+        St: Send + Sync + 'static,
         L: BlanketLayer,
     {
         router.mount(&self.global, &mut self.sink);
     }
 }
 
-impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
+impl<B: Broker + 'static, L, SC, St> BrokerScope<B, L, SC, St> {
     /// Mounts a definition on `source`, decoding with `codec`. The shared tail of the
     /// `include` / `include_on` forms.
     pub(super) fn mount_subscriber<S, D, C>(&mut self, source: S, def: D, codec: C)
@@ -159,8 +162,9 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
         D::Handler: 'static,
         C: Codec + 'static,
+        St: Send + Sync + 'static,
         L: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         let meta = subscriber_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -183,6 +187,7 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         C: Codec + 'static,
+        St: Send + Sync + 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -209,6 +214,7 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         D::Reply: Serialize + Send + Sync + 'static,
         C: Codec + 'static,
         RP: ReplyPublisher + 'static,
+        St: Send + Sync + 'static,
     {
         let meta = batch_publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -243,8 +249,9 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishLayer + 'static,
+        St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
     {
         let meta = publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -261,7 +268,7 @@ impl<B: Broker + 'static, L, SC> BrokerScope<B, L, SC> {
     }
 }
 
-impl<B, L, C> std::fmt::Debug for BrokerScope<B, L, C> {
+impl<B, L, C, St> std::fmt::Debug for BrokerScope<B, L, C, St> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BrokerScope")
             .field("sink", &self.sink)

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -13,7 +13,6 @@ use crate::{Broker, Publisher, ServerSpec};
 
 use tokio_util::task::TaskTracker;
 
-use crate::runtime::context::State;
 use crate::runtime::dispatch::{Delivery, Publishers};
 use crate::runtime::lifecycle::{BoxError, BrokerLifecycle};
 use crate::runtime::metadata::HandlerMetadata;
@@ -22,7 +21,7 @@ use crate::runtime::publish::PublishMiddleware;
 use crate::runtime::router::RouterSink;
 
 use super::scope::BrokerScope;
-use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StartupHook};
+use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 
 /// The top-level application object.
 ///
@@ -63,19 +62,18 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StartupHook};
 /// app.run().await
 /// # }
 /// ```
-pub struct RustStream<L = Identity> {
+pub struct RustStream<L = Identity, St = ()> {
     pub(super) info: AppInfo,
     pub(super) brokers: Vec<Arc<dyn BrokerLifecycle>>,
-    pub(super) starters: Vec<Starter>,
+    pub(super) starters: Vec<Starter<St>>,
     pub(super) handlers: Vec<HandlerMetadata>,
     pub(super) servers: BTreeMap<String, ServerSpec>,
     pub(super) publishers: Publishers,
     pub(super) publish_layers: Vec<Arc<dyn PublishMiddleware>>,
-    pub(super) state: State,
-    pub(super) on_startup: Vec<StartupHook>,
-    pub(super) after_startup: Vec<LifecycleHook>,
-    pub(super) on_shutdown: Vec<LifecycleHook>,
-    pub(super) after_shutdown: Vec<LifecycleHook>,
+    pub(super) state_init: StateInit<St>,
+    pub(super) after_startup: Vec<LifecycleHook<St>>,
+    pub(super) on_shutdown: Vec<LifecycleHook<St>>,
+    pub(super) after_shutdown: Vec<LifecycleHook<St>>,
     pub(super) shutdown_timeout: Option<Duration>,
     /// Tracks post-settle `and_after` continuations spawned during dispatch, so a graceful
     /// shutdown drains them after the dispatch loops stop. Shared (cloned) into every
@@ -84,7 +82,7 @@ pub struct RustStream<L = Identity> {
     pub(super) global: L,
 }
 
-impl<L> std::fmt::Debug for RustStream<L> {
+impl<L, St> std::fmt::Debug for RustStream<L, St> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RustStream")
             .field("info", &self.info)
@@ -94,8 +92,9 @@ impl<L> std::fmt::Debug for RustStream<L> {
     }
 }
 
-impl RustStream<Identity> {
-    /// Creates an empty service with the given metadata and no global middleware.
+impl RustStream<Identity, ()> {
+    /// Creates an empty service with the given metadata, no global middleware, and the unit
+    /// application state `()`. Produce a typed state with [`on_startup`](Self::on_startup).
     #[must_use]
     pub fn new(info: AppInfo) -> Self {
         Self {
@@ -106,8 +105,7 @@ impl RustStream<Identity> {
             servers: BTreeMap::new(),
             publishers: HashMap::new(),
             publish_layers: Vec::new(),
-            state: State::default(),
-            on_startup: Vec::new(),
+            state_init: Box::new(|| Box::pin(async { Ok(()) })),
             after_startup: Vec::new(),
             on_shutdown: Vec::new(),
             after_shutdown: Vec::new(),
@@ -118,12 +116,12 @@ impl RustStream<Identity> {
     }
 }
 
-impl<L> RustStream<L> {
+impl<L, St> RustStream<L, St> {
     /// Adds a global middleware layer, applied to every handler registered after it.
     ///
     /// The first layer added runs outermost. Call before [`with_broker`](Self::with_broker).
     #[must_use]
-    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, L>> {
+    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, L>, St> {
         RustStream {
             info: self.info,
             brokers: self.brokers,
@@ -132,8 +130,7 @@ impl<L> RustStream<L> {
             servers: self.servers,
             publishers: self.publishers,
             publish_layers: self.publish_layers,
-            state: self.state,
-            on_startup: self.on_startup,
+            state_init: self.state_init,
             after_startup: self.after_startup,
             on_shutdown: self.on_shutdown,
             after_shutdown: self.after_shutdown,
@@ -143,36 +140,48 @@ impl<L> RustStream<L> {
         }
     }
 
-    /// Inserts a shared application state value, readable from handlers and middleware via
-    /// [`Context::state`](crate::runtime::Context::state) then
-    /// [`State::get`](crate::runtime::State::get). For data scoped to a single delivery, use the
-    /// typed per-delivery context ([`Context::set`](crate::runtime::Context::set) /
-    /// [`Context::context`](crate::runtime::Context::context)) instead.
+    /// Produces the typed application state at startup, transitioning the app's state type from the
+    /// previous `St` to `St2`.
     ///
-    /// One value per type; inserting the same type again replaces it.
+    /// The hook runs once before brokers connect; its future can `await` (open a database pool,
+    /// connect a client), and the produced `St2` is shared with every handler (read via
+    /// [`Context::state`](crate::runtime::Context::state)) and the read-only lifecycle hooks. A
+    /// failing hook aborts startup. The initial state is `()` (from [`new`](Self::new)), so the
+    /// first call's hook receives `()`.
+    ///
+    /// Call this BEFORE registering handlers or read-only hooks: it fixes the app's state type, and
+    /// registrations made earlier (which saw a different state type) are not carried across.
     #[must_use]
-    pub fn insert_state<T>(mut self, value: T) -> Self
+    pub fn on_startup<F, Fut, St2, E>(self, hook: F) -> RustStream<L, St2>
     where
-        T: std::any::Any + Send + Sync,
-    {
-        self.state.insert(value);
-        self
-    }
-
-    /// Adds a hook run before brokers connect. It receives the [`State`] by value for lazily
-    /// creating shared resources (a database pool, a client) and returns it populated. A failing
-    /// hook aborts startup.
-    #[must_use]
-    pub fn on_startup<F, Fut, E>(mut self, hook: F) -> Self
-    where
-        F: FnOnce(State) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<State, E>> + Send,
+        F: FnOnce(St) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<St2, E>> + Send,
+        St: Send + 'static,
+        St2: Send + Sync + 'static,
         E: StdError + Send + Sync + 'static,
     {
-        self.on_startup.push(Box::new(move |state| {
-            Box::pin(async move { hook(state).await.map_err(|e| Box::new(e) as BoxError) })
-        }));
-        self
+        let prev = self.state_init;
+        RustStream {
+            info: self.info,
+            brokers: self.brokers,
+            starters: Vec::new(),
+            handlers: self.handlers,
+            servers: self.servers,
+            publishers: self.publishers,
+            publish_layers: self.publish_layers,
+            state_init: Box::new(move || {
+                Box::pin(async move {
+                    let prev_state = prev().await?;
+                    hook(prev_state).await.map_err(|e| Box::new(e) as BoxError)
+                })
+            }),
+            after_startup: Vec::new(),
+            on_shutdown: Vec::new(),
+            after_shutdown: Vec::new(),
+            shutdown_timeout: self.shutdown_timeout,
+            continuations: self.continuations,
+            global: self.global,
+        }
     }
 
     /// Adds a hook run after brokers connect and handlers are spawned (for example, to publish an
@@ -180,7 +189,8 @@ impl<L> RustStream<L> {
     #[must_use]
     pub fn after_startup<F, Fut, E>(self, hook: F) -> Self
     where
-        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
+        St: Send + Sync + 'static,
+        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -191,7 +201,8 @@ impl<L> RustStream<L> {
     #[must_use]
     pub fn on_shutdown<F, Fut, E>(self, hook: F) -> Self
     where
-        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
+        St: Send + Sync + 'static,
+        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -203,7 +214,8 @@ impl<L> RustStream<L> {
     #[must_use]
     pub fn after_shutdown<F, Fut, E>(self, hook: F) -> Self
     where
-        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
+        St: Send + Sync + 'static,
+        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -212,11 +224,12 @@ impl<L> RustStream<L> {
 
     fn push_lifecycle_hook<F, Fut, E>(mut self, phase: LifecyclePhase, hook: F) -> Self
     where
-        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
+        St: Send + Sync + 'static,
+        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
-        let boxed: LifecycleHook = Box::new(move |state| {
+        let boxed: LifecycleHook<St> = Box::new(move |state| {
             Box::pin(async move { hook(state).await.map_err(|e| Box::new(e) as BoxError) })
         });
         match phase {
@@ -299,7 +312,8 @@ impl<L> RustStream<L> {
     where
         B: Broker + 'static,
         L: Clone,
-        F: FnOnce(&mut BrokerScope<B, L>),
+        St: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, L, (), St>),
     {
         let broker = Arc::new(broker);
         let mut scope = self.new_scope(&broker, ());
@@ -320,7 +334,8 @@ impl<L> RustStream<L> {
         B: Broker + 'static,
         C: Codec + Clone + 'static,
         L: Clone,
-        F: FnOnce(&mut BrokerScope<B, L, C>),
+        St: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, L, C, St>),
     {
         let broker = Arc::new(broker);
         let mut scope = self.new_scope(&broker, codec);
@@ -330,10 +345,11 @@ impl<L> RustStream<L> {
     }
 
     /// Builds a fresh scope bound to `broker` carrying `codec` and the app's publishers / pipeline.
-    fn new_scope<B, C>(&self, broker: &Arc<B>, codec: C) -> BrokerScope<B, L, C>
+    fn new_scope<B, C>(&self, broker: &Arc<B>, codec: C) -> BrokerScope<B, L, C, St>
     where
         B: Broker + 'static,
         L: Clone,
+        St: Send + Sync + 'static,
     {
         BrokerScope {
             broker: broker.clone(),
@@ -347,9 +363,10 @@ impl<L> RustStream<L> {
     }
 
     /// Drains a built scope's registrations into the app and holds the broker for lifecycle.
-    fn collect_scope<B, C>(&mut self, broker: &Arc<B>, scope: BrokerScope<B, L, C>)
+    fn collect_scope<B, C>(&mut self, broker: &Arc<B>, scope: BrokerScope<B, L, C, St>)
     where
         B: Broker + 'static,
+        St: Send + Sync + 'static,
     {
         let lifecycle: Arc<dyn BrokerLifecycle> = broker.clone();
         let delivery = Arc::new(Delivery {

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -410,7 +410,6 @@ pub(crate) async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult, su
 mod tests {
     use futures::StreamExt;
 
-    use super::super::context::State;
     use super::super::dispatch::Delivery;
     use super::*;
     use crate::codec::JsonCodec;
@@ -451,7 +450,7 @@ mod tests {
             async move { outcomes }
         });
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("selective", &headers, &state, (), &delivery);
@@ -499,7 +498,7 @@ mod tests {
         });
 
         let tasks = TaskTracker::new();
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::with_tasks(tasks.clone());
         let headers = Headers::new();
         let mut ctx = Context::new("after-batch", &headers, &state, (), &delivery);
@@ -531,7 +530,7 @@ mod tests {
             vec![HandlerResult::Ack]
         });
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("short", &headers, &state, (), &delivery);
@@ -566,7 +565,7 @@ mod tests {
             async move { outcomes }
         });
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("delayed", &headers, &state, (), &delivery);
@@ -593,7 +592,7 @@ mod tests {
             HandlerResult::retry()
         });
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("uniform", &headers, &state, (), &delivery);

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -183,7 +183,6 @@ where
 mod tests {
     use futures::StreamExt;
 
-    use super::super::context::State;
     use super::super::dispatch::Delivery;
     use super::super::publish::TypedPublisher;
     use super::*;
@@ -254,7 +253,7 @@ mod tests {
         };
 
         publish_numbers(&broker, "orders", &[1, 2]).await;
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("orders", &headers, &state, (), &delivery);
@@ -292,7 +291,7 @@ mod tests {
         };
 
         publish_numbers(&broker, "orders", &[1, 2]).await;
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("orders", &headers, &state, (), &delivery);

--- a/src/runtime/cli.rs
+++ b/src/runtime/cli.rs
@@ -98,9 +98,9 @@ enum Command {
 /// # }
 /// ```
 #[must_use]
-pub fn run_main<L, F>(build: F) -> ExitCode
+pub fn run_main<L, St, F>(build: F) -> ExitCode
 where
-    F: FnOnce() -> RustStream<L>,
+    F: FnOnce() -> RustStream<L, St>,
 {
     match execute(build) {
         Ok(()) => ExitCode::SUCCESS,
@@ -111,9 +111,9 @@ where
     }
 }
 
-fn execute<L, F>(build: F) -> Result<(), CliError>
+fn execute<L, St, F>(build: F) -> Result<(), CliError>
 where
-    F: FnOnce() -> RustStream<L>,
+    F: FnOnce() -> RustStream<L, St>,
 {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match parse(&args)? {
@@ -162,7 +162,11 @@ fn parse_asyncapi(args: &[String]) -> Result<Command, CliError> {
 }
 
 #[cfg(feature = "asyncapi")]
-fn generate_spec<L>(app: &RustStream<L>, out: Option<&str>, yaml: bool) -> Result<(), CliError> {
+fn generate_spec<L, St>(
+    app: &RustStream<L, St>,
+    out: Option<&str>,
+    yaml: bool,
+) -> Result<(), CliError> {
     let spec = crate::asyncapi::build_spec(app);
     let text = if yaml {
         spec.to_yaml().map_err(CliError::SerializeYaml)?
@@ -181,7 +185,11 @@ fn generate_spec<L>(app: &RustStream<L>, out: Option<&str>, yaml: bool) -> Resul
 }
 
 #[cfg(not(feature = "asyncapi"))]
-fn generate_spec<L>(_app: &RustStream<L>, _out: Option<&str>, _yaml: bool) -> Result<(), CliError> {
+fn generate_spec<L, St>(
+    _app: &RustStream<L, St>,
+    _out: Option<&str>,
+    _yaml: bool,
+) -> Result<(), CliError> {
     Err(CliError::AsyncApiDisabled)
 }
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,14 +1,14 @@
-//! Per-delivery [`Context`] and the app-level [`State`] type-map.
+//! Per-delivery [`Context`], generic over the broker's typed per-delivery context `C` and the
+//! application's typed shared state `S`.
 //!
 //! A `Context` is built for each delivery and threaded (as `&mut`) through the middleware chain
 //! into the handler. It carries the channel the message arrived on, a working copy of the
-//! headers (middleware may enrich them), shared application state ([`Context::state`]), and the
-//! broker's typed per-delivery context read by key ([`Context::context`] / [`Context::set`]). The
-//! copy is lazy: the message headers are borrowed until the first [`headers_mut`](Context::headers_mut),
-//! so a delivery whose middleware never touches them pays no clone.
+//! headers (middleware may enrich them), the typed shared application state ([`Context::state`]),
+//! and the broker's typed per-delivery context read by key ([`Context::context`] /
+//! [`Context::set`]). The copy is lazy: the message headers are borrowed until the first
+//! [`headers_mut`](Context::headers_mut), so a delivery whose middleware never touches them pays no
+//! clone.
 
-use std::any::{Any, TypeId};
-use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -56,39 +56,6 @@ struct AfterHook {
     fut: Continuation,
 }
 
-/// App-level shared state: a type-map holding one value per type.
-///
-/// Put shared resources (database pools, HTTP clients, configuration) in here with
-/// [`RustStream::insert_state`](super::RustStream::insert_state); handlers and middleware read them
-/// from the [`Context`] with [`Context::state`] then [`State::get`]. For data scoped to a single
-/// delivery (broker fields, or middleware scratch), use the typed per-delivery context instead,
-/// reached with [`Context::context`] / [`Context::set`].
-#[derive(Default)]
-pub struct State {
-    map: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
-}
-
-impl State {
-    /// Inserts `value`, replacing any previous value of the same type.
-    pub fn insert<T: Any + Send + Sync>(&mut self, value: T) {
-        self.map.insert(TypeId::of::<T>(), Box::new(value));
-    }
-
-    /// Returns the stored value of type `T`, if any.
-    #[must_use]
-    pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
-        self.map.get(&TypeId::of::<T>())?.downcast_ref::<T>()
-    }
-}
-
-impl std::fmt::Debug for State {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("State")
-            .field("entries", &self.map.len())
-            .finish_non_exhaustive()
-    }
-}
-
 /// Per-delivery context, threaded through middleware and into the handler.
 ///
 /// Carries the channel ([`name`](Self::name)), a working copy of the message
@@ -98,18 +65,18 @@ impl std::fmt::Debug for State {
 /// [`publisher`](Self::publisher)s for publishing from inside a handler. The headers copy is made
 /// lazily on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit
 /// it: replies and manual publishes start from fresh headers, shaped by the publish pipeline.
-pub struct Context<'a, C = ()> {
+pub struct Context<'a, C = (), S = ()> {
     name: &'a str,
     original: &'a Headers,
     modified: Option<Headers>,
-    state: &'a State,
+    state: &'a S,
     cx: C,
     delivery: &'a Delivery,
     after: Vec<AfterHook>,
     failfast: Option<&'a ErrorShutdown>,
 }
 
-impl<C> std::fmt::Debug for Context<'_, C> {
+impl<C, S> std::fmt::Debug for Context<'_, C, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Context")
             .field("name", &self.name)
@@ -118,14 +85,14 @@ impl<C> std::fmt::Debug for Context<'_, C> {
     }
 }
 
-impl<'a, C> Context<'a, C> {
+impl<'a, C, S> Context<'a, C, S> {
     /// Creates a context for one delivery, borrowing the message headers until first mutation and
     /// carrying the typed per-delivery context `cx` (built by
     /// [`BuildContext`](crate::BuildContext) from the broker message).
     pub(crate) fn new(
         name: &'a str,
         headers: &'a Headers,
-        state: &'a State,
+        state: &'a S,
         cx: C,
         delivery: &'a Delivery,
     ) -> Self {
@@ -192,9 +159,8 @@ impl<'a, C> Context<'a, C> {
         self.modified.get_or_insert_with(|| self.original.clone())
     }
 
-    /// Returns the shared application [`State`], the type-map set once at build with
-    /// [`RustStream::insert_state`](super::RustStream::insert_state). Read a value from it with
-    /// [`State::get`].
+    /// Returns the shared application state: the typed `S` the app's `on_startup` produced (or
+    /// `()` when the app declares none), borrowed for the delivery. Read its fields directly.
     ///
     /// # Examples
     ///
@@ -202,15 +168,20 @@ impl<'a, C> Context<'a, C> {
     /// use ruststream::IncomingMessage;
     /// use ruststream::runtime::{Context, HandlerResult};
     ///
-    /// async fn handle<M: IncomingMessage>(_msg: &M, ctx: &mut Context<'_>) -> HandlerResult {
-    ///     if let Some(prefix) = ctx.state().get::<String>() {
-    ///         let _ = prefix;
-    ///     }
+    /// struct AppState {
+    ///     prefix: String,
+    /// }
+    ///
+    /// async fn handle<M: IncomingMessage>(
+    ///     _msg: &M,
+    ///     ctx: &mut Context<'_, (), AppState>,
+    /// ) -> HandlerResult {
+    ///     let _prefix = &ctx.state().prefix;
     ///     HandlerResult::Ack
     /// }
     /// ```
     #[must_use]
-    pub fn state(&self) -> &State {
+    pub fn state(&self) -> &S {
         self.state
     }
 
@@ -327,7 +298,7 @@ impl<'a, C> Context<'a, C> {
     ///     };
     /// }
     /// ```
-    pub fn after(&mut self, outcome: HandlerResult) -> After<'_, 'a, C> {
+    pub fn after(&mut self, outcome: HandlerResult) -> After<'_, 'a, C, S> {
         After {
             ctx: self,
             gate: Some(OutcomeKind::of(outcome)),
@@ -443,18 +414,18 @@ impl<'a, C> Context<'a, C> {
 /// Call [`then`](Self::then) to register the continuation. Holding it without calling `then`
 /// registers nothing.
 #[must_use = "call `.then(fut)` to register the post-settle hook"]
-pub struct After<'ctx, 'a, C = ()> {
-    ctx: &'ctx mut Context<'a, C>,
+pub struct After<'ctx, 'a, C = (), S = ()> {
+    ctx: &'ctx mut Context<'a, C, S>,
     gate: Option<OutcomeKind>,
 }
 
-impl<C> std::fmt::Debug for After<'_, '_, C> {
+impl<C, S> std::fmt::Debug for After<'_, '_, C, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("After").field("gate", &self.gate).finish()
     }
 }
 
-impl<C> After<'_, '_, C> {
+impl<C, S> After<'_, '_, C, S> {
     /// Registers `fut` to run after the message settles, if the settlement matches the gate this
     /// builder was created with (see [`Context::after`]).
     ///
@@ -488,7 +459,7 @@ mod tests {
 
     use futures::future::join_all;
 
-    use super::{Context, State};
+    use super::Context;
     use crate::Headers;
     use crate::runtime::dispatch::Delivery;
     use crate::runtime::handler::HandlerResult;
@@ -527,7 +498,7 @@ mod tests {
 
     #[test]
     fn take_hooks_runs_only_the_matching_gate() {
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("t", &headers, &state, (), &delivery);
@@ -570,7 +541,7 @@ mod tests {
 
     #[test]
     fn take_settle_hooks_drops_outcome_gated_ones() {
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("t", &headers, &state, (), &delivery);
@@ -609,8 +580,7 @@ mod tests {
             }
         }
 
-        let mut state = State::default();
-        state.insert(String::from("app"));
+        let state = String::from("app");
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let ctx = Context::new("test", &headers, &state, Meta { offset: 42 }, &delivery);
@@ -618,7 +588,7 @@ mod tests {
         // The typed broker field is read by key, straight off the context.
         assert_eq!(ctx.context(Offset), 42);
         // App state is reached only through state(), independent of the per-delivery context.
-        assert_eq!(ctx.state().get::<String>().map(String::as_str), Some("app"));
+        assert_eq!(ctx.state().as_str(), "app");
     }
 
     #[test]
@@ -644,7 +614,7 @@ mod tests {
             }
         }
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("test", &headers, &state, Scratch::default(), &delivery);
@@ -658,7 +628,7 @@ mod tests {
     fn headers_clone_only_on_first_mutation() {
         let mut original = Headers::new();
         original.insert("k", "v");
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let mut ctx = Context::new("test", &original, &state, (), &delivery);
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, warn};
 use crate::{AckError, BatchSubscriber, Headers, IncomingMessage, Subscriber};
 
 use super::batch::BatchHandler;
-use super::context::{Context, State};
+use super::context::Context;
 use super::failure::{DispatchFailure, FailurePolicy, panic_reason};
 use super::handler::{Handler, HandlerResult};
 use super::publish::PublishMiddleware;
@@ -171,19 +171,20 @@ impl std::fmt::Debug for Delivery {
 /// Spawns a task that drives `subscriber` through `handler` until `shutdown` is triggered or the
 /// stream terminates. Each delivery is given a [`Context`] built from `name`, the message headers,
 /// shared `state`, and the `delivery` publish context.
-pub(crate) fn spawn_dispatch<S, H, C>(
+pub(crate) fn spawn_dispatch<S, H, C, St>(
     mut subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
-    state: Arc<State>,
+    state: Arc<St>,
     delivery: Arc<Delivery>,
     failure: DispatchFailure,
 ) -> JoinHandle<()>
 where
     S: Subscriber + Send + 'static,
-    H: Handler<S::Message, C> + 'static,
+    H: Handler<S::Message, C, St> + 'static,
     C: crate::BuildContext<S::Message> + Send + 'static,
+    St: Send + Sync + 'static,
 {
     tokio::spawn(async move {
         let hooks = TaskTracker::new();
@@ -236,12 +237,12 @@ async fn drain_hooks(hooks: TaskTracker) {
 // identity, state, publish context, failure policy, worker policy); bundling them only to satisfy
 // the arg-count lint would hide what each spawn site passes.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_dispatch_workers<S, H, C>(
+pub(crate) fn spawn_dispatch_workers<S, H, C, St>(
     subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
-    state: Arc<State>,
+    state: Arc<St>,
     delivery: Arc<Delivery>,
     failure: DispatchFailure,
     workers: Workers,
@@ -249,8 +250,9 @@ pub(crate) fn spawn_dispatch_workers<S, H, C>(
 where
     S: Subscriber + Send + 'static,
     S::Message: Send + Sync + 'static,
-    H: Handler<S::Message, C> + 'static,
+    H: Handler<S::Message, C, St> + 'static,
     C: crate::BuildContext<S::Message> + Send + 'static,
+    St: Send + Sync + 'static,
 {
     if workers.is_sequential() {
         return spawn_dispatch(
@@ -269,12 +271,12 @@ where
 }
 
 #[allow(clippy::too_many_arguments)] // See spawn_dispatch_workers.
-fn spawn_dispatch_pool<S, H, C>(
+fn spawn_dispatch_pool<S, H, C, St>(
     mut subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
-    state: Arc<State>,
+    state: Arc<St>,
     delivery: Arc<Delivery>,
     failure: DispatchFailure,
     workers: Workers,
@@ -282,8 +284,9 @@ fn spawn_dispatch_pool<S, H, C>(
 where
     S: Subscriber + Send + 'static,
     S::Message: Send + Sync + 'static,
-    H: Handler<S::Message, C> + 'static,
+    H: Handler<S::Message, C, St> + 'static,
     C: crate::BuildContext<S::Message> + Send + 'static,
+    St: Send + Sync + 'static,
 {
     tokio::spawn(async move {
         let hooks = TaskTracker::new();
@@ -335,12 +338,12 @@ where
 }
 
 #[allow(clippy::too_many_arguments)] // See spawn_dispatch_workers.
-fn spawn_dispatch_lanes<S, H, C>(
+fn spawn_dispatch_lanes<S, H, C, St>(
     mut subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
-    state: Arc<State>,
+    state: Arc<St>,
     delivery: Arc<Delivery>,
     failure: DispatchFailure,
     workers: Workers,
@@ -348,8 +351,9 @@ fn spawn_dispatch_lanes<S, H, C>(
 where
     S: Subscriber + Send + 'static,
     S::Message: Send + Sync + 'static,
-    H: Handler<S::Message, C> + 'static,
+    H: Handler<S::Message, C, St> + 'static,
     C: crate::BuildContext<S::Message> + Send + 'static,
+    St: Send + Sync + 'static,
 {
     tokio::spawn(async move {
         // One sequential worker per lane, fed by a capacity-1 channel: a keyed delivery always
@@ -452,12 +456,14 @@ fn log_worker_exit(joined: Result<(), tokio::task::JoinError>) {
 /// each in its own task; keyed lanes do not apply at batch granularity (the macro rejects
 /// `by_key` on batch forms), so a keyed policy degrades to the plain pool.
 #[allow(clippy::too_many_arguments)] // See spawn_dispatch_workers.
-pub(crate) fn spawn_batch_dispatch<S, H>(
+pub(crate) fn spawn_batch_dispatch<S, H, St>(
     mut subscriber: S,
     handler: Arc<H>,
     shutdown: CancellationToken,
     name: Arc<str>,
-    state: Arc<State>,
+    // Batch handlers do not read the typed app state (a separate follow-up); the state is still
+    // received for starter-signature uniformity.
+    _state: Arc<St>,
     delivery: Arc<Delivery>,
     failure: DispatchFailure,
     workers: Workers,
@@ -466,6 +472,7 @@ where
     S: BatchSubscriber + Send + 'static,
     S::Message: Send + 'static,
     H: BatchHandler<S::Message> + 'static,
+    St: Send + Sync + 'static,
 {
     tokio::spawn(async move {
         let hooks = TaskTracker::new();
@@ -482,20 +489,15 @@ where
                     Some(Ok(batch)) => {
                         let batch: Vec<S::Message> = batch.into_iter().collect();
                         if workers.is_sequential() {
-                            run_batch(&*handler, batch, &name, &state, &delivery, &hooks, &failure)
-                                .await;
+                            run_batch(&*handler, batch, &name, &delivery, &hooks, &failure).await;
                         } else {
                             let handler = Arc::clone(&handler);
                             let name = Arc::clone(&name);
-                            let state = Arc::clone(&state);
                             let delivery = Arc::clone(&delivery);
                             let hooks = hooks.clone();
                             let failure = failure.clone();
                             tasks.spawn(async move {
-                                run_batch(
-                                    &*handler, batch, &name, &state, &delivery, &hooks, &failure,
-                                )
-                                .await;
+                                run_batch(&*handler, batch, &name, &delivery, &hooks, &failure).await;
                             });
                         }
                     }
@@ -525,16 +527,16 @@ where
 }
 
 #[allow(clippy::too_many_arguments)] // See spawn_dispatch_workers.
-async fn dispatch<H, M, C>(
+async fn dispatch<H, M, C, St>(
     handler: &H,
     msg: M,
     name: &str,
-    state: &State,
+    state: &St,
     delivery: &Delivery,
     hooks: &TaskTracker,
     failure: &DispatchFailure,
 ) where
-    H: Handler<M, C>,
+    H: Handler<M, C, St>,
     C: crate::BuildContext<M>,
     M: IncomingMessage,
 {
@@ -611,7 +613,6 @@ async fn run_batch<H, M>(
     handler: &H,
     batch: Vec<M>,
     name: &str,
-    state: &State,
     delivery: &Delivery,
     hooks: &TaskTracker,
     failure: &DispatchFailure,
@@ -620,8 +621,9 @@ async fn run_batch<H, M>(
     M: IncomingMessage,
 {
     let empty = Headers::new();
-    // A batch has no single broker message, so its context is the unit (no per-delivery fields).
-    let mut ctx = Context::new(name, &empty, state, (), delivery).with_failfast(&failure.shutdown);
+    // A batch has no single broker message, and batch handlers do not read the typed app state
+    // (state access in a batch handler is a separate follow-up), so its context is fully unit.
+    let mut ctx = Context::new(name, &empty, &(), (), delivery).with_failfast(&failure.shutdown);
     let result = AssertUnwindSafe(handler.handle_batch(batch, &mut ctx))
         .catch_unwind()
         .await;

--- a/src/runtime/dynstack.rs
+++ b/src/runtime/dynstack.rs
@@ -160,7 +160,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::super::HandlerExt;
-    use super::super::context::{Context, State};
+    use super::super::context::Context;
     use super::super::handler::{Handler, HandlerResult};
     use super::{BoxFut, DynMiddleware, DynStack, Next};
     use crate::Headers;
@@ -199,7 +199,7 @@ mod tests {
             }
         };
         let handler = inner.with(stack);
-        let state = State::default();
+        let state = ();
         let delivery = crate::runtime::dispatch::Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("test", &headers, &state, (), &delivery);

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -260,20 +260,20 @@ impl<E> IntoSettle for Result<Settle, E> {
 ///     assert_handler::<M, _>(|_msg: &M, _ctx: &mut Context| async { HandlerResult::Ack });
 /// }
 /// ```
-pub trait Handler<M, C = ()>: Send + Sync {
+pub trait Handler<M, C = (), S = ()>: Send + Sync {
     /// Handle one input, with the per-delivery [`Context`] (carrying the broker's typed context
-    /// `C`). The returned [`Settle`] carries the outcome the dispatcher settles by and any
-    /// post-settle continuation.
-    fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> impl Future<Output = Settle> + Send;
+    /// `C` and the shared application state `S`). The returned [`Settle`] carries the outcome the
+    /// dispatcher settles by and any post-settle continuation.
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send;
 }
 
-impl<M, C, F, Fut> Handler<M, C> for F
+impl<M, C, S, F, Fut> Handler<M, C, S> for F
 where
-    F: Fn(&M, &mut Context<'_, C>) -> Fut + Send + Sync,
+    F: Fn(&M, &mut Context<'_, C, S>) -> Fut + Send + Sync,
     Fut: Future + Send,
     Fut::Output: IntoSettle,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> impl Future<Output = Settle> + Send {
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send {
         // Build the inner future before the async block so it owns the closure's output and the
         // returned future is `Settle`-valued for any `Into<Settle>` return shape.
         let fut = (self)(msg, ctx);
@@ -281,11 +281,11 @@ where
     }
 }
 
-impl<M, C, H> Handler<M, C> for Arc<H>
+impl<M, C, S, H> Handler<M, C, S> for Arc<H>
 where
-    H: Handler<M, C>,
+    H: Handler<M, C, S>,
 {
-    fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> impl Future<Output = Settle> + Send {
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send {
         (**self).handle(msg, ctx)
     }
 }

--- a/src/runtime/middleware.rs
+++ b/src/runtime/middleware.rs
@@ -42,16 +42,18 @@ pub trait Layer<H> {
 /// [`TracingLayer`](layers::TracingLayer). Implement it for a custom layer to let the app's global
 /// stack reach router handlers; a layer that only wraps specific handler types cannot be blanket.
 pub trait BlanketLayer: Send + Sync {
-    /// Wraps `handler`, returning the layered handler.
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    /// Wraps `handler`, returning the layered handler. `S` is the app's shared-state type, threaded
+    /// so a blanket layer wraps a router handler without fixing its state type.
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static;
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static;
 }
 
 /// Convenience extension trait for fluent layer stacking on any [`Handler`].
-pub trait HandlerExt<M, C = ()>: Handler<M, C> + Sized {
+pub trait HandlerExt<M, C = (), S = ()>: Handler<M, C, S> + Sized {
     /// Wrap this handler with the given layer.
     fn with<L>(self, layer: L) -> L::Handler
     where
@@ -61,7 +63,7 @@ pub trait HandlerExt<M, C = ()>: Handler<M, C> + Sized {
     }
 }
 
-impl<M, C, H> HandlerExt<M, C> for H where H: Handler<M, C> {}
+impl<M, C, S, H> HandlerExt<M, C, S> for H where H: Handler<M, C, S> {}
 
 /// The identity [`Layer`]: returns the handler unchanged. The default global stack on
 /// [`RustStream`](super::RustStream).
@@ -77,11 +79,12 @@ impl<H> Layer<H> for Identity {
 }
 
 impl BlanketLayer for Identity {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         handler
     }
@@ -121,15 +124,16 @@ where
     Inner: BlanketLayer,
     Outer: BlanketLayer,
 {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         // Same order as the static `Layer` impl: inner wraps first (innermost), outer outside.
         self.outer
-            .apply::<M, C, _>(self.inner.apply::<M, C, _>(handler))
+            .apply::<M, C, S, _>(self.inner.apply::<M, C, S, _>(handler))
     }
 }
 
@@ -169,11 +173,12 @@ pub mod layers {
     }
 
     impl BlanketLayer for TracingLayer {
-        fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+        fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
         where
             M: Send + Sync + 'static,
             C: Send + 'static,
-            H: Handler<M, C> + 'static,
+            S: Send + Sync + 'static,
+            H: Handler<M, C, S> + 'static,
         {
             self.layer(handler)
         }
@@ -186,14 +191,19 @@ pub mod layers {
         target: Option<&'static str>,
     }
 
-    impl<M, C, H> Handler<M, C> for TracingHandler<H>
+    impl<M, C, S, H> Handler<M, C, S> for TracingHandler<H>
     where
         M: Sync,
         C: Send,
-        H: Handler<M, C>,
+        S: Send + Sync,
+        H: Handler<M, C, S>,
     {
         #[instrument(level = "trace", skip(self, msg, ctx), fields(target = self.target))]
-        fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> impl Future<Output = Settle> + Send {
+        fn handle(
+            &self,
+            msg: &M,
+            ctx: &mut Context<'_, C, S>,
+        ) -> impl Future<Output = Settle> + Send {
             async move {
                 debug!(target: "ruststream::dispatch", "delivery received");
                 // Log the outcome inside the settlement; the continuation (if any) flows through.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -22,7 +22,7 @@ mod typed;
 pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
 pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};
-pub use context::{After, Context, State};
+pub use context::{After, Context};
 pub use dispatch::{RETRY_COUNT_HEADER, Workers};
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
 pub use failure::{FailurePolicies, FailurePolicy};
@@ -35,6 +35,6 @@ pub use publish::{
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingDef, PublishingHandler};
-pub use router::{Router, RouterDef, RouterSink};
+pub use router::{Router, RouterDef, RouterHandlers, RouterSink};
 pub use subscriber_def::SubscriberDef;
 pub use typed::{Typed, typed};

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -32,6 +32,11 @@ pub trait PublishingDef: Send + Sync {
     /// The reply type the handler produces, encoded and published.
     type Reply;
 
+    /// The app's typed shared state the handler reads through
+    /// [`Context::state`](super::Context::state) (`()` when it names none). A publishing subscriber
+    /// mounts only on an app whose state type matches.
+    type State: Send + Sync;
+
     /// The subscription source this handler binds to (see
     /// [`SubscriberDef::Source`](super::SubscriberDef::Source)).
     type Source;
@@ -86,7 +91,7 @@ pub trait PublishingDef: Send + Sync {
     fn call(
         &self,
         input: &Self::Input,
-        ctx: &mut Context<'_>,
+        ctx: &mut Context<'_, (), Self::State>,
     ) -> impl Future<Output = Result<Self::Reply, HandlerResult>> + Send;
 }
 
@@ -125,7 +130,7 @@ impl<D, C, P, PC, PL> std::fmt::Debug for PublishingHandler<D, C, P, PC, PL> {
     }
 }
 
-impl<M, D, C, P, PC, PL> Handler<M> for PublishingHandler<D, C, P, PC, PL>
+impl<M, D, C, P, PC, PL> Handler<M, (), D::State> for PublishingHandler<D, C, P, PC, PL>
 where
     M: IncomingMessage,
     D: PublishingDef,
@@ -136,7 +141,7 @@ where
     PC: Codec,
     PL: PublishLayer,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_>) -> Settle {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, (), D::State>) -> Settle {
         // The publishing path settles by a bare outcome (no per-element continuation): decode,
         // run, publish the reply, then ack. It converts to `Settle` with no `and_after`.
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
@@ -187,7 +192,7 @@ mod tests {
     use super::{PublishingDef, publishing_metadata};
     use crate::Headers;
     use crate::Name;
-    use crate::runtime::context::{Context, State};
+    use crate::runtime::context::Context;
     use crate::runtime::dispatch::{Delivery, Workers};
     use crate::runtime::handler::HandlerResult;
 
@@ -198,6 +203,7 @@ mod tests {
     impl PublishingDef for ManualPub {
         type Input = u32;
         type Reply = u32;
+        type State = ();
         type Source = Name;
 
         fn source(&self) -> Name {
@@ -230,7 +236,7 @@ mod tests {
         let meta = publishing_metadata("in".to_owned(), &def);
         assert_eq!(meta.name, "in");
 
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("in", &headers, &state, (), &delivery);

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -23,7 +23,9 @@ use crate::runtime::publishing::{PublishingDef, PublishingHandler, publishing_me
 use crate::runtime::subscriber_def::{SubscriberDef, subscriber_metadata};
 use crate::runtime::typed::typed;
 
-use super::routes::{BatchRoute, HandleRoute, MountRoute, RouterDef, SubscribeRoute};
+use super::routes::{
+    BatchRoute, HandleRoute, MountRoute, RouteMeta, RouterDef, RouterHandlers, SubscribeRoute,
+};
 use super::sink::RouterSink;
 use super::{
     BatchPublishingRouter, IncludedBatchRouter, IncludedRouter, MergedRouter, PublishingRouter,
@@ -141,7 +143,6 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         other: Router<B, R2, C2, L2>,
     ) -> MergedRouter<B, R2, C2, L2, RC, RL, R>
     where
-        R2: RouterDef<B>,
         L2: BlanketLayer,
     {
         Router {
@@ -465,7 +466,7 @@ impl<B, S, H, R, RC, RL> Router<B, (BatchRoute<S, H>, R), RC, RL> {
     }
 }
 
-impl<B: Broker + 'static, R: RouterDef<B>, C, L> Router<B, R, C, L> {
+impl<B: Broker + 'static, R: RouterHandlers, C, L> Router<B, R, C, L> {
     /// Returns metadata for every registered handler, in registration order.
     #[must_use]
     pub fn handlers(&self) -> Vec<HandlerMetadata> {
@@ -483,47 +484,59 @@ struct ComposedBlanket<'a, Outer, Inner> {
 }
 
 impl<Outer: BlanketLayer, Inner: BlanketLayer> BlanketLayer for ComposedBlanket<'_, Outer, Inner> {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         self.outer
-            .apply::<M, C, _>(self.inner.apply::<M, C, _>(handler))
+            .apply::<M, C, S, _>(self.inner.apply::<M, C, S, _>(handler))
     }
 }
 
-impl<B, R, C, L> RouterDef<B> for Router<B, R, C, L>
+impl<B, R, C, L, St> RouterDef<B, St> for Router<B, R, C, L>
 where
     B: Broker + 'static,
-    R: RouterDef<B>,
+    R: RouterDef<B, St>,
     L: BlanketLayer,
 {
-    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>) {
         let composed = ComposedBlanket {
             outer: global,
             inner: &self.layers,
         };
         self.routes.mount(&composed, sink);
     }
+}
 
+impl<B, R, C, L> RouterHandlers for Router<B, R, C, L>
+where
+    R: RouterHandlers,
+{
     fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>) {
         self.routes.collect_handlers(out);
     }
 }
 
 // Lets a whole router be a single registration inside another router's list (`Router::merge`).
-impl<B, R, C, L> MountRoute<B> for Router<B, R, C, L>
+impl<B, R, C, L, St> MountRoute<B, St> for Router<B, R, C, L>
 where
     B: Broker + 'static,
-    R: RouterDef<B>,
+    R: RouterDef<B, St>,
     L: BlanketLayer,
 {
-    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>) {
         RouterDef::mount(self, global, sink);
     }
+}
 
+// Lets a merged router contribute its registrations' metadata to the outer router's `handlers()`.
+impl<B, R, C, L> RouteMeta for Router<B, R, C, L>
+where
+    R: RouterHandlers,
+{
     fn collect(&self, out: &mut Vec<HandlerMetadata>) {
         self.routes.collect_handlers(out);
     }

--- a/src/runtime/router/mod.rs
+++ b/src/runtime/router/mod.rs
@@ -19,7 +19,7 @@ mod routes;
 mod sink;
 
 pub use builder::Router;
-pub use routes::RouterDef;
+pub use routes::{RouterDef, RouterHandlers};
 pub use sink::RouterSink;
 
 use crate::{Subscriber, SubscriptionSource};

--- a/src/runtime/router/routes.rs
+++ b/src/runtime/router/routes.rs
@@ -48,38 +48,61 @@ pub struct BatchRoute<S, H> {
 }
 
 /// One mountable registration: applies the global blanket layer to its handler and registers it.
-pub(super) trait MountRoute<B> {
-    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>);
+/// `St` is the app's shared-state type, threaded so a route only mounts on a sink whose state type
+/// its handler matches (a state-agnostic handler matches any).
+pub(super) trait MountRoute<B, St> {
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>);
+}
+
+/// One registration's `AsyncAPI` metadata, collected independently of the app state type (so
+/// [`Router::handlers`](crate::runtime::Router::handlers) works whatever state the handlers read).
+pub(super) trait RouteMeta {
     fn collect(&self, out: &mut Vec<HandlerMetadata>);
 }
 
-impl<B, S, H> MountRoute<B> for SubscribeRoute<S, H>
-where
-    B: Broker + 'static,
-    S: SubscriptionSource<B> + Send + 'static,
-    S::Subscriber: Send + 'static,
-    SourceMessage<B, S>: Send + Sync + 'static,
-    H: Handler<SourceMessage<B, S>> + 'static,
-{
-    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
-        let handler = global.apply::<SourceMessage<B, S>, (), H>(self.handler);
-        sink.push_subscribe_workers(self.source, handler, self.meta, self.policies, self.workers);
-    }
-
+impl<S, H> RouteMeta for SubscribeRoute<S, H> {
     fn collect(&self, out: &mut Vec<HandlerMetadata>) {
         out.push(self.meta.clone());
     }
 }
 
-impl<B, S, H> MountRoute<B> for BatchRoute<S, H>
+impl<S, H> RouteMeta for BatchRoute<S, H> {
+    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
+        out.push(self.meta.clone());
+    }
+}
+
+impl<S, H> RouteMeta for HandleRoute<S, H> {
+    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
+        out.push(self.meta.clone());
+    }
+}
+
+impl<B, S, H, St> MountRoute<B, St> for SubscribeRoute<S, H>
+where
+    B: Broker + 'static,
+    S: SubscriptionSource<B> + Send + 'static,
+    S::Subscriber: Send + 'static,
+    SourceMessage<B, S>: Send + Sync + 'static,
+    St: Send + Sync + 'static,
+    H: Handler<SourceMessage<B, S>, (), St> + 'static,
+{
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>) {
+        let handler = global.apply::<SourceMessage<B, S>, (), St, H>(self.handler);
+        sink.push_subscribe_workers(self.source, handler, self.meta, self.policies, self.workers);
+    }
+}
+
+impl<B, S, H, St> MountRoute<B, St> for BatchRoute<S, H>
 where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: BatchSubscriber + Send + 'static,
     SourceMessage<B, S>: Send + 'static,
+    St: Send + Sync + 'static,
     H: BatchHandler<SourceMessage<B, S>> + 'static,
 {
-    fn mount_one<G: BlanketLayer>(self, _global: &G, sink: &mut RouterSink<B>) {
+    fn mount_one<G: BlanketLayer>(self, _global: &G, sink: &mut RouterSink<B, St>) {
         // Per-message layers cannot wrap a whole-batch handler, so neither the app-global stack
         // nor the router's own layers apply to batch registrations.
         sink.push_subscribe_batch(
@@ -90,26 +113,19 @@ where
             self.workers,
         );
     }
-
-    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
-        out.push(self.meta.clone());
-    }
 }
 
-impl<B, S, H> MountRoute<B> for HandleRoute<S, H>
+impl<B, S, H, St> MountRoute<B, St> for HandleRoute<S, H>
 where
     B: Broker + 'static,
     S: Subscriber + Send + 'static,
     S::Message: Send + Sync + 'static,
-    H: Handler<S::Message> + 'static,
+    St: Send + Sync + 'static,
+    H: Handler<S::Message, (), St> + 'static,
 {
-    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
-        let handler = global.apply::<S::Message, (), H>(self.handler);
+    fn mount_one<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>) {
+        let handler = global.apply::<S::Message, (), St, H>(self.handler);
         sink.push_handle(self.subscriber, handler, self.meta, self.policies);
-    }
-
-    fn collect(&self, out: &mut Vec<HandlerMetadata>) {
-        out.push(self.meta.clone());
     }
 }
 
@@ -120,34 +136,52 @@ where
 /// Implemented by [`Router`](crate::runtime::Router) and its internal registration list; you
 /// obtain one from a builder and pass it to
 /// [`include_router`](crate::runtime::BrokerScope::include_router). You do not implement it.
-pub trait RouterDef<B> {
+///
+/// `St` is the app's shared-state type: a router whose handlers read typed state is
+/// `RouterDef<B, St>` only for that `St`, while a state-agnostic router is generic over it, so it
+/// mounts on any app.
+pub trait RouterDef<B, St = ()> {
     /// Applies `global` to every registration and pushes it into `sink`. Called by `include_router`.
     #[doc(hidden)]
-    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>);
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>);
+}
 
+/// Metadata collection over a router's registration list, independent of the app state type. Split
+/// from [`RouterDef`] so [`Router::handlers`](crate::runtime::Router::handlers) does not have to
+/// name the state type a stateful router's handlers read.
+pub trait RouterHandlers {
     /// Appends each registration's metadata, in registration order.
     #[doc(hidden)]
     fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>);
 }
 
-impl<B: Broker + 'static> RouterDef<B> for () {
-    fn mount<G: BlanketLayer>(self, _global: &G, _sink: &mut RouterSink<B>) {}
+impl<B: Broker + 'static, St> RouterDef<B, St> for () {
+    fn mount<G: BlanketLayer>(self, _global: &G, _sink: &mut RouterSink<B, St>) {}
+}
+
+impl RouterHandlers for () {
     fn collect_handlers(&self, _out: &mut Vec<HandlerMetadata>) {}
 }
 
-impl<B, Head, Tail> RouterDef<B> for (Head, Tail)
+impl<B, Head, Tail, St> RouterDef<B, St> for (Head, Tail)
 where
     B: Broker + 'static,
-    Head: MountRoute<B>,
-    Tail: RouterDef<B>,
+    Head: MountRoute<B, St>,
+    Tail: RouterDef<B, St>,
 {
-    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B>) {
+    fn mount<G: BlanketLayer>(self, global: &G, sink: &mut RouterSink<B, St>) {
         // Registrations are prepended, so the tail holds the earlier ones; mount it first to keep
         // registration order.
         self.1.mount(global, sink);
         self.0.mount_one(global, sink);
     }
+}
 
+impl<Head, Tail> RouterHandlers for (Head, Tail)
+where
+    Head: RouteMeta,
+    Tail: RouterHandlers,
+{
     fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>) {
         self.1.collect_handlers(out);
         self.0.collect(out);

--- a/src/runtime/router/sink.rs
+++ b/src/runtime/router/sink.rs
@@ -8,7 +8,6 @@ use tokio_util::sync::CancellationToken;
 use crate::{BatchSubscriber, Broker, Subscriber, SubscriptionSource};
 
 use crate::runtime::batch::BatchHandler;
-use crate::runtime::context::State;
 use crate::runtime::dispatch::{
     Delivery, Workers, spawn_batch_dispatch, spawn_dispatch, spawn_dispatch_workers,
 };
@@ -22,10 +21,10 @@ use super::SourceMessage;
 /// A deferred registration: given the broker (after connect), shared state, the per-scope publish
 /// [`Delivery`] context, and the shutdown token, it opens the subscription and spawns the dispatch
 /// task. The source and handler are captured and type-erased.
-pub(crate) type BoundStarter<B> = Box<
+pub(crate) type BoundStarter<B, St> = Box<
     dyn FnOnce(
             Arc<B>,
-            Arc<State>,
+            Arc<St>,
             Arc<Delivery>,
             ErrorShutdown,
             CancellationToken,
@@ -33,17 +32,19 @@ pub(crate) type BoundStarter<B> = Box<
         + Send,
 >;
 
-/// The runtime collector a router mounts into: type-erased starters plus handler metadata.
+/// The runtime collector a router mounts into: type-erased starters plus handler metadata. `St` is
+/// the app's shared state type, threaded so a handler is only mounted on a sink whose state type it
+/// matches.
 ///
 /// Created and drained inside the application; a [`RouterDef`](crate::runtime::RouterDef) pushes
 /// into it during [`include_router`](crate::runtime::BrokerScope::include_router). You do not
 /// construct one directly.
-pub struct RouterSink<B> {
-    starters: Vec<BoundStarter<B>>,
+pub struct RouterSink<B, St = ()> {
+    starters: Vec<BoundStarter<B, St>>,
     handlers: Vec<HandlerMetadata>,
 }
 
-impl<B> std::fmt::Debug for RouterSink<B> {
+impl<B, St> std::fmt::Debug for RouterSink<B, St> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RouterSink")
             .field("handlers", &self.handlers.len())
@@ -51,7 +52,7 @@ impl<B> std::fmt::Debug for RouterSink<B> {
     }
 }
 
-impl<B: Broker + 'static> RouterSink<B> {
+impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
     pub(crate) fn new() -> Self {
         Self {
             starters: Vec::new(),
@@ -69,7 +70,7 @@ impl<B: Broker + 'static> RouterSink<B> {
     ) where
         S: Subscriber + Send + 'static,
         Cx: crate::BuildContext<S::Message> + Send + 'static,
-        H: Handler<S::Message, Cx> + 'static,
+        H: Handler<S::Message, Cx, St> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -134,7 +135,7 @@ impl<B: Broker + 'static> RouterSink<B> {
         S::Subscriber: Send + 'static,
         SourceMessage<B, S>: Send + Sync + 'static,
         Cx: crate::BuildContext<SourceMessage<B, S>> + Send + 'static,
-        H: Handler<SourceMessage<B, S>, Cx> + 'static,
+        H: Handler<SourceMessage<B, S>, Cx, St> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -166,7 +167,7 @@ impl<B: Broker + 'static> RouterSink<B> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         Cx: crate::BuildContext<SourceMessage<B, S>> + Send + 'static,
-        H: Handler<SourceMessage<B, S>, Cx> + 'static,
+        H: Handler<SourceMessage<B, S>, Cx, St> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -187,7 +188,7 @@ impl<B: Broker + 'static> RouterSink<B> {
         self.handlers.push(meta);
     }
 
-    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B>>, Vec<HandlerMetadata>) {
+    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B, St>>, Vec<HandlerMetadata>) {
         (self.starters, self.handlers)
     }
 }

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -3,6 +3,8 @@
 
 use super::dispatch::Workers;
 use super::failure::FailurePolicies;
+// Kept in scope for the `[`Handler`]` intra-doc links; the trait no longer bounds `type Handler`.
+#[allow(unused_imports)]
 use super::handler::Handler;
 use super::metadata::HandlerMetadata;
 
@@ -22,7 +24,12 @@ pub trait SubscriberDef: Sized {
     type Context;
 
     /// The concrete handler type over [`Input`](Self::Input) and [`Context`](Self::Context).
-    type Handler: Handler<Self::Input, Self::Context>;
+    ///
+    /// The handler bound is enforced where the def is mounted (against the app's state type `St`),
+    /// not on the trait: a handler that reads typed application state is
+    /// [`Handler<Input, Context, St>`](Handler) only for its declared `St`, while one that ignores
+    /// state is generic over it. Pinning a single state type here would reject both shapes.
+    type Handler;
 
     /// The subscription source this handler binds to. The bound to
     /// [`SubscriptionSource`](crate::SubscriptionSource) for the target broker is applied where the
@@ -95,7 +102,7 @@ mod tests {
     use super::{SubscriberDef, subscriber_metadata};
     use crate::Headers;
     use crate::Name;
-    use crate::runtime::context::{Context, State};
+    use crate::runtime::context::Context;
     use crate::runtime::dispatch::{Delivery, Workers};
     use crate::runtime::handler::{Handler, HandlerResult, Settle};
 
@@ -142,7 +149,7 @@ mod tests {
 
         // Drive the consumed handler so source(), into_handler() and the Noop body are exercised.
         let handler = def.into_handler();
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("manual", &headers, &state, (), &delivery);

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -63,15 +63,16 @@ impl<M, T, C, H> fmt::Debug for Typed<M, T, C, H> {
     }
 }
 
-impl<M, T, C, H, Cx> Handler<M, Cx> for Typed<M, T, C, H>
+impl<M, T, C, H, Cx, St> Handler<M, Cx, St> for Typed<M, T, C, H>
 where
     M: IncomingMessage,
     T: DeserializeOwned + Send + Sync,
     C: Codec,
     Cx: Send,
-    H: Handler<T, Cx>,
+    St: Send + Sync,
+    H: Handler<T, Cx, St>,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, Cx>) -> Settle {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, Cx, St>) -> Settle {
         match self.codec.decode::<T>(msg.payload()) {
             Ok(value) => self.inner.handle(&value, ctx).await,
             Err(err) => {
@@ -104,7 +105,7 @@ mod tests {
 
     use super::typed;
     use crate::codec::JsonCodec;
-    use crate::runtime::context::{Context, State};
+    use crate::runtime::context::Context;
     use crate::runtime::dispatch::Delivery;
     use crate::runtime::failure::FailurePolicy;
     use crate::runtime::handler::{Handler, HandlerResult};
@@ -147,7 +148,7 @@ mod tests {
     async fn decoded_value_reaches_inner() {
         let seen = Arc::new(AtomicU32::new(0));
         let handler = typed(JsonCodec, counting_inner(&seen));
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("typed", &headers, &state, (), &delivery);
@@ -164,7 +165,7 @@ mod tests {
     async fn decode_failure_drops_by_default() {
         let seen = Arc::new(AtomicU32::new(0));
         let handler = typed(JsonCodec, counting_inner(&seen));
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("typed", &headers, &state, (), &delivery);
@@ -182,7 +183,7 @@ mod tests {
         let seen = Arc::new(AtomicU32::new(0));
         let handler =
             typed(JsonCodec, counting_inner(&seen)).on_decode_failure(FailurePolicy::Retry);
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("typed", &headers, &state, (), &delivery);
@@ -199,7 +200,7 @@ mod tests {
     async fn typed_handler_is_debug_and_stub_acks() {
         let seen = Arc::new(AtomicU32::new(0));
         let handler = typed(JsonCodec, counting_inner(&seen));
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("typed", &headers, &state, (), &delivery);
@@ -263,7 +264,7 @@ mod tests {
 
         let seen = Arc::new(AtomicU32::new(0));
         let handler = typed(JsonCodec, counting_inner(&seen));
-        let state = State::default();
+        let state = ();
         let delivery = Delivery::empty();
         let headers = Headers::new();
         let mut ctx = Context::new("orders.inbound", &headers, &state, (), &delivery);

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -12,7 +12,7 @@ use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, BlanketLayer, Context, Handler, HandlerMetadata, HandlerResult, Layer, Outgoing,
-    PublishMiddleware, PublishNext, Router, RustStream, Settle, State,
+    PublishMiddleware, PublishNext, Router, RustStream, Settle,
 };
 use ruststream::{Name, OutgoingMessage, Publisher};
 use serde::{Deserialize, Serialize};
@@ -50,13 +50,14 @@ impl<H> Layer<H> for CountLayer {
     }
 }
 
-impl<M, C, H> Handler<M, C> for CountHandler<H>
+impl<M, C, S, H> Handler<M, C, S> for CountHandler<H>
 where
     M: Sync,
     C: Send,
-    H: Handler<M, C>,
+    S: Send + Sync,
+    H: Handler<M, C, S>,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C>) -> Settle {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> Settle {
         self.count.fetch_add(1, Ordering::SeqCst);
         self.inner.handle(msg, ctx).await
     }
@@ -64,11 +65,12 @@ where
 
 // Lets CountLayer be an app-global layer that reaches router handlers via include_router.
 impl BlanketLayer for CountLayer {
-    fn apply<M, C, H>(&self, handler: H) -> impl Handler<M, C> + 'static
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
     where
         M: Send + Sync + 'static,
         C: Send + 'static,
-        H: Handler<M, C> + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
     {
         CountHandler {
             inner: handler,
@@ -464,16 +466,18 @@ async fn handler_reads_context_topic_and_state() {
     let seen_clone = Arc::clone(&seen);
 
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
-        .insert_state(Config {
-            greeting: "hello".to_owned(),
+        .on_startup(|()| async {
+            Ok::<_, std::convert::Infallible>(Config {
+                greeting: "hello".to_owned(),
+            })
         })
         .with_broker(broker, |b| {
             let subscriber = b.broker().subscribe("orders");
             b.handle(
                 subscriber,
-                move |_msg: &_, ctx: &mut Context| {
+                move |_msg: &_, ctx: &mut Context<'_, (), Config>| {
                     let name = ctx.name().to_owned();
-                    let greeting = ctx.state().get::<Config>().map(|c| c.greeting.clone());
+                    let greeting = Some(ctx.state().greeting.clone());
                     // Middleware/handlers may enrich the working headers.
                     ctx.headers_mut().insert("x-seen", b"1".to_vec());
                     let seen = Arc::clone(&seen_clone);
@@ -522,35 +526,34 @@ async fn lifespan_hooks_run_in_order() {
 
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
         .shutdown_timeout(Duration::from_secs(5))
-        .on_startup(move |mut state: State| {
+        .on_startup(move |()| {
             let o1 = Arc::clone(&o1);
             async move {
-                state.insert(Config {
-                    greeting: "lazy".to_owned(),
-                });
                 o1.lock().expect("poisoned").push("startup");
-                Ok::<State, std::convert::Infallible>(state)
+                Ok::<Config, std::convert::Infallible>(Config {
+                    greeting: "lazy".to_owned(),
+                })
             }
         })
-        .after_startup(move |_state| {
+        .after_startup(move |_state: Arc<Config>| {
             let o2 = Arc::clone(&o2);
             async move {
                 o2.lock().expect("poisoned").push("after_startup");
                 Ok::<(), std::convert::Infallible>(())
             }
         })
-        .on_shutdown(move |_state| {
+        .on_shutdown(move |_state: Arc<Config>| {
             let o3 = Arc::clone(&o3);
             async move {
                 o3.lock().expect("poisoned").push("on_shutdown");
                 Ok::<(), std::convert::Infallible>(())
             }
         })
-        .after_shutdown(move |state| {
+        .after_shutdown(move |state: Arc<Config>| {
             let o4 = Arc::clone(&o4);
-            let greeting = state.get::<Config>().map(|c| c.greeting.clone());
+            let greeting = state.greeting.clone();
             async move {
-                assert_eq!(greeting.as_deref(), Some("lazy"));
+                assert_eq!(greeting.as_str(), "lazy");
                 o4.lock().expect("poisoned").push("after_shutdown");
                 Ok::<(), std::convert::Infallible>(())
             }

--- a/tests/context_extensions.rs
+++ b/tests/context_extensions.rs
@@ -295,14 +295,14 @@ async fn state_reaches_app_state_independently_of_the_delivery_context() {
     let seen_clone = Arc::clone(&seen);
 
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
-        .insert_state(AppPrefix("svc".to_owned()))
+        .on_startup(|()| async { Ok::<_, std::convert::Infallible>(AppPrefix("svc".to_owned())) })
         .with_broker(broker, |b| {
             let subscriber = b.broker().subscribe("orders");
             b.handle(
                 subscriber,
-                move |_msg: &MemoryMessage, ctx: &mut Context<'_>| {
-                    // App state through state(), independent of the per-delivery context.
-                    let prefix = ctx.state().get::<AppPrefix>().map(|p| p.0.clone());
+                move |_msg: &MemoryMessage, ctx: &mut Context<'_, (), AppPrefix>| {
+                    // The typed app state through state(), independent of the per-delivery context.
+                    let prefix = Some(ctx.state().0.clone());
                     let seen = Arc::clone(&seen_clone);
                     async move {
                         *seen.lock().expect("poisoned") = prefix;

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -571,8 +571,8 @@ static CTX_REPLY: AtomicU32 = AtomicU32::new(0);
 static CTX_REPLY_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ctx-in", publish("ctx-out"))]
-async fn ctx_reply(req: &Request, ctx: &mut Context) -> Response {
-    let bump = ctx.state().get::<Bump>().map_or(0, |b| b.0);
+async fn ctx_reply(req: &Request, ctx: &mut Context<'_, (), Bump>) -> Response {
+    let bump = ctx.state().0;
     Response {
         doubled: req.n + bump,
     }
@@ -592,7 +592,7 @@ async fn publishing_handler_reads_context_state() {
     let replies = TypedPublisher::new(broker.publisher());
 
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
-        .insert_state(Bump(100))
+        .on_startup(|()| async { Ok::<_, std::convert::Infallible>(Bump(100)) })
         .with_broker(broker, |b| {
             b.include_publishing(ctx_reply, replies);
             b.include(ctx_sink);

--- a/tests/post_settle_hooks.rs
+++ b/tests/post_settle_hooks.rs
@@ -50,12 +50,8 @@ struct Counters {
 /// retry-gated, and an ungated hook. The retry-gated one must never fire, proving drop and retry
 /// are distinct mechanics.
 #[subscriber("orders")]
-async fn handle_order(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let c = ctx
-        .state()
-        .get::<Counters>()
-        .expect("counters in state")
-        .clone();
+async fn handle_order(order: &Order, ctx: &mut Context<'_, (), Counters>) -> HandlerResult {
+    let c = ctx.state().clone();
     let outcome = if order.id % 2 == 1 {
         HandlerResult::Ack
     } else {
@@ -88,9 +84,10 @@ async fn outcome_gated_and_ungated_hooks_fire_per_settlement() {
     let broker = MemoryBroker::new();
     let publisher = broker.publisher();
     let counters = Counters::default();
+    let startup_counters = counters.clone();
 
     let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
-        .insert_state(counters.clone())
+        .on_startup(move |()| async move { Ok::<_, std::convert::Infallible>(startup_counters) })
         .with_broker(broker, |b| b.include(handle_order));
 
     let shutdown = Arc::new(Notify::new());


### PR DESCRIPTION
# Description

Replace the `Any`-keyed `State` type-map with a single typed application-state value threaded through the runtime at compile time. The state `S` is produced by `on_startup` (the value the hook returns becomes the state and fixes the app's state type) and read with `ctx.state() -> &S` - no lookup, `Option`, or downcast.

- `Context<'a, C, S>`, `Handler<M, C, S>`, and the middleware stack (`BlanketLayer::apply<M, C, S, H>`, `Layer` handlers, `Typed`) thread `S` parallel to the per-delivery context `C`.
- `RustStream<L, St>` is a producer-model builder: `on_startup` transitions `RustStream<L, St> -> RustStream<L, St2>`. `run`, the CLI runner, and `build_spec` are now `St`-generic.
- A `#[subscriber]` handler that names the state as the third `Context` generic is bound to it; one that names none is generic over the state and mounts on any app. Mounting only succeeds when the declared state matches the app's, checked at compile time.
- `PublishingDef` carries a `type State` so a publishing reply handler reads typed state too. Router registrations thread `St` through `RouterDef<B, St>`/`MountRoute`; metadata collection moves to a state-independent `RouterHandlers` trait.
- Batch handlers keep a unit-state context (documented follow-up).

Fixes #94

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable

> Stacked PR: base is `feat/93-typed-context` (#99). Retarget to `v0.5` once #93 merges.