### PR TITLE
refactor: publishers live in typed state (drop the named-publisher registry)

### DIFF
--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -287,10 +287,6 @@ fn expand_batch_publishing(
         failure_method,
     } = parts;
 
-    // Like the single-message publishing form, a batch publishing handler pins its `State` to the
-    // type it names as the third `Context` generic (defaulting to `()`).
-    let state_ty = state_ty.clone().unwrap_or_else(|| quote!(()));
-
     let declared_ty = match &func.sig.output {
         ReturnType::Type(_, ty) => &**ty,
         ReturnType::Default => {
@@ -326,6 +322,17 @@ fn expand_batch_publishing(
             quote!(::core::result::Result::Ok((async move #block).await)),
         )
     };
+
+    // Like the single-message publishing form: the handler implements `BatchPublishingCall` only
+    // for its named state (mounts on a matching app), or generically when it names none (mounts on
+    // any app). The metadata-only `BatchPublishingDef` is unconditional.
+    let (impl_generics, state_in_ctx) = match &state_ty {
+        Some(state_ty) => (quote!(), quote!(#state_ty)),
+        None => (
+            quote!(<__RsState: ::core::marker::Send + ::core::marker::Sync>),
+            quote!(__RsState),
+        ),
+    };
     Ok(quote! {
         #[allow(non_camel_case_types)]
         #vis struct #name;
@@ -333,7 +340,6 @@ fn expand_batch_publishing(
         impl ::ruststream::runtime::BatchPublishingDef for #name {
             type Input = #input_ty;
             type Reply = #reply_elem;
-            type State = #state_ty;
             type Source = #source_ty;
 
             fn source(&self) -> Self::Source { #source_expr }
@@ -350,11 +356,15 @@ fn expand_batch_publishing(
             #input_schema
 
             #message_meta
+        }
 
+        impl #impl_generics
+            ::ruststream::runtime::BatchPublishingCall<#state_in_ctx> for #name
+        {
             async fn call(
                 &self,
                 #pat: &[#input_ty],
-                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_ty>,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_in_ctx>,
             ) -> ::core::result::Result<
                 ::std::vec::Vec<#reply_elem>,
                 ::ruststream::runtime::HandlerResult,
@@ -467,10 +477,6 @@ fn expand_publishing(
         failure_method,
     } = parts;
 
-    // A publishing handler reads the app state by naming it as the third `Context` generic; the def
-    // pins `State` to it (defaulting to `()`), so the subscriber mounts only on a matching app.
-    let state_ty = state_ty.clone().unwrap_or_else(|| quote!(()));
-
     let declared_ty = match &func.sig.output {
         ReturnType::Type(_, ty) => &**ty,
         ReturnType::Default => {
@@ -490,6 +496,17 @@ fn expand_publishing(
             quote!(::core::result::Result::Ok((async move #block).await)),
         ),
     };
+
+    // As for `expand_subscribing`: a publishing handler that names a state type implements
+    // `PublishingCall` only for that state (mounts on a matching app); one that names none is
+    // generic over the state (mounts on any app). The metadata-only `PublishingDef` is unconditional.
+    let (impl_generics, state_in_ctx) = match &state_ty {
+        Some(state_ty) => (quote!(), quote!(#state_ty)),
+        None => (
+            quote!(<__RsState: ::core::marker::Send + ::core::marker::Sync>),
+            quote!(__RsState),
+        ),
+    };
     Ok(quote! {
         #[allow(non_camel_case_types)]
         #vis struct #name;
@@ -497,7 +514,6 @@ fn expand_publishing(
         impl ::ruststream::runtime::PublishingDef for #name {
             type Input = #input_ty;
             type Reply = #reply_ty;
-            type State = #state_ty;
             type Source = #source_ty;
 
             fn source(&self) -> Self::Source { #source_expr }
@@ -514,11 +530,15 @@ fn expand_publishing(
             #input_schema
 
             #message_meta
+        }
 
+        impl #impl_generics
+            ::ruststream::runtime::PublishingCall<#state_in_ctx> for #name
+        {
             async fn call(
                 &self,
                 #pat: &#input_ty,
-                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_ty>,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_in_ctx>,
             ) -> ::core::result::Result<#reply_ty, ::ruststream::runtime::HandlerResult> {
                 #call_body
             }

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -6,7 +6,7 @@ lifetimes:
 | Level | Type | Lives for | Holds |
 |---|---|---|---|
 | Application | the state type `S` | the whole service | shared resources: pools, clients, configuration |
-| Delivery | `Context<'_, C, S>` | one message | the channel name, a headers working copy, the broker's typed per-delivery context `C` (read by key), the typed shared state `S` and named publishers |
+| Delivery | `Context<'_, C, S>` | one message | the channel name, a headers working copy, the broker's typed per-delivery context `C` (read by key), and the typed shared state `S` |
 
 The state is produced once, at startup, and is a single typed value of your own choosing. A
 `Context` is built fresh for every delivery and threaded as `&mut` through the middleware chain into
@@ -55,7 +55,6 @@ What the context exposes:
 | `state()` | `&S` | the typed shared application state, borrowed directly |
 | `context(KEY)` | `KEY::Value` | a [broker field](#per-delivery-context) read by compile-time key |
 | `set(KEY, v)` | `()` | write a per-delivery [scratch value](#per-delivery-context) (middleware) |
-| `publisher(KEY)` | `Option<ScopedPublisher>` | a [named publisher](publishing.md#publishing-from-inside-a-handler) resolved by compile-time key |
 | `after(outcome).then(fut)` | `()` | a [post-settle hook](#post-settle-hooks) gated on the settlement outcome |
 | `after_ack(fut)` / `after_settle(fut)` | `()` | post-settle hook sugar (after an ack / after any settlement) |
 
@@ -109,12 +108,11 @@ Two boundaries to keep in mind:
   headers; attach outgoing metadata in the [publish pipeline](publishing.md#the-publish-pipeline)
   (a `PublishLayer` or `PublishMiddleware`) instead.
 
-## Publishing through the context
+## Publishing from a handler
 
-`ctx.publisher("name")` resolves a publisher registered with `RustStream::publisher(name, p)` and
-returns `None` when nothing is registered under that name. Sends through it run the application's
-dynamic publish middleware - the same chain as a macro reply - so a manual publish is not a hole
-in the pipeline:
+To publish from inside a handler (beyond the `publish(..)` reply form), put the publisher in the
+typed application state and reach it with `ctx.state()` - it stays typed, so the handler uses its
+own API directly:
 
 ```rust
 --8<-- "examples/publishing.rs:forward"

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -24,10 +24,9 @@ fixing the app's state type:
 
 The state type is checked at compile time: a `#[subscriber]` handler that reads state names it as
 the third `Context` generic (`Context<'_, C, S>`), and the runtime only lets that handler mount on
-an app whose state type matches. A plain handler that names no state type is generic over it, so it
-mounts on any app. (A `publish(..)` handler is the exception: it pins its state to `()` when none is
-named, so to mount one on a stateful app name the app's state explicitly as
-`ctx: &mut Context<'_, (), S>`.) The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
+an app whose state type matches. A handler that names no state type is generic over it, so it mounts
+on any app - this holds for `publish(..)` handlers too: one that ignores the state omits the
+`Context` parameter entirely and still mounts on a stateful app. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
 references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when a
 shared value must change at runtime. See [Lifespan](lifespan.md) for the startup-hook contract.
 

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -29,7 +29,7 @@ A `#[subscriber]` handler that reads state names it as the third `Context` gener
 type matches, checked at compile time. A plain handler that names no state type is generic over it
 and mounts on any app; a `publish(..)` handler instead pins its state to `()` when none is named, so
 name the app's state explicitly to mount one on a stateful app. Everything else the context carries
-(the headers working copy, named publishers) is covered in [Context and state](context.md).
+(the headers working copy, broker per-delivery fields) is covered in [Context and state](context.md).
 
 ## Lifecycle hooks
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -1,7 +1,7 @@
 # Publishing and replies
 
 There are two ways to publish: return a reply from a handler, or publish explicitly from inside a
-handler through a named publisher. Both run through the publish pipeline.
+handler through a publisher held in the typed application state.
 
 ## Replying from a handler
 
@@ -55,28 +55,19 @@ Make publishing handlers idempotent under redelivery.
 ## Publishing from inside a handler
 
 To publish to a destination other than a single reply (fan-out, side effects, routing to a different
-broker), register a named publisher on the application under a compile-time `PublisherKey` and
-resolve it from the context by the same key. Declare the key once with `publisher_key!` and import
-it at both sites; a misspelled key is a compile error, not a runtime `None`.
-
-<!-- inline-rust: minimal named-publisher registration fragment; the full build wiring is compiled in publishing.rs:pipeline, pulled in later on this page -->
-```rust
-use ruststream::publisher_key;
-
-publisher_key!(Egress);
-
-// register at build time, bound to the key
-let app = RustStream::new(info)
-    .publisher(Egress, egress_publisher)
-    .with_broker(broker, |b| b.include(forward));
-```
+broker), put the publisher in the [typed application state](lifespan.md) and reach it from the
+handler with `ctx.state()`. A publisher is a value like any other shared resource; in the state it
+stays typed, so the handler uses its own API directly, with no registry and no runtime lookup.
 
 ```rust
 use ruststream::codec::{Codec, JsonCodec};
-use ruststream::runtime::{HandlerResult, Outgoing};
+use ruststream::{OutgoingMessage, Publisher};
 
 --8<-- "examples/publishing.rs:forward"
 ```
+
+The publisher is produced in `on_startup` and stored in the state struct, the same as a database
+pool or HTTP client (see [Lifespan](lifespan.md)).
 
 !!! note "Handlers that publish must own their context"
     A closure handler cannot return a future that borrows `&mut Context`. Use a `#[subscriber]`
@@ -113,8 +104,9 @@ Both levels compose on the application:
 --8<-- "examples/publishing.rs:pipeline"
 ```
 
-Manual publishes through `ctx.publisher(..)` run through the dynamic pipeline (the static layer is a
-property of a specific `TypedPublisher`). The full program is
+The pipeline runs on the reply path (the `publish(..)` form). A publisher held in the state is used
+directly, so compose any per-publisher transforms onto it with `TypedPublisher::layer` when you
+build it. The full program is
 [`examples/publishing.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/publishing.rs).
 
 ## Batch replies and transactions

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -30,7 +30,7 @@ shared state, or to publish from inside the handler:
 
 The macro resolves the context type itself, so the `Context` name needs no import when it appears
 only in `#[subscriber]` signatures. The full context surface - the headers working copy, state
-access, named publishers - is covered in [Context and state](context.md).
+access, broker per-delivery fields - is covered in [Context and state](context.md).
 
 ### Acking
 

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -38,10 +38,10 @@ struct Event {
 }
 
 // --8<-- [start:reply]
-// The app declares a typed state (`AppState`), so a `publish(..)` handler names it as the third
-// `Context` generic even when it does not read it.
+// A `publish(..)` handler that does not read the app state omits the `Context` parameter entirely;
+// it stays generic over the state and mounts on an app with any state type.
 #[subscriber("requests", publish("responses"))]
-async fn respond(req: &Request, _ctx: &mut Context<'_, (), AppState>) -> Response {
+async fn respond(req: &Request) -> Response {
     println!("responding to request {}", req.id);
     Response { ok: true }
 }
@@ -51,10 +51,7 @@ async fn respond(req: &Request, _ctx: &mut Context<'_, (), AppState>) -> Respons
 // `Ok` publishes the reply and acks; `Err` publishes nothing and the dispatcher acts on the
 // returned HandlerResult (here: drop the malformed request instead of replying).
 #[subscriber("validated-requests", publish("responses"))]
-async fn validate(
-    req: &Request,
-    _ctx: &mut Context<'_, (), AppState>,
-) -> Result<Response, HandlerResult> {
+async fn validate(req: &Request) -> Result<Response, HandlerResult> {
     if req.id == 0 {
         return Err(HandlerResult::drop());
     }
@@ -110,10 +107,7 @@ impl PublishMiddleware for AuditPublish {
 // --8<-- [start:batch_publishing]
 /// Confirms a whole page of orders; the replies become visible atomically on commit.
 #[subscriber(batch("orders"), publish("confirmations"))]
-async fn confirm(
-    orders: &[Event],
-    _ctx: &mut Context<'_, (), AppState>,
-) -> Result<Vec<Event>, HandlerResult> {
+async fn confirm(orders: &[Event]) -> Result<Vec<Event>, HandlerResult> {
     if orders.is_empty() {
         return Err(HandlerResult::drop()); // nothing published, whole batch settled
     }

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -1,5 +1,5 @@
-//! The publishing forms from the Publishing guide: a reply handler, a named publisher resolved
-//! from the context, and the two-level publish pipeline (static layer + dynamic middleware).
+//! The publishing forms from the Publishing guide: a reply handler, a publisher shared through the
+//! typed application state, and the two-level publish pipeline (static layer + dynamic middleware).
 //!
 //! ```text
 //! cargo run --example publishing --features macros,memory,json -- run
@@ -9,16 +9,18 @@ use std::future::Future;
 use std::pin::Pin;
 
 use ruststream::codec::{Codec, JsonCodec};
-use ruststream::memory::MemoryBroker;
+use ruststream::memory::{MemoryBroker, MemoryPublisher};
 use ruststream::runtime::{
-    AppInfo, HandlerResult, Outgoing, PublishLayer, PublishMiddleware, PublishNext, RustStream,
-    TypedPublisher,
+    AppInfo, HandlerResult, Identity, Outgoing, PublishLayer, PublishMiddleware, PublishNext,
+    RustStream, TypedPublisher,
 };
-use ruststream::{publisher_key, subscriber};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
 
-// A compile-time publisher key: declared once, imported at both the registration and the handler.
-publisher_key!(Egress);
+// A publisher shared with handlers as a typed field of the application state.
+struct AppState {
+    egress: MemoryPublisher,
+}
 
 #[derive(Debug, Deserialize)]
 struct Request {
@@ -36,8 +38,10 @@ struct Event {
 }
 
 // --8<-- [start:reply]
+// The app declares a typed state (`AppState`), so a `publish(..)` handler names it as the third
+// `Context` generic even when it does not read it.
 #[subscriber("requests", publish("responses"))]
-async fn respond(req: &Request) -> Response {
+async fn respond(req: &Request, _ctx: &mut Context<'_, (), AppState>) -> Response {
     println!("responding to request {}", req.id);
     Response { ok: true }
 }
@@ -47,7 +51,10 @@ async fn respond(req: &Request) -> Response {
 // `Ok` publishes the reply and acks; `Err` publishes nothing and the dispatcher acts on the
 // returned HandlerResult (here: drop the malformed request instead of replying).
 #[subscriber("validated-requests", publish("responses"))]
-async fn validate(req: &Request) -> Result<Response, HandlerResult> {
+async fn validate(
+    req: &Request,
+    _ctx: &mut Context<'_, (), AppState>,
+) -> Result<Response, HandlerResult> {
     if req.id == 0 {
         return Err(HandlerResult::drop());
     }
@@ -56,14 +63,14 @@ async fn validate(req: &Request) -> Result<Response, HandlerResult> {
 // --8<-- [end:reply_result]
 
 // --8<-- [start:forward]
+// The egress publisher is a typed field of the app state, so the handler reaches it through
+// `ctx.state()` and publishes with the publisher's own API - no registry, no erased lookup.
 #[subscriber("ingress")]
-async fn forward(event: &Event, ctx: &mut Context<'_>) -> HandlerResult {
-    if let Some(publisher) = ctx.publisher(Egress) {
-        let payload = JsonCodec.encode(event).expect("serializable");
-        let out = Outgoing::new("egress", payload);
-        if publisher.publish(out).await.is_err() {
-            return HandlerResult::retry();
-        }
+async fn forward(event: &Event, ctx: &mut Context<'_, (), AppState>) -> HandlerResult {
+    let payload = JsonCodec.encode(event).expect("serializable");
+    let out = OutgoingMessage::new("egress", payload.as_ref());
+    if ctx.state().egress.publish(out).await.is_err() {
+        return HandlerResult::retry();
     }
     HandlerResult::Ack
 }
@@ -103,7 +110,10 @@ impl PublishMiddleware for AuditPublish {
 // --8<-- [start:batch_publishing]
 /// Confirms a whole page of orders; the replies become visible atomically on commit.
 #[subscriber(batch("orders"), publish("confirmations"))]
-async fn confirm(orders: &[Event]) -> Result<Vec<Event>, HandlerResult> {
+async fn confirm(
+    orders: &[Event],
+    _ctx: &mut Context<'_, (), AppState>,
+) -> Result<Vec<Event>, HandlerResult> {
     if orders.is_empty() {
         return Err(HandlerResult::drop()); // nothing published, whole batch settled
     }
@@ -112,15 +122,15 @@ async fn confirm(orders: &[Event]) -> Result<Vec<Event>, HandlerResult> {
 // --8<-- [end:batch_publishing]
 
 #[ruststream::app]
-fn app() -> RustStream {
+fn app() -> RustStream<Identity, AppState> {
     let broker = MemoryBroker::new();
     let egress = broker.publisher();
     // --8<-- [start:pipeline]
     RustStream::new(AppInfo::new("publishing", "0.1.0"))
-        // dynamic, app-wide: wraps every published message
+        // dynamic, app-wide: wraps every published reply
         .publish_layer(AuditPublish)
-        // a named publisher under a compile-time key, resolvable from any handler's context
-        .publisher(Egress, egress)
+        // a publisher shared with handlers as typed state, reached via `ctx.state().egress`
+        .on_startup(move |()| async move { Ok::<_, std::convert::Infallible>(AppState { egress }) })
         .with_broker(broker, |b| {
             // static, per-publisher: composed onto this TypedPublisher at compile time
             let replies = TypedPublisher::new(b.broker().publisher()).layer(EnvelopeLayer);

--- a/examples/routed_service/payments.rs
+++ b/examples/routed_service/payments.rs
@@ -35,13 +35,10 @@ pub(crate) async fn process_payment(
 /// atomically on commit. The batch contract guarantees a non-empty page, so the handler maps it
 /// straight to replies; returning the bare `Vec` publishes them all and acks the batch.
 // --8<-- [start:batch]
-// This handler ignores the app state, but a `publish(..)` def pins its state type, so it names the
-// router's `Repository` state to mount alongside the stateful `process_payment` handler.
+// This handler ignores the app state, so it omits the `Context` parameter and stays generic over
+// the state; it still mounts alongside the stateful `process_payment` handler on the same router.
 #[subscriber(batch("clearings"), publish("settlements"))]
-pub(crate) async fn settle(
-    clearings: &[Clearing],
-    _ctx: &mut Context<'_, (), Repository>,
-) -> Vec<Settlement> {
+pub(crate) async fn settle(clearings: &[Clearing]) -> Vec<Settlement> {
     clearings
         .iter()
         .map(|c| Settlement {

--- a/src/runtime/app/include.rs
+++ b/src/runtime/app/include.rs
@@ -8,11 +8,11 @@ use crate::codec::Codec;
 use crate::{BatchSubscriber, Broker, Publisher, Subscriber, SubscriptionSource};
 
 use crate::runtime::batch::BatchDef;
-use crate::runtime::batch_publishing::BatchPublishingDef;
+use crate::runtime::batch_publishing::BatchPublishingCall;
 use crate::runtime::handler::Handler;
 use crate::runtime::middleware::Layer;
 use crate::runtime::publish::{PublishLayer, ReplyPublisher, TypedPublisher};
-use crate::runtime::publishing::{PublishingDef, PublishingHandler};
+use crate::runtime::publishing::{PublishingCall, PublishingHandler};
 use crate::runtime::subscriber_def::SubscriberDef;
 use crate::runtime::typed::Typed;
 
@@ -144,7 +144,7 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
     /// every reply, commits, then acks the batch; any failure aborts and the batch is retried.
     pub fn include_batch_publishing<D, RP>(&mut self, def: D, publisher: RP)
     where
-        D: BatchPublishingDef<State = St> + 'static,
+        D: BatchPublishingCall<St> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
@@ -164,7 +164,7 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingDef<State = St> + 'static,
+        D: BatchPublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
@@ -182,7 +182,7 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
     /// default with [`with_broker_codec`](crate::runtime::RustStream::with_broker_codec).
     pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
     where
-        D: PublishingDef + 'static,
+        D: PublishingCall<St> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
@@ -215,7 +215,7 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingDef + 'static,
+        D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         P: Publisher + 'static,
@@ -322,7 +322,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
     /// through `publisher`.
     pub fn include_batch_publishing<D, RP>(&mut self, def: D, publisher: RP)
     where
-        D: BatchPublishingDef<State = St> + 'static,
+        D: BatchPublishingCall<St> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
@@ -341,7 +341,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingDef<State = St> + 'static,
+        D: BatchPublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
@@ -355,7 +355,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
     /// input with the scope's default codec and sending the reply through `publisher`.
     pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
     where
-        D: PublishingDef + 'static,
+        D: PublishingCall<St> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
@@ -388,7 +388,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingDef + 'static,
+        D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         P: Publisher + 'static,

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -10,7 +10,7 @@ use crate::{BatchSubscriber, Broker, Publisher, Subscriber, SubscriptionSource};
 
 use crate::runtime::batch::{BatchDef, batch_metadata, typed_batch};
 use crate::runtime::batch_publishing::{
-    BatchPublishingDef, BatchPublishingHandler, batch_publishing_metadata,
+    BatchPublishingCall, BatchPublishingHandler, batch_publishing_metadata,
 };
 use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
@@ -18,7 +18,7 @@ use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{BlanketLayer, Identity, Layer};
 use crate::runtime::publish::{PublishLayer, PublishMiddleware, ReplyPublisher, TypedPublisher};
 use crate::runtime::publisher_registry::ErasedPublisher;
-use crate::runtime::publishing::{PublishingDef, PublishingHandler, publishing_metadata};
+use crate::runtime::publishing::{PublishingCall, PublishingHandler, publishing_metadata};
 use crate::runtime::router::{RouterDef, RouterSink};
 use crate::runtime::subscriber_def::{SubscriberDef, subscriber_metadata};
 use crate::runtime::typed::{Typed, typed};
@@ -199,7 +199,7 @@ impl<B: Broker + 'static, L, SC, St> BrokerScope<B, L, SC, St> {
     ) where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingDef<State = St> + 'static,
+        D: BatchPublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         C: Codec + 'static,
@@ -232,7 +232,7 @@ impl<B: Broker + 'static, L, SC, St> BrokerScope<B, L, SC, St> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingDef + 'static,
+        D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         C: Codec + 'static,

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -12,7 +12,6 @@ use crate::runtime::batch::{BatchDef, batch_metadata, typed_batch};
 use crate::runtime::batch_publishing::{
     BatchPublishingDef, BatchPublishingHandler, batch_publishing_metadata,
 };
-use crate::runtime::dispatch::Publishers;
 use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
 use crate::runtime::metadata::HandlerMetadata;
@@ -34,7 +33,6 @@ use crate::runtime::typed::{Typed, typed};
 pub struct BrokerScope<B, L = Identity, C = (), St = ()> {
     pub(super) broker: Arc<B>,
     pub(super) sink: RouterSink<B, St>,
-    pub(super) publishers: Publishers,
     pub(super) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
     pub(super) retry_publisher: Option<Arc<dyn ErasedPublisher>>,
     pub(super) global: L,
@@ -46,17 +44,6 @@ impl<B: Broker + 'static, L, C, St> BrokerScope<B, L, C, St> {
     #[must_use]
     pub fn broker(&self) -> &B {
         &self.broker
-    }
-
-    /// Resolves a named publisher by its compile-time [`PublisherKey`](crate::runtime::PublisherKey),
-    /// registered with [`RustStream::publisher`](crate::runtime::RustStream::publisher), to capture
-    /// in a handler and publish to.
-    #[must_use]
-    pub fn publisher<K: crate::runtime::PublisherKey>(
-        &self,
-        _key: K,
-    ) -> Option<Arc<dyn ErasedPublisher>> {
-        self.publishers.get(&std::any::TypeId::of::<K>()).cloned()
     }
 
     /// Wires a publisher for the broker-agnostic `retry_after` fallback on this scope.

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -1,19 +1,15 @@
 //! The [`RustStream`] builder: construction, configuration and handler registration.
 
 use std::{
-    collections::{BTreeMap, HashMap},
-    error::Error as StdError,
-    future::Future,
-    sync::Arc,
-    time::Duration,
+    collections::BTreeMap, error::Error as StdError, future::Future, sync::Arc, time::Duration,
 };
 
 use crate::codec::Codec;
-use crate::{Broker, Publisher, ServerSpec};
+use crate::{Broker, ServerSpec};
 
 use tokio_util::task::TaskTracker;
 
-use crate::runtime::dispatch::{Delivery, Publishers};
+use crate::runtime::dispatch::Delivery;
 use crate::runtime::lifecycle::{BoxError, BrokerLifecycle};
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{Identity, Stack};
@@ -68,7 +64,6 @@ pub struct RustStream<L = Identity, St = ()> {
     pub(super) starters: Vec<Starter<St>>,
     pub(super) handlers: Vec<HandlerMetadata>,
     pub(super) servers: BTreeMap<String, ServerSpec>,
-    pub(super) publishers: Publishers,
     pub(super) publish_layers: Vec<Arc<dyn PublishMiddleware>>,
     pub(super) state_init: StateInit<St>,
     pub(super) after_startup: Vec<LifecycleHook<St>>,
@@ -103,7 +98,6 @@ impl RustStream<Identity, ()> {
             starters: Vec::new(),
             handlers: Vec::new(),
             servers: BTreeMap::new(),
-            publishers: HashMap::new(),
             publish_layers: Vec::new(),
             state_init: Box::new(|| Box::pin(async { Ok(()) })),
             after_startup: Vec::new(),
@@ -128,7 +122,6 @@ impl<L, St> RustStream<L, St> {
             starters: self.starters,
             handlers: self.handlers,
             servers: self.servers,
-            publishers: self.publishers,
             publish_layers: self.publish_layers,
             state_init: self.state_init,
             after_startup: self.after_startup,
@@ -167,7 +160,6 @@ impl<L, St> RustStream<L, St> {
             starters: Vec::new(),
             handlers: self.handlers,
             servers: self.servers,
-            publishers: self.publishers,
             publish_layers: self.publish_layers,
             state_init: Box::new(move || {
                 Box::pin(async move {
@@ -248,25 +240,6 @@ impl<L, St> RustStream<L, St> {
     #[must_use]
     pub fn shutdown_timeout(mut self, timeout: Duration) -> Self {
         self.shutdown_timeout = Some(timeout);
-        self
-    }
-
-    /// Registers a named publisher under a compile-time
-    /// [`PublisherKey`](crate::runtime::PublisherKey), so handlers can publish to it by key
-    /// (including from a different broker's scope).
-    ///
-    /// Declare the key with [`publisher_key!`](crate::publisher_key) and import it at both the
-    /// registration and the handler. The publisher is held type-erased; resolve it with
-    /// [`BrokerScope::publisher`](BrokerScope::publisher) or
-    /// [`Context::publisher`](crate::runtime::Context::publisher).
-    #[must_use]
-    pub fn publisher<K, P>(mut self, _key: K, publisher: P) -> Self
-    where
-        K: crate::runtime::PublisherKey,
-        P: Publisher + 'static,
-    {
-        self.publishers
-            .insert(std::any::TypeId::of::<K>(), Arc::new(publisher));
         self
     }
 
@@ -359,7 +332,6 @@ impl<L, St> RustStream<L, St> {
         BrokerScope {
             broker: broker.clone(),
             sink: RouterSink::new(),
-            publishers: self.publishers.clone(),
             pipeline: self.publish_layers.iter().cloned().collect(),
             retry_publisher: None,
             global: self.global.clone(),
@@ -375,8 +347,6 @@ impl<L, St> RustStream<L, St> {
     {
         let lifecycle: Arc<dyn BrokerLifecycle> = broker.clone();
         let delivery = Arc::new(Delivery {
-            publishers: self.publishers.clone(),
-            pipeline: scope.pipeline.clone(),
             retry_publisher: scope.retry_publisher.clone(),
             tasks: self.continuations.clone(),
         });

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -28,8 +28,8 @@ use super::publish::{PublishMiddleware, ReplyPublisher};
 /// The batch counterpart of [`PublishingDef`](super::PublishingDef): the handler consumes the
 /// whole decoded batch and returns the replies for it, all-or-nothing. Selective per-element
 /// outcomes are deliberately unsupported here - there is no coherent transaction commit for a
-/// half-nacked batch; handlers needing both publish manually via
-/// [`Context::publisher`](super::Context::publisher) from a plain batch handler.
+/// half-nacked batch; handlers needing both publish manually from a plain batch handler through a
+/// publisher held in the typed application state.
 pub trait BatchPublishingDef: Send + Sync {
     /// The decoded element type; the handler consumes `&[Input]`.
     type Input;

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -37,11 +37,6 @@ pub trait BatchPublishingDef: Send + Sync {
     /// The reply element type; each entry of the returned `Vec` is encoded and published.
     type Reply;
 
-    /// The app's typed shared state the handler reads through
-    /// [`Context::state`](super::Context::state) (`()` when it names none). A batch publishing
-    /// subscriber mounts only on an app whose state type matches.
-    type State: Send + Sync;
-
     /// The subscription source this handler binds to (see
     /// [`SubscriberDef::Source`](super::SubscriberDef::Source)).
     type Source;
@@ -88,15 +83,23 @@ pub trait BatchPublishingDef: Send + Sync {
     fn message_description(&self) -> Option<&'static str> {
         None
     }
+}
 
+/// Runs a [`BatchPublishingDef`]'s handler body over an app state of type `S`.
+///
+/// Split from [`BatchPublishingDef`] so a handler that ignores the app state is generic over `S`
+/// (mounts on any app), while one that reads it via [`Context::state`](super::Context::state)
+/// implements this only for its declared `S` - the state match is checked at compile time without
+/// pinning a single `State` on the def.
+pub trait BatchPublishingCall<S>: BatchPublishingDef {
     /// Runs the handler body on one decoded batch.
     ///
-    /// `Ok(replies)` publishes every reply to [`reply_name`](Self::reply_name) and acks the
-    /// batch; `Err(result)` publishes nothing and settles the whole batch with `result`.
+    /// `Ok(replies)` publishes every reply to [`reply_name`](BatchPublishingDef::reply_name) and
+    /// acks the batch; `Err(result)` publishes nothing and settles the whole batch with `result`.
     fn call(
         &self,
         batch: &[Self::Input],
-        ctx: &mut Context<'_, (), Self::State>,
+        ctx: &mut Context<'_, (), S>,
     ) -> impl Future<Output = Result<Vec<Self::Reply>, HandlerResult>> + Send;
 }
 
@@ -138,19 +141,20 @@ impl<D, C, R> std::fmt::Debug for BatchPublishingHandler<D, C, R> {
     }
 }
 
-impl<M, D, C, R> BatchHandler<M, D::State> for BatchPublishingHandler<D, C, R>
+impl<M, D, C, R, S> BatchHandler<M, S> for BatchPublishingHandler<D, C, R>
 where
     M: IncomingMessage,
-    D: BatchPublishingDef,
+    D: BatchPublishingCall<S>,
     D::Input: DeserializeOwned + Send + Sync,
     D::Reply: Serialize + Send + Sync,
     C: Codec,
     R: ReplyPublisher,
+    S: Send + Sync,
 {
-    async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_, (), D::State>) {
+    async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_, (), S>) {
         let subscription = ctx.name().to_owned();
         let (values, accepted) =
-            decode_batch::<M, D::Input, C, D::State>(batch, &self.codec, self.decode, ctx).await;
+            decode_batch::<M, D::Input, C, S>(batch, &self.codec, self.decode, ctx).await;
         if accepted.is_empty() {
             return;
         }
@@ -203,7 +207,6 @@ mod tests {
     impl BatchPublishingDef for Confirm {
         type Input = u32;
         type Reply = u32;
-        type State = ();
         type Source = crate::Name;
 
         fn source(&self) -> Self::Source {
@@ -213,11 +216,14 @@ mod tests {
         fn reply_name(&self) -> &str {
             self.reply_to
         }
+    }
 
+    // Ignores the app state, so it is generic over it (mounts on any app).
+    impl<S: Send + Sync> BatchPublishingCall<S> for Confirm {
         async fn call(
             &self,
             batch: &[u32],
-            _ctx: &mut Context<'_>,
+            _ctx: &mut Context<'_, (), S>,
         ) -> Result<Vec<u32>, HandlerResult> {
             if let Some(result) = self.fail_with {
                 return Err(result);

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -17,7 +17,6 @@ use crate::{Field, FieldMut, Headers};
 use super::dispatch::Delivery;
 use super::failure::ErrorShutdown;
 use super::handler::HandlerResult;
-use super::publish::ScopedPublisher;
 
 /// A post-settle continuation: a boxed `Send` future the dispatcher runs after the message (or
 /// batch) has been settled.
@@ -60,11 +59,11 @@ struct AfterHook {
 ///
 /// Carries the channel ([`name`](Self::name)), a working copy of the message
 /// [`headers`](Self::headers) (middleware may enrich them for the handler; the broker message
-/// itself is untouched), shared application [state](Self::state), the broker's typed per-delivery
-/// context read by key ([`context`](Self::context) / [`set`](Self::set)), and access to named
-/// [`publisher`](Self::publisher)s for publishing from inside a handler. The headers copy is made
-/// lazily on the first [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit
-/// it: replies and manual publishes start from fresh headers, shaped by the publish pipeline.
+/// itself is untouched), the typed shared application [state](Self::state) (where a publisher to
+/// publish from a handler lives), and the broker's typed per-delivery context read by key
+/// ([`context`](Self::context) / [`set`](Self::set)). The headers copy is made lazily on the first
+/// [`headers_mut`](Self::headers_mut) call. Outgoing messages do not inherit it: replies and manual
+/// publishes start from fresh headers, shaped by the publish pipeline.
 pub struct Context<'a, C = (), S = ()> {
     name: &'a str,
     original: &'a Headers,
@@ -130,22 +129,6 @@ impl<'a, C, S> Context<'a, C, S> {
     #[must_use]
     pub fn name(&self) -> &str {
         self.name
-    }
-
-    /// Resolves a named publisher by its compile-time [`PublisherKey`](super::PublisherKey)
-    /// (registered with [`RustStream::publisher`](super::RustStream::publisher)) to publish from
-    /// this handler.
-    ///
-    /// Sends through it run the scope's publish middleware (envelope, metrics) - the same chain as a
-    /// macro reply - so a manual publish is not a hole in the pipeline. Returns `None` if no
-    /// publisher is registered under `key`.
-    #[must_use]
-    pub fn publisher<K: super::PublisherKey>(&self, _key: K) -> Option<ScopedPublisher<'_>> {
-        let publisher = self.delivery.publishers.get(&std::any::TypeId::of::<K>())?;
-        Some(ScopedPublisher::new(
-            publisher.as_ref(),
-            &self.delivery.pipeline,
-        ))
     }
 
     /// The working copy of the message headers.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -2,7 +2,6 @@
 //! until shutdown is signalled or the stream ends. Lifted out of the former `Router` so
 //! [`RustStream`](super::RustStream) can own task spawning directly.
 
-use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -22,12 +21,7 @@ use super::batch::BatchHandler;
 use super::context::Context;
 use super::failure::{DispatchFailure, FailurePolicy, panic_reason};
 use super::handler::{Handler, HandlerResult};
-use super::publish::PublishMiddleware;
 use super::publisher_registry::ErasedPublisher;
-
-/// Named publishers registered on the application, resolvable from a [`Context`] by a compile-time
-/// [`PublisherKey`](super::PublisherKey) (keyed by the key type's `TypeId`, not a hashed string).
-pub(crate) type Publishers = HashMap<std::any::TypeId, Arc<dyn ErasedPublisher>>;
 
 /// Header carrying the framework's deferred-republish retry count.
 ///
@@ -119,14 +113,10 @@ impl Default for Workers {
     }
 }
 
-/// Per-scope publish context threaded into every delivery's [`Context`]: the named-publisher
-/// registry, the scope's publish middleware pipeline, and the app-wide tracker for post-settle
-/// continuations. A handler resolves a publisher with [`Context::publisher`] and its sends run
-/// through `pipeline`, the same chain as a macro reply; an `and_after` continuation is spawned onto
-/// `tasks` so a graceful shutdown drains it.
+/// Per-scope publish context threaded into every delivery's [`Context`]: the broker-agnostic
+/// `retry_after` fallback publisher and the app-wide tracker for post-settle continuations. An
+/// `and_after` continuation is spawned onto `tasks` so a graceful shutdown drains it.
 pub(crate) struct Delivery {
-    pub(crate) publishers: Publishers,
-    pub(crate) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
     /// Publisher used by the broker-agnostic `retry_after` fallback to re-publish a message to its
     /// own source subject after the delay. `None` when the scope did not opt in, in which case a
     /// `NackAfter` on a non-native broker degrades to an immediate requeue (with a warning).
@@ -138,8 +128,7 @@ pub(crate) struct Delivery {
 }
 
 impl Delivery {
-    /// An empty delivery context: no publishers, no pipeline, no retry publisher, a fresh
-    /// continuation tracker. For tests.
+    /// An empty delivery context: no retry publisher, a fresh continuation tracker. For tests.
     #[cfg(test)]
     pub(crate) fn empty() -> Self {
         Self::with_tasks(TaskTracker::new())
@@ -150,8 +139,6 @@ impl Delivery {
     #[cfg(test)]
     pub(crate) fn with_tasks(tasks: TaskTracker) -> Self {
         Self {
-            publishers: HashMap::new(),
-            pipeline: Arc::from([]),
             retry_publisher: None,
             tasks,
         }
@@ -161,8 +148,6 @@ impl Delivery {
 impl std::fmt::Debug for Delivery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Delivery")
-            .field("publishers", &self.publishers.len())
-            .field("layers", &self.pipeline.len())
             .field("retry_publisher", &self.retry_publisher.is_some())
             .field("pending_continuations", &self.tasks.len())
             .finish_non_exhaustive()
@@ -808,8 +793,6 @@ mod tests {
         // Subscribe before publishing: the in-memory broker does not buffer earlier messages.
         let mut sub = broker.subscribe("orders");
         let delivery = Delivery {
-            publishers: HashMap::new(),
-            pipeline: Arc::from([]),
             retry_publisher: Some(Arc::new(broker.publisher())),
             tasks: TaskTracker::new(),
         };
@@ -844,8 +827,6 @@ mod tests {
         let broker = MemoryBroker::new();
         let mut sub = broker.subscribe("orders");
         let delivery = Delivery {
-            publishers: HashMap::new(),
-            pipeline: Arc::from([]),
             retry_publisher: Some(Arc::new(broker.publisher())),
             tasks: TaskTracker::new(),
         };
@@ -891,8 +872,6 @@ mod tests {
         // land here and never on `sub`.
         let other = MemoryBroker::new();
         let delivery = Delivery {
-            publishers: HashMap::new(),
-            pipeline: Arc::from([]),
             retry_publisher: Some(Arc::new(other.publisher())),
             tasks: TaskTracker::new(),
         };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,7 +21,7 @@ mod typed;
 
 pub use app::{AppInfo, BrokerScope, RustStream, RustStreamError};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};
-pub use batch_publishing::{BatchPublishingDef, BatchPublishingHandler};
+pub use batch_publishing::{BatchPublishingCall, BatchPublishingDef, BatchPublishingHandler};
 pub use context::{After, Context};
 pub use dispatch::{RETRY_COUNT_HEADER, Workers};
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
@@ -34,7 +34,7 @@ pub use publish::{
     ReplyPublisher, Transactional, TypedPublisher,
 };
 pub use publisher_registry::ErasedPublisher;
-pub use publishing::{PublishingDef, PublishingHandler};
+pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};
 pub use router::{Router, RouterDef, RouterHandlers, RouterSink};
 pub use subscriber_def::SubscriberDef;
 pub use typed::{Typed, typed};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -31,9 +31,9 @@ pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
     Outgoing, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext, PublishStack,
-    ReplyPublisher, ScopedPublisher, Transactional, TypedPublisher,
+    ReplyPublisher, Transactional, TypedPublisher,
 };
-pub use publisher_registry::{ErasedPublisher, PublisherKey};
+pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingDef, PublishingHandler};
 pub use router::{Router, RouterDef, RouterHandlers, RouterSink};
 pub use subscriber_def::SubscriberDef;

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -149,46 +149,6 @@ pub(crate) fn run_publish<'a>(
     .run(out)
 }
 
-/// A named publisher resolved from a [`Context`](super::Context), sending through the scope's
-/// publish pipeline.
-///
-/// Returned by [`Context::publisher`](super::Context::publisher). Publishing through it runs the
-/// same [`PublishMiddleware`] chain (envelope, metrics) as a macro reply, so a manual publish from a
-/// handler is not a hole in the pipeline.
-pub struct ScopedPublisher<'a> {
-    publisher: &'a dyn ErasedPublisher,
-    pipeline: &'a [Arc<dyn PublishMiddleware>],
-}
-
-impl<'a> ScopedPublisher<'a> {
-    pub(crate) fn new(
-        publisher: &'a dyn ErasedPublisher,
-        pipeline: &'a [Arc<dyn PublishMiddleware>],
-    ) -> Self {
-        Self {
-            publisher,
-            pipeline,
-        }
-    }
-
-    /// Sends `out` through the publish pipeline to the broker.
-    ///
-    /// # Errors
-    ///
-    /// Returns the boxed error from a middleware or the broker publish if either fails.
-    pub async fn publish(&self, mut out: Outgoing<'_>) -> Result<(), BoxError> {
-        run_publish(self.pipeline, self.publisher, &mut out).await
-    }
-}
-
-impl std::fmt::Debug for ScopedPublisher<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ScopedPublisher")
-            .field("layers", &self.pipeline.len())
-            .finish_non_exhaustive()
-    }
-}
-
 /// A static, compile-time publish transform: mutates an [`Outgoing`] before it is sent.
 ///
 /// The publish-side counterpart to the consume-side [`Layer`](super::Layer): zero-cost composition,

--- a/src/runtime/publisher_registry.rs
+++ b/src/runtime/publisher_registry.rs
@@ -1,73 +1,19 @@
-//! Type-erased publishers, registered by compile-time key on [`RustStream`](super::RustStream).
+//! Type-erased publisher, used by the broker-agnostic `retry_after` fallback.
 //!
-//! A handler subscribed on one broker may need to publish to another (a different connection, or a
-//! different broker entirely). Publishers of different brokers have different types, so the
-//! registry stores them erased behind [`ErasedPublisher`], keyed by a zero-sized
-//! [`PublisherKey`]. Resolve one in a broker scope with
-//! [`BrokerScope::publisher`](super::BrokerScope::publisher) or in a handler with
-//! [`Context::publisher`](super::Context::publisher).
+//! The deferred-redelivery fallback (see [`BrokerScope::retry_via`](super::BrokerScope::retry_via))
+//! re-publishes a message to its own source subject through a publisher whose concrete type does
+//! not matter to the runtime, so it is held erased behind [`ErasedPublisher`]. To share a publisher
+//! with handlers, put it in the typed application state instead and read it with
+//! [`Context::state`](super::Context::state).
 
 use crate::{Headers, OutgoingMessage, Publisher};
 
 use super::lifecycle::{BoxError, BoxFuture};
 
-/// A compile-time key identifying a named publisher, in place of a string name.
-///
-/// Each key is a distinct zero-sized type, so a misspelled key is a compile error (an undeclared
-/// identifier) where a misspelled string name was only a runtime `None`, and the key is unique by
-/// construction (correct for cross-broker publishing). Declare one with
-/// [`publisher_key!`](crate::publisher_key), bind it to a publisher at build time with
-/// [`RustStream::publisher`](super::RustStream::publisher), and resolve it from a handler with
-/// [`Context::publisher`](super::Context::publisher).
-///
-/// # Examples
-///
-/// ```
-/// use ruststream::publisher_key;
-/// use ruststream::runtime::PublisherKey;
-///
-/// publisher_key!(pub Orders);
-/// assert_eq!(Orders::NAME, "Orders");
-/// ```
-pub trait PublisherKey: 'static {
-    /// A human-readable label (the key's identifier), for diagnostics.
-    const NAME: &'static str;
-}
-
-/// Declares a [`PublisherKey`]: a zero-sized type usable as a publisher key at both registration
-/// (`RustStream::publisher(KEY, p)`) and resolution (`ctx.publisher(KEY)`).
-///
-/// The key is a distinct type, so referencing an undeclared one is a compile error. Group keys in a
-/// shared module so the registration and the handler import the same type.
-///
-/// # Examples
-///
-/// ```
-/// use ruststream::publisher_key;
-///
-/// publisher_key!(
-///     /// Outbound order events.
-///     pub Orders
-/// );
-/// publisher_key!(pub(crate) Payments);
-/// ```
-#[macro_export]
-macro_rules! publisher_key {
-    ($(#[$meta:meta])* $vis:vis $name:ident) => {
-        $(#[$meta])*
-        #[derive(::core::clone::Clone, ::core::marker::Copy, ::core::fmt::Debug)]
-        $vis struct $name;
-
-        impl $crate::runtime::PublisherKey for $name {
-            const NAME: &'static str = ::core::stringify!($name);
-        }
-    };
-}
-
 /// A publisher with its concrete type and error erased.
 ///
-/// Blanket-implemented for every [`Publisher`], so any broker's publisher can be registered by
-/// name and shared as `Arc<dyn ErasedPublisher>`.
+/// Blanket-implemented for every [`Publisher`], so any broker's publisher can be held as
+/// `Arc<dyn ErasedPublisher>` for the `retry_after` fallback.
 pub trait ErasedPublisher: Send + Sync {
     /// Publishes `payload` to `name`, with no headers.
     ///

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -32,11 +32,6 @@ pub trait PublishingDef: Send + Sync {
     /// The reply type the handler produces, encoded and published.
     type Reply;
 
-    /// The app's typed shared state the handler reads through
-    /// [`Context::state`](super::Context::state) (`()` when it names none). A publishing subscriber
-    /// mounts only on an app whose state type matches.
-    type State: Send + Sync;
-
     /// The subscription source this handler binds to (see
     /// [`SubscriberDef::Source`](super::SubscriberDef::Source)).
     type Source;
@@ -82,16 +77,24 @@ pub trait PublishingDef: Send + Sync {
     fn message_description(&self) -> Option<&'static str> {
         None
     }
+}
 
+/// Runs a [`PublishingDef`]'s handler body over an app state of type `S`.
+///
+/// Split from [`PublishingDef`] so a handler that ignores the app state is generic over `S` (mounts
+/// on any app), while one that reads it via [`Context::state`](super::Context::state) implements
+/// this only for its declared `S` - the same shape as [`Handler<M, C, S>`](super::Handler), so the
+/// state match is checked at compile time without pinning a single `State` on the def.
+pub trait PublishingCall<S>: PublishingDef {
     /// Runs the handler body.
     ///
-    /// `Ok(reply)` is encoded and published to [`reply_name`](Self::reply_name), then the incoming
-    /// message is acked. `Err(result)` skips publishing and the dispatcher acts on the returned
-    /// [`HandlerResult`] (for example [`HandlerResult::retry`] to ask for redelivery).
+    /// `Ok(reply)` is encoded and published to [`reply_name`](PublishingDef::reply_name), then the
+    /// incoming message is acked. `Err(result)` skips publishing and the dispatcher acts on the
+    /// returned [`HandlerResult`] (for example [`HandlerResult::retry`] to ask for redelivery).
     fn call(
         &self,
         input: &Self::Input,
-        ctx: &mut Context<'_, (), Self::State>,
+        ctx: &mut Context<'_, (), S>,
     ) -> impl Future<Output = Result<Self::Reply, HandlerResult>> + Send;
 }
 
@@ -130,18 +133,19 @@ impl<D, C, P, PC, PL> std::fmt::Debug for PublishingHandler<D, C, P, PC, PL> {
     }
 }
 
-impl<M, D, C, P, PC, PL> Handler<M, (), D::State> for PublishingHandler<D, C, P, PC, PL>
+impl<M, D, C, P, PC, PL, S> Handler<M, (), S> for PublishingHandler<D, C, P, PC, PL>
 where
     M: IncomingMessage,
-    D: PublishingDef,
+    D: PublishingCall<S>,
     D::Input: DeserializeOwned + Send + Sync,
     D::Reply: Serialize + Send + Sync,
     C: Codec,
     P: Publisher,
     PC: Codec,
     PL: PublishLayer,
+    S: Send + Sync,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, (), D::State>) -> Settle {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, (), S>) -> Settle {
         // The publishing path settles by a bare outcome (no per-element continuation): decode,
         // run, publish the reply, then ack. It converts to `Settle` with no `and_after`.
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
@@ -189,7 +193,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{PublishingDef, publishing_metadata};
+    use super::{PublishingCall, PublishingDef, publishing_metadata};
     use crate::Headers;
     use crate::Name;
     use crate::runtime::context::Context;
@@ -203,7 +207,6 @@ mod tests {
     impl PublishingDef for ManualPub {
         type Input = u32;
         type Reply = u32;
-        type State = ();
         type Source = Name;
 
         fn source(&self) -> Name {
@@ -216,8 +219,15 @@ mod tests {
         fn reply_name(&self) -> &str {
             "out"
         }
+    }
 
-        async fn call(&self, input: &u32, _ctx: &mut Context<'_>) -> Result<u32, HandlerResult> {
+    // Ignores the app state, so it is generic over it (mounts on any app).
+    impl<S: Send + Sync> PublishingCall<S> for ManualPub {
+        async fn call(
+            &self,
+            input: &u32,
+            _ctx: &mut Context<'_, (), S>,
+        ) -> Result<u32, HandlerResult> {
             Ok(*input)
         }
     }

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -11,17 +11,12 @@ use std::{
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
-    AppInfo, BlanketLayer, Context, Handler, HandlerMetadata, HandlerResult, Layer, Outgoing,
-    PublishMiddleware, PublishNext, Router, RustStream, Settle,
+    AppInfo, BlanketLayer, Context, Handler, HandlerMetadata, HandlerResult, Layer, Router,
+    RustStream, Settle,
 };
-use ruststream::{Name, OutgoingMessage, Publisher, publisher_key};
+use ruststream::{Name, OutgoingMessage, Publisher};
 use serde::{Deserialize, Serialize};
-use std::future::Future;
-use std::pin::Pin;
 use tokio::sync::Notify;
-
-// Compile-time key for the cross-broker named publisher used by the bridge tests.
-publisher_key!(Egress);
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Order {
@@ -391,24 +386,28 @@ async fn global_layer_wraps_handlers() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn cross_broker_publish_via_named_publisher() {
+async fn cross_broker_publish_via_captured_publisher() {
     let ingress = MemoryBroker::new();
     let egress = MemoryBroker::new();
     let ingress_pub = ingress.publisher();
+    // Capture the egress broker's own publisher into a handler on the ingress broker - typed, no
+    // registry.
+    let egress_pub = egress.publisher();
 
     let received = Arc::new(AtomicU32::new(0));
     let received_clone = Arc::clone(&received);
 
     let app = RustStream::new(AppInfo::new("bridge", "0.1.0"))
-        .publisher(Egress, egress.publisher())
         .with_broker(ingress, |b| {
-            let out = b.publisher(Egress).expect("egress registered");
+            let out = egress_pub.clone();
             b.subscribe(
                 Name::new("orders"),
                 move |_msg: &_, _ctx: &mut Context| {
-                    let out = Arc::clone(&out);
+                    let out = out.clone();
                     async move {
-                        let _ = out.publish_bytes("responses", b"reply").await;
+                        let _ = out
+                            .publish(OutgoingMessage::new("responses", b"reply".as_slice()))
+                            .await;
                         HandlerResult::Ack
                     }
                 },
@@ -635,98 +634,4 @@ async fn wait_for_published(publisher: &impl Publisher, seen: &AtomicU32, timeou
     })
     .await;
     assert!(result.is_ok(), "no delivery within {timeout:?}");
-}
-
-/// A publish middleware that tags every outgoing message with a header.
-struct Tagger;
-
-impl PublishMiddleware for Tagger {
-    fn on_publish<'a>(
-        &'a self,
-        out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a>,
-    ) -> Pin<
-        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
-    > {
-        Box::pin(async move {
-            out.headers_mut().insert("x-envelope", b"1".to_vec());
-            next.run(out).await
-        })
-    }
-}
-
-/// A handler that publishes manually via `ctx.publisher`. A struct (not a closure) so the future
-/// may borrow `ctx` across the await.
-struct Bridge;
-
-impl<M: Send + Sync> Handler<M> for Bridge {
-    async fn handle(&self, _msg: &M, ctx: &mut Context<'_>) -> Settle {
-        if let Some(out) = ctx.publisher(Egress) {
-            let _ = out
-                .publish(Outgoing::new("responses", b"reply".as_slice()))
-                .await;
-        }
-        HandlerResult::Ack.into()
-    }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn ctx_publisher_runs_through_pipeline() {
-    let ingress = MemoryBroker::new();
-    let egress = MemoryBroker::new();
-    let ingress_pub = ingress.publisher();
-
-    let tagged = Arc::new(AtomicU32::new(0));
-    let tagged_clone = Arc::clone(&tagged);
-
-    let app = RustStream::new(AppInfo::new("bridge", "0.1.0"))
-        .publisher(Egress, egress.publisher())
-        .publish_layer(Tagger)
-        .with_broker(ingress, |b| {
-            b.subscribe(Name::new("orders"), Bridge, HandlerMetadata::raw("orders"));
-        })
-        .with_broker(egress, |b| {
-            let subscriber = b.broker().subscribe("responses");
-            b.handle(
-                subscriber,
-                move |msg: &_, _ctx: &mut Context| {
-                    let tagged = Arc::clone(&tagged_clone);
-                    // The Tagger middleware must have run on the manual publish.
-                    let has_header = ruststream::IncomingMessage::headers(msg)
-                        .get("x-envelope")
-                        .is_some();
-                    async move {
-                        if has_header {
-                            tagged.fetch_add(1, Ordering::SeqCst);
-                        }
-                        HandlerResult::Ack
-                    }
-                },
-                HandlerMetadata::raw("responses"),
-            );
-        });
-
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress_pub
-                .publish(OutgoingMessage::new("orders", b"x"))
-                .await;
-            tokio::task::yield_now().await;
-            if tagged.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "manual publish did not reach egress with the pipeline header",
-    );
-
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
 }


### PR DESCRIPTION
# Description

With typed application state (#94/#100), a shared publisher is just a typed field of the state struct, reached with `ctx.state()` - typed end to end, no erased runtime lookup. That makes the named-publisher registry added in #95/#101 redundant, so this removes it.

- Delete `PublisherKey`, the `publisher_key!` macro, `RustStream::publisher`, `BrokerScope::publisher`, `Context::publisher`, and `ScopedPublisher`.
- Drop the `Publishers` registry and the per-delivery publish pipeline from `Delivery` (only `ctx.publisher` fed them); `ErasedPublisher` stays for the `retry_after` fallback.
- The reply path (`publish(..)`) and its app-wide `publish_layer` pipeline are unchanged.

To publish from a handler now: put the publisher in the state struct and call its own API (`ctx.state().egress.publish(..)`). Migrated the publishing example, the cross-broker test (captures the publisher directly), and the Publishing / Context / Lifespan / Subscribers guides; removed the test that asserted `ctx.publisher` ran the pipeline.

This also dissolves most of the publish-path context need (#103): a handler now holds both its per-delivery context `C` and the publisher (state), so propagating a trace id is an explicit, typed wiring in the handler - no special publish-middleware-context machinery.

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable

> Stacked on `v0.5`. Builds on the typed-state work (#100); supersedes the publisher-keys registry (#101).