### PR TITLE
feat(cli): refresh the memory scaffold pin to 0.5 and compile it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,14 @@ jobs:
       # The trybuild UI snapshots in tests/ui are rustc-version-sensitive, so they
       # run on stable only: RUN_UI_TESTS=1 opts the `ui` test in here, every other
       # run (the 1.85 job, the coverage job, a local `cargo test`) leaves it unset
-      # and the test skips itself.
+      # and the test skips itself. RUN_SCAFFOLD_BUILD=1 opts in the heavy `ruststream
+      # new` compile-check the same way (a nested `cargo build` of the rendered
+      # memory template), so template rot fails CI instead of a user's first build.
       - name: cargo test
         if: matrix.toolchain == 'stable' || matrix.toolchain == '1.85'
         env:
           RUN_UI_TESTS: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
+          RUN_SCAFFOLD_BUILD: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
         run: cargo test --workspace --all-features
 
   coverage:

--- a/src/bin/ruststream/scaffold.rs
+++ b/src/bin/ruststream/scaffold.rs
@@ -98,6 +98,8 @@ fn validate_name(name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::{BrokerKind, create_in, render, validate_name};
 
     #[test]
@@ -178,5 +180,51 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         create_in(tmp.path(), "svc", BrokerKind::Memory).unwrap();
         assert!(create_in(tmp.path(), "svc", BrokerKind::Memory).is_err());
+    }
+
+    /// Renders the `memory` scaffold and compiles it against this workspace, so template rot - an
+    /// API drift or an invalid feature in `Cargo.toml.in` - fails CI here instead of in a user's
+    /// first `cargo build`. The string-substitution tests above never compile the output; this one
+    /// does, the `memory` template being the only broker the core owns.
+    ///
+    /// Heavy (a nested `cargo build`), so it is opt-in like the trybuild UI test: the stable CI job
+    /// sets `RUN_SCAFFOLD_BUILD=1`; the 1.85 job, coverage, and a local `cargo test` leave it unset
+    /// and skip. The template pins the published `ruststream = "0.x"`, which is not on crates.io
+    /// during a pre-release cycle, so the generated manifest is patched to this workspace before the
+    /// build - exercising the template's real feature list and code, sourced locally.
+    #[test]
+    fn memory_scaffold_compiles() {
+        if std::env::var("RUN_SCAFFOLD_BUILD").as_deref() != Ok("1") {
+            eprintln!(
+                "skipping scaffold build; set RUN_SCAFFOLD_BUILD=1 (stable toolchain) to run"
+            );
+            return;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = create_in(tmp.path(), "scaffold_check", BrokerKind::Memory).unwrap();
+
+        let workspace = env!("CARGO_MANIFEST_DIR");
+        let manifest = dir.join("Cargo.toml");
+        let mut cargo = std::fs::read_to_string(&manifest).unwrap();
+        write!(
+            cargo,
+            "\n[patch.crates-io]\nruststream = {{ path = {workspace:?} }}\n"
+        )
+        .unwrap();
+        std::fs::write(&manifest, cargo).unwrap();
+
+        let cargo_bin = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+        let status = std::process::Command::new(cargo_bin)
+            .current_dir(&dir)
+            .args(["build"])
+            // A separate target dir keeps the nested build off the outer test run's lock.
+            .env("CARGO_TARGET_DIR", tmp.path().join("target"))
+            .status()
+            .expect("spawn cargo build for the scaffolded project");
+        assert!(
+            status.success(),
+            "the scaffolded memory project failed to compile"
+        );
     }
 }

--- a/src/bin/ruststream/templates/memory/Cargo.toml.in
+++ b/src/bin/ruststream/templates/memory/Cargo.toml.in
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.3", features = ["macros", "memory", "json", "asyncapi", "logging"] }
+ruststream = { version = "0.5", features = ["macros", "memory", "json", "asyncapi", "logging"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
# Description

Closes the in-core, verifiable slice of #98 and lands the first step of #97 Phase 1 ("templates are never compiled") for the one broker the core owns.

- **Refresh the `memory` scaffold pin.** `ruststream new --broker memory` emitted a project pinning `ruststream = "0.3"`, so a project scaffolded off the 0.5 CLI started two minor versions behind. Bumped to `"0.5"`. The template source already uses current 0.5 API (the publishing `confirm` handler omits the `Context` parameter, which works since publishing defs are generic over state), so only the pin was stale.
- **Compile the template in CI.** The scaffolder is a `template.replace` over strings, so API drift or an invalid feature only surfaced in a user's first `cargo build`. Added a `memory_scaffold_compiles` test that renders the template and runs a nested `cargo build` against this workspace. The pinned `ruststream = "0.5"` is not on crates.io mid-release, so the generated manifest is patched to the workspace path - the test exercises the template's real feature list and code, sourced locally.
- **Opt-in like the UI test.** The nested build is heavy, so it gates on `RUN_SCAFFOLD_BUILD=1`, mirroring `RUN_UI_TESTS`: the stable CI job sets it; the 1.85 job, coverage, and a local `cargo test` leave it unset and the test skips itself.

Scope: only `memory` (core-owned, compile-verified here). `nats`/`nats-js` keep their `0.3` pins - they are coupled to the unreleased `ruststream-nats` 0.5 and, per #97, move out to the broker repo where they can be CI-compiled against the real client. The Redis templates (#98) are authored in `ruststream-fred` under the same system.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`, and the gated build with `RUN_SCAFFOLD_BUILD=1`)

## Related

- Part of #98 (the pin refresh; Redis content stays in `ruststream-fred`)
- First step of #97 Phase 1 (CI-compiled templates) for the core-owned `memory` template
