### PR TITLE
feat: optional broker labels surfaced as AsyncAPI servers

### DIFF
--- a/examples/asyncapi_http.rs
+++ b/examples/asyncapi_http.rs
@@ -37,16 +37,16 @@ async fn handle(order: &Order) -> HandlerResult {
 
 // --8<-- [start:server]
 fn service() -> RustStream {
-    // `MemoryBroker` has no network address, so its server is declared explicitly. A
-    // self-describing broker (the sibling NATS / Redis crates implement `DescribeServer`) is
-    // instead registered with `with_broker_labeled("production", broker, ...)`, which derives this
-    // server entry from the broker itself, with no separate `.server(..)` call.
-    RustStream::new(AppInfo::new("orders", "0.1.0"))
-        .server(
-            "production",
-            ruststream::ServerSpec::new("nats.example.com:4222", "nats"),
-        )
-        .with_broker(MemoryBroker::new(), |b| b.include(handle))
+    // `with_broker_labeled` records the broker under a label that is both its stable identity and
+    // its AsyncAPI server name, deriving the server entry from the broker's own `DescribeServer`
+    // spec - here the in-memory broker, which describes itself as an in-process "memory" server
+    // with no host. A broker without a `DescribeServer` impl is instead declared explicitly with
+    // `.server(name, spec)` alongside a plain `with_broker`.
+    RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker_labeled(
+        "in-process",
+        MemoryBroker::new(),
+        |b| b.include(handle),
+    )
 }
 // --8<-- [end:server]
 

--- a/examples/asyncapi_http.rs
+++ b/examples/asyncapi_http.rs
@@ -37,6 +37,10 @@ async fn handle(order: &Order) -> HandlerResult {
 
 // --8<-- [start:server]
 fn service() -> RustStream {
+    // `MemoryBroker` has no network address, so its server is declared explicitly. A
+    // self-describing broker (the sibling NATS / Redis crates implement `DescribeServer`) is
+    // instead registered with `with_broker_labeled("production", broker, ...)`, which derives this
+    // server entry from the broker itself, with no separate `.server(..)` call.
     RustStream::new(AppInfo::new("orders", "0.1.0"))
         .server(
             "production",

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -60,8 +60,10 @@ impl Spec {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct Server {
-    /// The host (and optional port), e.g. `"nats.example.com:4222"`.
-    pub host: String,
+    /// The host (and optional port), e.g. `"nats.example.com:4222"`. Absent for an in-process
+    /// broker with no network address (the in-memory broker).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
     /// The messaging protocol, e.g. `"nats"`.
     pub protocol: String,
     /// Optional human description.

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -144,9 +144,12 @@ pub trait Subscribe: Broker {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ServerSpec {
-    /// The host (and optional port) clients connect to, e.g. `"nats.example.com:4222"`.
-    pub host: String,
-    /// The messaging protocol, e.g. `"nats"`, `"kafka"`, `"amqp"`.
+    /// The host (and optional port) clients connect to, e.g. `"nats.example.com:4222"`. `None` for
+    /// an in-process broker with no network address (the in-memory broker), reachable only within
+    /// the running service; such a server carries no `host` in the `AsyncAPI` document.
+    pub host: Option<String>,
+    /// The messaging protocol, e.g. `"nats"`, `"kafka"`, `"amqp"`, or `"memory"` for the in-process
+    /// broker.
     pub protocol: String,
     /// An optional human description of this server.
     pub description: Option<String>,
@@ -157,7 +160,21 @@ impl ServerSpec {
     #[must_use]
     pub fn new(host: impl Into<String>, protocol: impl Into<String>) -> Self {
         Self {
-            host: host.into(),
+            host: Some(host.into()),
+            protocol: protocol.into(),
+            description: None,
+        }
+    }
+
+    /// Describes an in-process server with no network address (the in-memory broker), reachable only
+    /// within the running service.
+    ///
+    /// It still has a stable identity (its label / server name) so a multi-broker service can route
+    /// to and distinguish it, but the generated `AsyncAPI` server carries no `host`.
+    #[must_use]
+    pub fn in_process(protocol: impl Into<String>) -> Self {
+        Self {
+            host: None,
             protocol: protocol.into(),
             description: None,
         }
@@ -174,9 +191,11 @@ impl ServerSpec {
 /// A broker that describes itself as an `AsyncAPI` server.
 ///
 /// Broker crates implement this so their connection coordinates land in the generated `AsyncAPI`
-/// document; wire it onto a service with
-/// [`RustStream::server`](crate::runtime::RustStream::server). Brokers without a meaningful network
-/// address (the in-memory test broker) simply do not implement it.
+/// document and the broker carries a stable identity when registered with
+/// [`with_broker_labeled`](crate::runtime::RustStream::with_broker_labeled); it can also be wired on
+/// manually with [`RustStream::server`](crate::runtime::RustStream::server). A broker without a
+/// network address (the in-memory broker) describes itself with
+/// [`ServerSpec::in_process`], so it still gets a label / identity for multi-broker routing.
 ///
 /// # Examples
 ///

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -28,8 +28,8 @@ use std::{
 };
 
 use crate::{
-    AckError, Broker, Headers, IncomingMessage, OutgoingMessage, Publisher, RawMessage, Subscribe,
-    Subscriber, SubscriptionSource,
+    AckError, Broker, DescribeServer, Headers, IncomingMessage, OutgoingMessage, Publisher,
+    RawMessage, ServerSpec, Subscribe, Subscriber, SubscriptionSource,
 };
 use bytes::Bytes;
 use futures::Stream;
@@ -160,6 +160,17 @@ impl Broker for MemoryBroker {
             .expect("memory broker mutex poisoned")
             .clear();
         Ok(())
+    }
+}
+
+impl DescribeServer for MemoryBroker {
+    /// The in-memory broker has no network address, so it describes itself as an in-process server
+    /// over the `"memory"` protocol. Registered with
+    /// [`with_broker_labeled`](crate::runtime::RustStream::with_broker_labeled), the label is its
+    /// stable identity, letting a service mount several memory brokers with disjoint routing and
+    /// address each one by name.
+    fn describe_server(&self) -> ServerSpec {
+        ServerSpec::in_process("memory")
     }
 }
 

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -70,8 +70,16 @@ impl<L: Send, St: Send + Sync> RustStream<L, St> {
         let state = Arc::new(state);
 
         for broker in &brokers {
-            broker.connect().await.map_err(RustStreamError::Connect)?;
-            info!(target: "ruststream::lifecycle", broker = broker.name(), "broker connected");
+            broker
+                .lifecycle
+                .connect()
+                .await
+                .map_err(RustStreamError::Connect)?;
+            info!(
+                target: "ruststream::lifecycle",
+                broker = broker.label.as_deref().unwrap_or_else(|| broker.lifecycle.name()),
+                "broker connected",
+            );
         }
 
         let token = CancellationToken::new();
@@ -128,8 +136,16 @@ impl<L: Send, St: Send + Sync> RustStream<L, St> {
         drain_continuations(continuations, shutdown_timeout).await;
 
         for broker in brokers.iter().rev() {
-            broker.shutdown().await.map_err(RustStreamError::Shutdown)?;
-            debug!(target: "ruststream::lifecycle", broker = broker.name(), "broker shut down");
+            broker
+                .lifecycle
+                .shutdown()
+                .await
+                .map_err(RustStreamError::Shutdown)?;
+            debug!(
+                target: "ruststream::lifecycle",
+                broker = broker.label.as_deref().unwrap_or_else(|| broker.lifecycle.name()),
+                "broker shut down",
+            );
         }
 
         for hook in after_shutdown {

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::codec::Codec;
-use crate::{Broker, ServerSpec};
+use crate::{Broker, DescribeServer, ServerSpec};
 
 use tokio_util::task::TaskTracker;
 
@@ -60,7 +60,7 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 /// ```
 pub struct RustStream<L = Identity, St = ()> {
     pub(super) info: AppInfo,
-    pub(super) brokers: Vec<Arc<dyn BrokerLifecycle>>,
+    pub(super) brokers: Vec<RegisteredBroker>,
     pub(super) starters: Vec<Starter<St>>,
     pub(super) handlers: Vec<HandlerMetadata>,
     pub(super) servers: BTreeMap<String, ServerSpec>,
@@ -75,6 +75,16 @@ pub struct RustStream<L = Identity, St = ()> {
     /// [`Delivery`].
     pub(super) continuations: TaskTracker,
     pub(super) global: L,
+}
+
+/// A broker held by the app for lifecycle management, paired with its optional label.
+///
+/// The label is the broker's stable runtime identity and its `AsyncAPI` server name; it is `Some`
+/// for a broker registered through [`with_broker_labeled`](RustStream::with_broker_labeled) (or its
+/// codec variant) and `None` otherwise.
+pub(super) struct RegisteredBroker {
+    pub(super) lifecycle: Arc<dyn BrokerLifecycle>,
+    pub(super) label: Option<String>,
 }
 
 impl<L, St> std::fmt::Debug for RustStream<L, St> {
@@ -262,7 +272,10 @@ impl<L, St> RustStream<L, St> {
     where
         B: Broker + 'static,
     {
-        self.brokers.push(Arc::new(broker));
+        self.brokers.push(RegisteredBroker {
+            lifecycle: Arc::new(broker),
+            label: None,
+        });
         self
     }
 
@@ -271,6 +284,11 @@ impl<L, St> RustStream<L, St> {
     /// Build the [`ServerSpec`] directly, or get it from a broker that implements
     /// [`DescribeServer`](crate::DescribeServer): `app.server("nats", broker.describe_server())`.
     /// `build_spec` emits these in the document's `servers` section.
+    ///
+    /// For a self-describing broker, prefer
+    /// [`with_broker_labeled`](Self::with_broker_labeled), which derives this entry from the broker
+    /// under its label in one step. Use this method for brokers without a network address (the
+    /// in-memory broker), or to override a labeled broker's own spec.
     #[must_use]
     pub fn server(mut self, name: impl Into<String>, spec: ServerSpec) -> Self {
         self.servers.insert(name.into(), spec);
@@ -296,7 +314,7 @@ impl<L, St> RustStream<L, St> {
         let broker = Arc::new(broker);
         let mut scope = self.new_scope(&broker, ());
         build(&mut scope);
-        self.collect_scope(&broker, scope);
+        self.collect_scope(&broker, scope, None);
         self
     }
 
@@ -318,8 +336,103 @@ impl<L, St> RustStream<L, St> {
         let broker = Arc::new(broker);
         let mut scope = self.new_scope(&broker, codec);
         build(&mut scope);
-        self.collect_scope(&broker, scope);
+        self.collect_scope(&broker, scope, None);
         self
+    }
+
+    /// Registers a self-describing broker under `label`, along with the handlers attached to it.
+    ///
+    /// The `label` is the broker's stable identity in the service and the name of its `AsyncAPI`
+    /// server: the broker's [`describe_server`](DescribeServer::describe_server) coordinates are
+    /// recorded in the `servers` map under `label`, so the document stays in sync with the brokers
+    /// actually mounted, with no separate [`server`](Self::server) call. An explicit
+    /// [`server(label, spec)`](Self::server) entry for the same label takes precedence.
+    ///
+    /// Like [`with_broker`](Self::with_broker), the scope has no default codec; use
+    /// [`with_broker_labeled_codec`](Self::with_broker_labeled_codec) to set one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "memory")]
+    /// # async fn run() -> Result<(), ruststream::runtime::RustStreamError> {
+    /// use ruststream::runtime::{AppInfo, RustStream};
+    /// use ruststream::{Broker, DescribeServer, ServerSpec};
+    ///
+    /// # struct NatsBroker;
+    /// # impl NatsBroker { fn new(_: &str) -> Self { Self } }
+    /// # impl Broker for NatsBroker {
+    /// #     type Error = std::io::Error;
+    /// #     async fn connect(&self) -> Result<(), Self::Error> { Ok(()) }
+    /// #     async fn shutdown(&self) -> Result<(), Self::Error> { Ok(()) }
+    /// # }
+    /// # impl DescribeServer for NatsBroker {
+    /// #     fn describe_server(&self) -> ServerSpec { ServerSpec::new("nats:4222", "nats") }
+    /// # }
+    /// let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+    ///     .with_broker_labeled("ingress", NatsBroker::new("nats://localhost"), |_b| {});
+    /// // The AsyncAPI `servers` map now carries "ingress" with the broker's host / protocol.
+    /// app.run().await
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_broker_labeled<B, F>(
+        mut self,
+        label: impl Into<String>,
+        broker: B,
+        build: F,
+    ) -> Self
+    where
+        B: DescribeServer + 'static,
+        L: Clone,
+        St: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, L, (), St>),
+    {
+        let label = self.record_server(label, &broker);
+        let broker = Arc::new(broker);
+        let mut scope = self.new_scope(&broker, ());
+        build(&mut scope);
+        self.collect_scope(&broker, scope, Some(label));
+        self
+    }
+
+    /// Registers a self-describing broker under `label` with a default `codec`.
+    ///
+    /// Combines [`with_broker_labeled`](Self::with_broker_labeled) (the label is the broker's
+    /// identity and `AsyncAPI` server name) with
+    /// [`with_broker_codec`](Self::with_broker_codec) (macro handlers mount without repeating the
+    /// codec).
+    #[must_use]
+    pub fn with_broker_labeled_codec<B, C, F>(
+        mut self,
+        label: impl Into<String>,
+        broker: B,
+        codec: C,
+        build: F,
+    ) -> Self
+    where
+        B: DescribeServer + 'static,
+        C: Codec + Clone + 'static,
+        L: Clone,
+        St: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, L, C, St>),
+    {
+        let label = self.record_server(label, &broker);
+        let broker = Arc::new(broker);
+        let mut scope = self.new_scope(&broker, codec);
+        build(&mut scope);
+        self.collect_scope(&broker, scope, Some(label));
+        self
+    }
+
+    /// Records `broker`'s server coordinates under `label` (keeping an explicit
+    /// [`server`](Self::server) entry already set for the same label), returning the owned label.
+    fn record_server<B: DescribeServer>(&mut self, label: impl Into<String>, broker: &B) -> String {
+        let label = label.into();
+        self.servers
+            .entry(label.clone())
+            .or_insert_with(|| broker.describe_server());
+        label
     }
 
     /// Builds a fresh scope bound to `broker` carrying `codec` and the app's publishers / pipeline.
@@ -339,9 +452,14 @@ impl<L, St> RustStream<L, St> {
         }
     }
 
-    /// Drains a built scope's registrations into the app and holds the broker for lifecycle.
-    fn collect_scope<B, C>(&mut self, broker: &Arc<B>, scope: BrokerScope<B, L, C, St>)
-    where
+    /// Drains a built scope's registrations into the app and holds the broker for lifecycle,
+    /// recording `label` as the broker's stable runtime identity (`None` when unlabeled).
+    fn collect_scope<B, C>(
+        &mut self,
+        broker: &Arc<B>,
+        scope: BrokerScope<B, L, C, St>,
+        label: Option<String>,
+    ) where
         B: Broker + 'static,
         St: Send + Sync + 'static,
     {
@@ -359,7 +477,7 @@ impl<L, St> RustStream<L, St> {
             }));
             self.handlers.push(meta);
         }
-        self.brokers.push(lifecycle);
+        self.brokers.push(RegisteredBroker { lifecycle, label });
     }
 
     /// Returns metadata for every registered handler, in registration order. Input to the

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -68,6 +68,67 @@ fn build_spec_includes_servers_and_yaml() {
     assert!(yaml.contains("host: nats.example.com:4222"));
 }
 
+/// A self-describing broker: a labeled registration derives its `AsyncAPI` server from this.
+struct DescribingBroker {
+    host: String,
+}
+
+impl DescribingBroker {
+    fn new(host: impl Into<String>) -> Self {
+        Self { host: host.into() }
+    }
+}
+
+impl ruststream::Broker for DescribingBroker {
+    type Error = std::convert::Infallible;
+
+    async fn connect(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl ruststream::DescribeServer for DescribingBroker {
+    fn describe_server(&self) -> ServerSpec {
+        ServerSpec::new(self.host.clone(), "nats").with_description("ingress")
+    }
+}
+
+#[test]
+fn labeled_broker_populates_server_from_describe() {
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0")).with_broker_labeled(
+        "ingress",
+        DescribingBroker::new("nats.example.com:4222"),
+        |_b| {},
+    );
+
+    let spec = build_spec(&app);
+    let server = &spec.servers["ingress"];
+    assert_eq!(server.host, "nats.example.com:4222");
+    assert_eq!(server.protocol, "nats");
+    assert_eq!(server.description.as_deref(), Some("ingress"));
+}
+
+#[test]
+fn explicit_server_overrides_labeled_broker() {
+    // An explicit server set for the same label takes precedence over the broker's own spec.
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0"))
+        .server("ingress", ServerSpec::new("override:4222", "custom"))
+        .with_broker_labeled(
+            "ingress",
+            DescribingBroker::new("nats.example.com:4222"),
+            |_b| {},
+        );
+
+    let spec = build_spec(&app);
+    let server = &spec.servers["ingress"];
+    assert_eq!(server.host, "override:4222");
+    assert_eq!(server.protocol, "custom");
+}
+
 #[test]
 fn viewer_html_embeds_spec_url_and_cdn() {
     let html = render_viewer_html("/asyncapi.json", &ViewerOptions::default());

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -59,7 +59,7 @@ fn build_spec_includes_servers_and_yaml() {
 
     let spec = build_spec(&app);
     let server = &spec.servers["nats"];
-    assert_eq!(server.host, "nats.example.com:4222");
+    assert_eq!(server.host.as_deref(), Some("nats.example.com:4222"));
     assert_eq!(server.protocol, "nats");
     assert_eq!(server.description.as_deref(), Some("primary"));
 
@@ -107,9 +107,37 @@ fn labeled_broker_populates_server_from_describe() {
 
     let spec = build_spec(&app);
     let server = &spec.servers["ingress"];
-    assert_eq!(server.host, "nats.example.com:4222");
+    assert_eq!(server.host.as_deref(), Some("nats.example.com:4222"));
     assert_eq!(server.protocol, "nats");
     assert_eq!(server.description.as_deref(), Some("ingress"));
+}
+
+#[test]
+fn labeled_memory_broker_is_an_in_process_server() {
+    // The in-memory broker has no network address: a labeled registration still gives it a server
+    // entry (its label) over the "memory" protocol, with no host. This is what lets a service mount
+    // several memory brokers with disjoint routing and address each by name.
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0")).with_broker_labeled(
+        "local",
+        MemoryBroker::new(),
+        |b| {
+            let orders = b.broker().subscribe("orders");
+            b.handle(
+                orders,
+                |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
+                HandlerMetadata::raw("orders"),
+            );
+        },
+    );
+
+    let spec = build_spec(&app);
+    let server = &spec.servers["local"];
+    assert_eq!(server.host, None);
+    assert_eq!(server.protocol, "memory");
+
+    // A server with no host must not emit a `host` key in the document.
+    let json = spec.to_json().unwrap();
+    assert!(!json.contains("\"host\""));
 }
 
 #[test]
@@ -125,7 +153,7 @@ fn explicit_server_overrides_labeled_broker() {
 
     let spec = build_spec(&app);
     let server = &spec.servers["ingress"];
-    assert_eq!(server.host, "override:4222");
+    assert_eq!(server.host.as_deref(), Some("override:4222"));
     assert_eq!(server.protocol, "custom");
 }
 


### PR DESCRIPTION
# Description

Gives each broker registration an optional **label** that is both its stable runtime identity and
its AsyncAPI server name, so the `servers` section of the generated document is derived from the
brokers actually mounted instead of being hand-maintained in parallel with `with_broker`.

- A broker is now held as `RegisteredBroker { lifecycle, label }` (the label lives with its broker,
  not in a parallel vector).
- New `with_broker_labeled(label, broker, build)` and `with_broker_labeled_codec(..)` (require
  `B: DescribeServer`): record the label and auto-populate `servers[label]` from the broker's own
  `describe_server()`. An explicit `server(label, spec)` for the same label takes precedence.
- `ServerSpec.host` is now optional (`ServerSpec::in_process(protocol)`), and `MemoryBroker`
  implements `DescribeServer` as an in-process `"memory"` server with no host. So a memory broker
  can be labeled and carry a stable identity, letting a service mount several memory brokers with
  disjoint routing namespaces and address each one by label (the basis for unambiguous routing in
  the in-process test harness, #110). An in-process server emits no `host` key in the document.
- Startup / shutdown logs now report a broker by its label when present, falling back to the
  concrete type name.
- Backward compatible: unlabeled `with_broker` / `with_broker_codec` and manual `RustStream::server`
  are unchanged.

Prerequisite for the in-process test harness (#110), which addresses a specific broker by label.

Fixes #109

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
