### PR TITLE
feat: per-delivery context on the publish path + OpenTelemetry (#103)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ macros = ["dep:ruststream-macros"]
 asyncapi = ["json", "dep:schemars", "dep:serde_norway"]
 metrics = ["dep:prometheus"]
 logging = ["dep:tracing-subscriber"]
+opentelemetry = []
 cli = ["dep:clap", "dep:anyhow"]
 testing = ["dep:inventory", "tokio/test-util"]
 

--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -471,7 +471,7 @@ fn expand_publishing(
         input_schema,
         message_meta,
         ctx_param,
-        ctx_ty: _,
+        ctx_ty,
         state_ty,
         workers_method,
         failure_method,
@@ -514,6 +514,7 @@ fn expand_publishing(
         impl ::ruststream::runtime::PublishingDef for #name {
             type Input = #input_ty;
             type Reply = #reply_ty;
+            type Context = #ctx_ty;
             type Source = #source_ty;
 
             fn source(&self) -> Self::Source { #source_expr }
@@ -538,7 +539,7 @@ fn expand_publishing(
             async fn call(
                 &self,
                 #pat: &#input_ty,
-                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_in_ctx>,
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, #ctx_ty, #state_in_ctx>,
             ) -> ::core::result::Result<#reply_ty, ::ruststream::runtime::HandlerResult> {
                 #call_body
             }

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,0 +1,60 @@
+# OpenTelemetry
+
+The `opentelemetry` feature gives a service distributed tracing: a trace flows from an incoming
+message onto the replies it produces, so one trace spans the whole consume-transform-produce chain.
+It is built on the typed publish-path context - the same seam that lets a publish transform read the
+delivery that produced a reply.
+
+```toml
+ruststream = { version = "0.5", features = ["macros", "memory", "json", "opentelemetry"] }
+```
+
+It is dependency-light: it carries the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and
+emits `tracing` spans, leaving the export to a collector to your subscriber (for example
+[`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry)), exactly as the
+[logging](logging.md) guide leaves the subscriber to you. Propagation itself is broker-agnostic and
+works with no subscriber at all.
+
+## Wiring it up
+
+Create an `OpenTelemetry`, add its consume layer app-wide, and bake its propagation onto the reply
+publisher:
+
+```rust
+--8<-- "tests/opentelemetry.rs:wiring"
+```
+
+- `consume_layer()` is a consume-side [layer](middleware.md): per delivery it reads the incoming
+  `traceparent`, opens a `tracing` span for the handler, and records the *consumer's* span on the
+  working headers. It applies to handlers mounted directly and through a [router](routing.md).
+- `propagation()` is a static [publish layer](publishing.md): it copies the working `traceparent`
+  (and `tracestate`) onto every reply, so a downstream service sees the consumer span as the reply's
+  parent. Reuse it on a batch publisher with `for_batch(otel.propagation())`.
+
+## What gets propagated
+
+A delivery carrying `00-<trace-id>-<span-id>-01` continues that trace: the reply keeps the same
+`trace-id` and carries a fresh `span-id` (the consumer's span), so the trace is linked end to end. A
+delivery with no `traceparent` starts a fresh, sampled root trace. The spans are emitted under the
+`ruststream.consume` target with `trace_id` / `span_id` / `subscription` fields.
+
+## Reading the trace in a handler
+
+The consumer's trace context is on the working headers, so a handler reads it the same way any
+header is read - through the [context](context.md):
+
+<!-- inline-rust: one-line read of the working traceparent inside a handler; the full traced app, including this access, is compiled in tests/opentelemetry.rs and embedded above -->
+```rust
+let traceparent = ctx.headers().get_str("traceparent");
+```
+
+Parse it into a `TraceContext` (`TraceContext::parse`) to read the `trace_id` / `span_id` or to
+check whether the trace is `sampled()`.
+
+## Exporting to a collector
+
+This crate stops at the W3C context and `tracing` spans; turning those into OTLP and shipping them to
+a collector is the binary's job, the same split as [logging](logging.md). Add
+`tracing-opentelemetry` and an exporter in your binary, install it as a `tracing` subscriber, and the
+`ruststream.consume` spans flow through it. The propagation layer keeps the trace linked across every
+broker hop regardless of which exporter you choose.

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -79,17 +79,25 @@ pool or HTTP client (see [Lifespan](lifespan.md)).
 Two kinds of transform run before a message leaves the process, and they compose:
 
 - **Static `PublishLayer`** on a `TypedPublisher`, added with `.layer(..)`. Zero-cost,
-  per-destination transforms (an envelope, a fixed content type). They run first, closest to the
-  value.
-- **Dynamic publish middleware** on the application, added with `.publish_layer(..)`. Cross-cutting
-  concerns (publish metrics, a dead-letter wrapper) applied to every published message. They run
-  outside the static layers, then the message is sent.
+  per-destination transforms (an envelope, a fixed content type, or stamping the delivery's trace /
+  correlation id onto the reply). They run first, closest to the value.
+- **Static `PublishMiddleware`** on the application, added with `.publish_layer(..)`. Cross-cutting
+  concerns (publish metrics, a dead-letter wrapper) applied to every published message, around the
+  send so they can observe its result. The chain composes into a concrete type, mirroring the
+  consume-side stack: the default (no middleware) is a direct send. For a middleware set decided at
+  runtime, wrap it in a `PublishDynStack` (the publish counterpart of `DynStack`) and add that.
 
-A static `PublishLayer` implements `apply(&mut Outgoing<'_>)`:
+A static `PublishLayer` implements `apply(&mut Outgoing<'_>, &PublishContext<'_, C>)`; the
+`PublishContext` is a read-only view of the delivery that produced the reply (its channel, the
+incoming headers, and the broker's typed per-delivery context by `Field` key), so a layer can carry
+a value from the incoming message onto the reply:
 
 ```rust
 --8<-- "examples/publishing.rs:static_layer"
 ```
+
+A batch handler's replies skip the per-message `.layer(..)` stack; add a transform there with
+`.batch_layer(..)`, reusing a per-message `PublishLayer` via `for_batch(layer)`.
 
 A dynamic middleware implements `PublishMiddleware` with an around/next signature, so it can
 short-circuit, retry, or observe:

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -89,10 +89,10 @@ impl<C> PublishLayer<C> for EnvelopeLayer {
 struct AuditPublish;
 
 impl PublishMiddleware for AuditPublish {
-    fn on_publish<'a>(
+    fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a>,
+        next: PublishNext<'a, N>,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
     > {

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -77,8 +77,8 @@ async fn forward(event: &Event, ctx: &mut Context<'_, (), AppState>) -> HandlerR
 /// A static, per-publisher transform: stamps an envelope header on every outgoing message.
 struct EnvelopeLayer;
 
-impl PublishLayer for EnvelopeLayer {
-    fn apply(&self, out: &mut Outgoing<'_>) {
+impl<C> PublishLayer<C> for EnvelopeLayer {
+    fn apply(&self, out: &mut Outgoing<'_>, _cx: &ruststream::runtime::PublishContext<'_, C>) {
         out.headers_mut().insert("x-envelope", b"1".to_vec());
     }
 }

--- a/examples/routed_service/observability.rs
+++ b/examples/routed_service/observability.rs
@@ -60,8 +60,8 @@ impl<M: Send + Sync, C: Send, S: Send + Sync, H: Handler<M, C, S>> Handler<M, C,
 /// attaches it to the confirmations publisher, so every confirmation carries the header.
 pub(crate) struct StampSource;
 
-impl PublishLayer for StampSource {
-    fn apply(&self, out: &mut Outgoing<'_>) {
+impl<C> PublishLayer<C> for StampSource {
+    fn apply(&self, out: &mut Outgoing<'_>, _cx: &ruststream::runtime::PublishContext<'_, C>) {
         out.headers_mut()
             .insert("x-source-service", b"orders-service".to_vec());
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
   - Observability:
       - guides/logging.md
       - guides/metrics.md
+      - guides/opentelemetry.md
       - guides/asyncapi.md
   - Testing:
       - guides/testing.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,9 @@ pub mod metrics;
 #[cfg(feature = "logging")]
 pub mod logging;
 
+#[cfg(feature = "opentelemetry")]
+pub mod opentelemetry;
+
 /// Implementation detail used by the `#[subscriber]` macro to capture a payload's JSON Schema.
 ///
 /// Not part of the public API; no stability guarantees.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,7 @@ use prometheus::{
 
 use crate::runtime::{
     BlanketLayer, Context, Handler, HandlerResult, Layer, Outgoing, PublishMiddleware, PublishNext,
-    Settle,
+    PublishPipeline, Settle,
 };
 
 /// Default histogram buckets (seconds) for handler duration.
@@ -258,10 +258,10 @@ impl std::fmt::Debug for MetricsPublish {
 }
 
 impl PublishMiddleware for MetricsPublish {
-    fn on_publish<'a>(
+    fn on_publish<'a, N: PublishPipeline>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a>,
+        next: PublishNext<'a, N>,
     ) -> PublishFut<'a> {
         let name = out.name().to_owned();
         Box::pin(async move {

--- a/src/opentelemetry.rs
+++ b/src/opentelemetry.rs
@@ -1,0 +1,477 @@
+//! W3C Trace Context propagation and consumer spans (`opentelemetry` feature).
+//!
+//! Distributed tracing for a RustStream service, built on the publish-path context from the typed
+//! [`Context`](crate::runtime::Context) system: a trace / correlation id flows from an incoming
+//! message onto the replies it produces, so a trace spans the whole consume-transform-produce chain.
+//!
+//! Two pieces, wired like [`metrics`](crate::metrics):
+//!
+//! - [`OpenTelemetry::consume_layer`] - a consume-side [`Layer`] that, per delivery, reads the
+//!   incoming [W3C `traceparent`](https://www.w3.org/TR/trace-context/) header, opens a `tracing`
+//!   span for the handler, and stamps the *consumer's* span onto the working headers so a reply
+//!   published from that handler becomes its child.
+//! - [`OpenTelemetry::propagation`] - a static [`PublishLayer`] that copies the working
+//!   `traceparent` onto every reply. Reuse it on a batch publisher with
+//!   [`for_batch`](crate::runtime::for_batch).
+//!
+//! This module is dependency-light: it carries the W3C context and emits `tracing` spans, leaving
+//! the export to a collector to the binary's subscriber (for example `tracing-opentelemetry`),
+//! exactly as [`logging`](crate::logging) leaves the subscriber to the user. Propagation itself is
+//! broker-agnostic and works with no subscriber at all.
+//!
+//! # Examples
+//!
+//! ```
+//! # #[cfg(all(feature = "memory", feature = "json"))]
+//! # {
+//! use ruststream::memory::MemoryBroker;
+//! use ruststream::opentelemetry::OpenTelemetry;
+//! use ruststream::runtime::TypedPublisher;
+//!
+//! let otel = OpenTelemetry::new();
+//! let broker = MemoryBroker::new();
+//! // Replies carry the delivery's trace context.
+//! let publisher = TypedPublisher::new(broker.publisher()).layer(otel.propagation());
+//! # let _ = publisher;
+//! # }
+//! ```
+
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tracing::Instrument;
+
+use crate::runtime::{
+    BlanketLayer, Context, Handler, Layer, Outgoing, PublishContext, PublishLayer, Settle,
+};
+
+/// The HTTP header carrying the W3C trace context.
+const TRACEPARENT: &str = "traceparent";
+/// The HTTP header carrying vendor-specific trace state, propagated verbatim.
+const TRACESTATE: &str = "tracestate";
+
+/// A [W3C trace context](https://www.w3.org/TR/trace-context/): the `trace-id`, the current
+/// `span-id` (the `parent-id` field of the `traceparent` header), and the trace flags.
+///
+/// Parsed from and formatted to the `traceparent` header (`00-<trace-id>-<span-id>-<flags>`); the
+/// version is always `00`. A reply published from a handler carries the consumer's context, so a
+/// downstream service sees the consumer span as the reply's parent.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::opentelemetry::TraceContext;
+///
+/// let tc = TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+///     .expect("valid traceparent");
+/// assert!(tc.sampled());
+/// assert_eq!(
+///     tc.to_header(),
+///     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TraceContext {
+    trace_id: [u8; 16],
+    span_id: [u8; 8],
+    flags: u8,
+}
+
+impl TraceContext {
+    /// Starts a fresh, sampled trace with a new `trace-id` and `span-id`.
+    ///
+    /// Used when an incoming message carries no (valid) `traceparent`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let root = TraceContext::root();
+    /// assert!(root.sampled());
+    /// assert_eq!(root.to_header().len(), "00-".len() + 32 + 1 + 16 + 1 + 2);
+    /// ```
+    #[must_use]
+    pub fn root() -> Self {
+        let mut trace_id = [0u8; 16];
+        let mut span_id = [0u8; 8];
+        fill_random(&mut trace_id);
+        fill_random(&mut span_id);
+        Self {
+            trace_id,
+            span_id,
+            flags: 0x01,
+        }
+    }
+
+    /// The child of this context: the same trace, a fresh `span-id`. The consumer's own span.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let parent = TraceContext::root();
+    /// let child = parent.child();
+    /// assert_eq!(parent.trace_id(), child.trace_id());
+    /// assert_ne!(parent.span_id(), child.span_id());
+    /// ```
+    #[must_use]
+    pub fn child(&self) -> Self {
+        let mut span_id = [0u8; 8];
+        fill_random(&mut span_id);
+        Self {
+            trace_id: self.trace_id,
+            span_id,
+            flags: self.flags,
+        }
+    }
+
+    /// Parses a `traceparent` header value, or `None` if it is malformed or names the all-zero
+    /// (invalid) `trace-id` / `span-id`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// assert!(TraceContext::parse("not-a-traceparent").is_none());
+    /// assert!(
+    ///     TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_some()
+    /// );
+    /// ```
+    #[must_use]
+    pub fn parse(header: &str) -> Option<Self> {
+        let mut parts = header.split('-');
+        let version = parts.next()?;
+        let trace = parts.next()?;
+        let span = parts.next()?;
+        let flags = parts.next()?;
+        if parts.next().is_some() || version != "00" {
+            return None;
+        }
+        let mut trace_id = [0u8; 16];
+        let mut span_id = [0u8; 8];
+        read_hex(trace, &mut trace_id)?;
+        read_hex(span, &mut span_id)?;
+        if trace_id == [0u8; 16] || span_id == [0u8; 8] {
+            return None;
+        }
+        let mut flag_byte = [0u8; 1];
+        read_hex(flags, &mut flag_byte)?;
+        Some(Self {
+            trace_id,
+            span_id,
+            flags: flag_byte[0],
+        })
+    }
+
+    /// Formats this context as a `traceparent` header value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let header = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    /// assert_eq!(TraceContext::parse(header).unwrap().to_header(), header);
+    /// ```
+    #[must_use]
+    pub fn to_header(&self) -> String {
+        let mut out = String::with_capacity(55);
+        out.push_str("00-");
+        write_hex(&self.trace_id, &mut out);
+        out.push('-');
+        write_hex(&self.span_id, &mut out);
+        out.push('-');
+        write_hex(&[self.flags], &mut out);
+        out
+    }
+
+    /// The 16-byte `trace-id`, hex-encoded - the identity of the whole trace.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let tc = TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    ///     .unwrap();
+    /// assert_eq!(tc.trace_id(), "4bf92f3577b34da6a3ce929d0e0e4736");
+    /// ```
+    #[must_use]
+    pub fn trace_id(&self) -> String {
+        let mut out = String::with_capacity(32);
+        write_hex(&self.trace_id, &mut out);
+        out
+    }
+
+    /// The 8-byte `span-id`, hex-encoded - the identity of this span within the trace.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let tc = TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    ///     .unwrap();
+    /// assert_eq!(tc.span_id(), "00f067aa0ba902b7");
+    /// ```
+    #[must_use]
+    pub fn span_id(&self) -> String {
+        let mut out = String::with_capacity(16);
+        write_hex(&self.span_id, &mut out);
+        out
+    }
+
+    /// Whether the sampled flag (bit 0) is set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::TraceContext;
+    ///
+    /// let sampled = TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    ///     .unwrap();
+    /// assert!(sampled.sampled());
+    /// let off = TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
+    ///     .unwrap();
+    /// assert!(!off.sampled());
+    /// ```
+    #[must_use]
+    pub const fn sampled(&self) -> bool {
+        self.flags & 0x01 != 0
+    }
+}
+
+/// The OpenTelemetry tracing integration: hands out the consume-side span [`Layer`] and the
+/// publish-side propagation [`PublishLayer`].
+///
+/// Cheap to construct and clone (it holds no state); make one and reuse it across the app.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::opentelemetry::OpenTelemetry;
+///
+/// let otel = OpenTelemetry::new();
+/// let _consume = otel.consume_layer();
+/// let _publish = otel.propagation();
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenTelemetry;
+
+impl OpenTelemetry {
+    /// Creates the integration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::OpenTelemetry;
+    ///
+    /// let _otel = OpenTelemetry::new();
+    /// ```
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// The consume-side [`Layer`]: opens a span per delivery and stamps the consumer's trace context
+    /// onto the working headers. Add it with
+    /// [`RustStream::layer`](crate::runtime::RustStream::layer).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::OpenTelemetry;
+    ///
+    /// let _layer = OpenTelemetry::new().consume_layer();
+    /// ```
+    #[must_use]
+    pub const fn consume_layer(&self) -> OpenTelemetryLayer {
+        OpenTelemetryLayer
+    }
+
+    /// The publish-side [`PublishLayer`]: copies the delivery's `traceparent` onto every reply. Bake
+    /// it onto a [`TypedPublisher`](crate::runtime::TypedPublisher) with
+    /// [`layer`](crate::runtime::TypedPublisher::layer) (or, for a batch publisher, via
+    /// [`for_batch`](crate::runtime::for_batch)).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::opentelemetry::OpenTelemetry;
+    ///
+    /// let _propagation = OpenTelemetry::new().propagation();
+    /// ```
+    #[must_use]
+    pub const fn propagation(&self) -> TracePropagation {
+        TracePropagation
+    }
+}
+
+/// The consume-side [`Layer`] handed out by [`OpenTelemetry::consume_layer`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenTelemetryLayer;
+
+impl<H> Layer<H> for OpenTelemetryLayer {
+    type Handler = OpenTelemetryHandler<H>;
+
+    fn layer(&self, inner: H) -> Self::Handler {
+        OpenTelemetryHandler { inner }
+    }
+}
+
+// Lets the span layer ride the app-wide stack and reach handlers mounted through a router (whose
+// concrete types the router hides), the same way `MetricsLayer` does. The wrapped handler reads the
+// trace context off the typed `Context`, not the broker message, so it needs no `IncomingMessage`
+// bound and applies to any handler.
+impl BlanketLayer for OpenTelemetryLayer {
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
+    where
+        M: Send + Sync + 'static,
+        C: Send + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
+    {
+        self.layer(handler)
+    }
+}
+
+/// The handler produced by [`OpenTelemetryLayer::layer`]: opens a span and stamps the consumer's
+/// trace context onto the working headers before running the wrapped handler.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpenTelemetryHandler<H> {
+    inner: H,
+}
+
+impl<M, C, S, H> Handler<M, C, S> for OpenTelemetryHandler<H>
+where
+    M: Sync,
+    C: Send,
+    S: Send + Sync,
+    H: Handler<M, C, S>,
+{
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send {
+        // Continue the incoming trace (or start one), then publish the consumer's own span as the
+        // working `traceparent` so a reply from this handler becomes its child.
+        let consumer = ctx
+            .headers()
+            .get_str(TRACEPARENT)
+            .and_then(TraceContext::parse)
+            .map_or_else(TraceContext::root, |incoming| incoming.child());
+        let span = tracing::info_span!(
+            "ruststream.consume",
+            otel.kind = "consumer",
+            subscription = %ctx.name(),
+            trace_id = %consumer.trace_id(),
+            span_id = %consumer.span_id(),
+        );
+        ctx.headers_mut().insert(TRACEPARENT, consumer.to_header());
+        self.inner.handle(msg, ctx).instrument(span)
+    }
+}
+
+/// The publish-side [`PublishLayer`] handed out by [`OpenTelemetry::propagation`].
+///
+/// Copies the originating delivery's `traceparent` (and `tracestate`) onto the reply, so the trace
+/// continues across the publish. Generic over the handler context, so it mounts on any publisher.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TracePropagation;
+
+impl<C> PublishLayer<C> for TracePropagation {
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>) {
+        if let Some(traceparent) = cx.headers().get_str(TRACEPARENT) {
+            out.headers_mut()
+                .insert(TRACEPARENT, traceparent.as_bytes().to_vec());
+            if let Some(tracestate) = cx.headers().get_str(TRACESTATE) {
+                out.headers_mut()
+                    .insert(TRACESTATE, tracestate.as_bytes().to_vec());
+            }
+        }
+    }
+}
+
+/// Fills `buf` with unpredictable bytes for a fresh trace- or span-id.
+///
+/// Uses a per-process randomly seeded [`RandomState`] hashing a monotonic counter, so ids are
+/// well-distributed and unique within the process without pulling a random-number dependency (trace
+/// ids are identifiers, not secrets).
+fn fill_random(buf: &mut [u8]) {
+    static SEED: LazyLock<RandomState> = LazyLock::new(RandomState::new);
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    for chunk in buf.chunks_mut(8) {
+        let mut hasher = SEED.build_hasher();
+        hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
+        let bytes = hasher.finish().to_be_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+}
+
+/// Writes `bytes` as lowercase hex into `out`.
+fn write_hex(bytes: &[u8], out: &mut String) {
+    for &byte in bytes {
+        out.push(char::from_digit(u32::from(byte >> 4), 16).expect("nibble is < 16"));
+        out.push(char::from_digit(u32::from(byte & 0x0f), 16).expect("nibble is < 16"));
+    }
+}
+
+/// Reads `out.len()` bytes of lowercase / uppercase hex from `s` into `out`, or `None` on a length
+/// or digit mismatch.
+fn read_hex(s: &str, out: &mut [u8]) -> Option<()> {
+    if s.len() != out.len() * 2 {
+        return None;
+    }
+    for (index, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(s.get(index * 2..index * 2 + 2)?, 16).ok()?;
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_is_sampled_and_unique() {
+        let a = TraceContext::root();
+        let b = TraceContext::root();
+        assert!(a.sampled());
+        assert_ne!(a.trace_id(), b.trace_id());
+        assert_ne!(a.span_id(), b.span_id());
+    }
+
+    #[test]
+    fn child_keeps_trace_changes_span() {
+        let parent = TraceContext::root();
+        let child = parent.child();
+        assert_eq!(parent.trace_id(), child.trace_id());
+        assert_ne!(parent.span_id(), child.span_id());
+        assert_eq!(parent.sampled(), child.sampled());
+    }
+
+    #[test]
+    fn parse_rejects_malformed() {
+        assert!(TraceContext::parse("").is_none());
+        assert!(TraceContext::parse("00-tooshort-00f067aa0ba902b7-01").is_none());
+        // All-zero ids are invalid per the spec.
+        assert!(
+            TraceContext::parse("00-00000000000000000000000000000000-00f067aa0ba902b7-01")
+                .is_none()
+        );
+        // Unsupported version.
+        assert!(
+            TraceContext::parse("01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn round_trips_through_the_header() {
+        let header = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let parsed = TraceContext::parse(header).expect("valid");
+        assert_eq!(parsed.to_header(), header);
+    }
+}

--- a/src/runtime/app/include.rs
+++ b/src/runtime/app/include.rs
@@ -188,14 +188,19 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
+        D::Context: crate::BuildContext<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+            > + Send
+            + Sync
+            + 'static,
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
-        PL: PublishLayer + 'static,
+        PL: PublishLayer<D::Context> + 'static,
         St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
         L::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
-                (),
+                D::Context,
                 St,
             > + 'static,
     {
@@ -218,12 +223,14 @@ impl<B: Broker + 'static, L, St> BrokerScope<B, L, (), St> {
         D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
+        D::Context:
+            crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + Sync + 'static,
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
-        PL: PublishLayer + 'static,
+        PL: PublishLayer<D::Context> + 'static,
         St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, PC, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         let codec = publisher.codec().clone();
         self.mount_publishing(source, def, codec, publisher);
@@ -361,14 +368,19 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
+        D::Context: crate::BuildContext<
+                <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
+            > + Send
+            + Sync
+            + 'static,
         P: Publisher + 'static,
         PC: Codec + 'static,
-        PL: PublishLayer + 'static,
+        PL: PublishLayer<D::Context> + 'static,
         St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
         L::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
-                (),
+                D::Context,
                 St,
             > + 'static,
     {
@@ -391,12 +403,14 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St> BrokerScope<B, L, C
         D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
+        D::Context:
+            crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + Sync + 'static,
         P: Publisher + 'static,
         PC: Codec + 'static,
-        PL: PublishLayer + 'static,
+        PL: PublishLayer<D::Context> + 'static,
         St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         let codec = self.codec.clone();
         self.mount_publishing(source, def, codec, publisher);

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -16,7 +16,7 @@ use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{BlanketLayer, Identity, Layer};
-use crate::runtime::publish::{PublishLayer, PublishMiddleware, ReplyPublisher, TypedPublisher};
+use crate::runtime::publish::{PublishLayer, PublishPipeline, ReplyPublisher, TypedPublisher};
 use crate::runtime::publisher_registry::ErasedPublisher;
 use crate::runtime::publishing::{PublishingCall, PublishingHandler, publishing_metadata};
 use crate::runtime::router::{RouterDef, RouterSink};
@@ -33,7 +33,7 @@ use crate::runtime::typed::{Typed, typed};
 pub struct BrokerScope<B, L = Identity, C = (), St = ()> {
     pub(super) broker: Arc<B>,
     pub(super) sink: RouterSink<B, St>,
-    pub(super) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
+    pub(super) pipeline: Arc<dyn PublishPipeline>,
     pub(super) retry_publisher: Option<Arc<dyn ErasedPublisher>>,
     pub(super) global: L,
     pub(super) codec: C,

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -235,13 +235,15 @@ impl<B: Broker + 'static, L, SC, St> BrokerScope<B, L, SC, St> {
         D: PublishingCall<St> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
+        D::Context:
+            crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + Sync + 'static,
         C: Codec + 'static,
         P: Publisher + 'static,
         PC: Codec + 'static,
-        PL: PublishLayer + 'static,
+        PL: PublishLayer<D::Context> + 'static,
         St: Send + Sync + 'static,
         L: Layer<PublishingHandler<D, C, P, PC, PL>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, (), St> + 'static,
+        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
     {
         let meta = publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -13,7 +13,7 @@ use crate::runtime::dispatch::Delivery;
 use crate::runtime::lifecycle::{BoxError, BrokerLifecycle};
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{Identity, Stack};
-use crate::runtime::publish::PublishMiddleware;
+use crate::runtime::publish::{PublishCons, PublishEnd, PublishMiddleware, PublishPipeline};
 use crate::runtime::router::RouterSink;
 #[cfg(feature = "testing")]
 use crate::testing::coordinator::TestHooks;
@@ -66,7 +66,7 @@ pub struct RustStream<L = Identity, St = ()> {
     pub(super) starters: Vec<Starter<St>>,
     pub(super) handlers: Vec<HandlerMetadata>,
     pub(super) servers: BTreeMap<String, ServerSpec>,
-    pub(super) publish_layers: Vec<Arc<dyn PublishMiddleware>>,
+    pub(super) publish_pipeline: Arc<dyn PublishPipeline>,
     pub(super) state_init: StateInit<St>,
     pub(super) after_startup: Vec<LifecycleHook<St>>,
     pub(super) on_shutdown: Vec<LifecycleHook<St>>,
@@ -129,7 +129,7 @@ impl RustStream<Identity, ()> {
             starters: Vec::new(),
             handlers: Vec::new(),
             servers: BTreeMap::new(),
-            publish_layers: Vec::new(),
+            publish_pipeline: Arc::new(PublishEnd),
             state_init: Box::new(|| Box::pin(async { Ok(()) })),
             after_startup: Vec::new(),
             on_shutdown: Vec::new(),
@@ -155,7 +155,7 @@ impl<L, St> RustStream<L, St> {
             starters: self.starters,
             handlers: self.handlers,
             servers: self.servers,
-            publish_layers: self.publish_layers,
+            publish_pipeline: self.publish_pipeline,
             state_init: self.state_init,
             after_startup: self.after_startup,
             on_shutdown: self.on_shutdown,
@@ -195,7 +195,7 @@ impl<L, St> RustStream<L, St> {
             starters: Vec::new(),
             handlers: self.handlers,
             servers: self.servers,
-            publish_layers: self.publish_layers,
+            publish_pipeline: self.publish_pipeline,
             state_init: Box::new(move || {
                 Box::pin(async move {
                     let prev_state = prev().await?;
@@ -288,7 +288,11 @@ impl<L, St> RustStream<L, St> {
     where
         M: PublishMiddleware + 'static,
     {
-        self.publish_layers.push(Arc::new(middleware));
+        // Prepend `middleware` to the boxed tail: the chain stays statically composed inside the
+        // single `Arc<dyn PublishPipeline>` (no per-layer `dyn` dispatch), the first added runs
+        // outermost.
+        let tail = self.publish_pipeline;
+        self.publish_pipeline = Arc::new(PublishCons::new(middleware, tail));
         self
     }
 
@@ -472,7 +476,7 @@ impl<L, St> RustStream<L, St> {
         BrokerScope {
             broker: broker.clone(),
             sink: RouterSink::new(),
-            pipeline: self.publish_layers.iter().cloned().collect(),
+            pipeline: self.publish_pipeline.clone(),
             retry_publisher: None,
             global: self.global.clone(),
             codec,

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -21,7 +21,7 @@ use super::dispatch::Workers;
 use super::failure::{FailurePolicies, FailurePolicy};
 use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
-use super::publish::{PublishMiddleware, ReplyPublisher};
+use super::publish::{PublishContext, PublishMiddleware, ReplyPublisher};
 
 /// A batch subscriber definition that produces replies to publish.
 ///
@@ -161,9 +161,10 @@ where
         let outcome = match self.def.call(&values, ctx).await {
             Ok(replies) => {
                 let name = self.def.reply_name();
+                let pubcx = PublishContext::new(ctx.name(), ctx.headers(), ctx.cx_ref());
                 match self
                     .publisher
-                    .publish_batch(name, &replies, &self.pipeline)
+                    .publish_batch(name, &replies, &self.pipeline, &pubcx)
                     .await
                 {
                     Ok(()) => HandlerResult::Ack,

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -21,7 +21,7 @@ use super::dispatch::Workers;
 use super::failure::{FailurePolicies, FailurePolicy};
 use super::handler::HandlerResult;
 use super::metadata::HandlerMetadata;
-use super::publish::{PublishContext, PublishMiddleware, ReplyPublisher};
+use super::publish::{PublishContext, PublishPipeline, ReplyPublisher};
 
 /// A batch subscriber definition that produces replies to publish.
 ///
@@ -130,7 +130,7 @@ pub struct BatchPublishingHandler<D, C, R> {
     pub(crate) def: D,
     pub(crate) codec: C,
     pub(crate) publisher: R,
-    pub(crate) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
+    pub(crate) pipeline: Arc<dyn PublishPipeline>,
     pub(crate) decode: FailurePolicy,
 }
 
@@ -164,7 +164,7 @@ where
                 let pubcx = PublishContext::new(ctx.name(), ctx.headers(), ctx.cx_ref());
                 match self
                     .publisher
-                    .publish_batch(name, &replies, &self.pipeline, &pubcx)
+                    .publish_batch(name, &replies, &*self.pipeline, &pubcx)
                     .await
                 {
                     Ok(()) => HandlerResult::Ack,
@@ -261,7 +261,7 @@ mod tests {
             },
             codec: JsonCodec,
             publisher: TypedPublisher::with_codec(broker.publisher(), JsonCodec).transactional(),
-            pipeline: Arc::from([]),
+            pipeline: Arc::new(crate::runtime::PublishEnd),
             decode: FailurePolicy::Drop,
         };
 
@@ -299,7 +299,7 @@ mod tests {
             },
             codec: JsonCodec,
             publisher: TypedPublisher::with_codec(broker.publisher(), JsonCodec).transactional(),
-            pipeline: Arc::from([]),
+            pipeline: Arc::new(crate::runtime::PublishEnd),
             decode: FailurePolicy::Drop,
         };
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -224,6 +224,15 @@ impl<'a, C, S> Context<'a, C, S> {
         key.get(&self.cx)
     }
 
+    /// The broker's per-delivery context, borrowed for the publish path.
+    ///
+    /// A reply published from this handler carries the delivery's typed context to its static
+    /// [`PublishLayer`](super::PublishLayer) as a [`PublishContext`](super::PublishContext); this is
+    /// the accessor the runtime uses to build that read-only view.
+    pub(crate) fn cx_ref(&self) -> &C {
+        &self.cx
+    }
+
     /// Writes a per-delivery scratch value downstream handlers read by `key`.
     ///
     /// Middleware uses this to hand typed data to downstream handlers (an authenticated user, a

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,9 +36,9 @@ pub(crate) use lifecycle::BrokerLifecycle;
 pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    BatchIdentity, BatchPublishLayer, BatchPublishStack, ForBatch, Outgoing, PublishContext,
-    PublishIdentity, PublishLayer, PublishMiddleware, PublishNext, PublishStack, ReplyPublisher,
-    Transactional, TypedPublisher, for_batch,
+    BatchIdentity, BatchPublishLayer, BatchPublishStack, ForBatch, Outgoing, PublishCons,
+    PublishContext, PublishEnd, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext,
+    PublishPipeline, PublishStack, ReplyPublisher, Transactional, TypedPublisher, for_batch,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,8 +36,9 @@ pub(crate) use lifecycle::BrokerLifecycle;
 pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    Outgoing, PublishContext, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext,
-    PublishStack, ReplyPublisher, Transactional, TypedPublisher,
+    BatchIdentity, BatchPublishLayer, BatchPublishStack, ForBatch, Outgoing, PublishContext,
+    PublishIdentity, PublishLayer, PublishMiddleware, PublishNext, PublishStack, ReplyPublisher,
+    Transactional, TypedPublisher, for_batch,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,9 +36,10 @@ pub(crate) use lifecycle::BrokerLifecycle;
 pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    BatchIdentity, BatchPublishLayer, BatchPublishStack, ForBatch, Outgoing, PublishCons,
-    PublishContext, PublishEnd, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext,
-    PublishPipeline, PublishStack, ReplyPublisher, Transactional, TypedPublisher, for_batch,
+    BatchIdentity, BatchPublishLayer, BatchPublishStack, DynPublishMiddleware, ForBatch, Outgoing,
+    PublishCons, PublishContext, PublishDynNext, PublishDynStack, PublishEnd, PublishIdentity,
+    PublishLayer, PublishMiddleware, PublishNext, PublishPipeline, PublishStack, ReplyPublisher,
+    Transactional, TypedPublisher, for_batch,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,8 +36,8 @@ pub(crate) use lifecycle::BrokerLifecycle;
 pub use metadata::HandlerMetadata;
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    Outgoing, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext, PublishStack,
-    ReplyPublisher, Transactional, TypedPublisher,
+    Outgoing, PublishContext, PublishIdentity, PublishLayer, PublishMiddleware, PublishNext,
+    PublishStack, ReplyPublisher, Transactional, TypedPublisher,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -239,6 +239,88 @@ impl<C, Inner: PublishLayer<C>, Outer: PublishLayer<C>> PublishLayer<C>
     }
 }
 
+/// A static publish transform that runs only on a `#[subscriber(batch(..), publish(..))]` handler's
+/// replies, not on single-message replies.
+///
+/// The batch counterpart of [`PublishLayer`], kept a distinct trait so a transform that belongs to
+/// the batch path only (a header marking a reply as batched, a per-batch sampling decision) cannot
+/// be added with [`TypedPublisher::layer`] by mistake; it is added with
+/// [`TypedPublisher::batch_layer`], which the single-message mounts reject at compile time. The
+/// per-message [`PublishLayer`] stack does not run for batched replies and this one does not run for
+/// single-message replies - the two paths are independent. To use the same transform on both, add
+/// it to each, reusing it on the batch side with [`for_batch`] (no second implementation). Each
+/// reply in the batch is passed through it individually, reading the delivery through
+/// [`PublishContext`].
+pub trait BatchPublishLayer<C = ()>: Send + Sync {
+    /// Transforms one of the batch's outgoing replies before it is sent.
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>);
+}
+
+/// The no-op [`BatchPublishLayer`]: the default for a [`TypedPublisher`] with no batch transforms.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BatchIdentity;
+
+impl<C> BatchPublishLayer<C> for BatchIdentity {
+    fn apply(&self, _out: &mut Outgoing<'_>, _cx: &PublishContext<'_, C>) {}
+}
+
+/// Composes two [`BatchPublishLayer`]s: `inner` runs first, then `outer`. Built by
+/// [`TypedPublisher::batch_layer`]; you rarely name it directly.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BatchPublishStack<Inner, Outer> {
+    inner: Inner,
+    outer: Outer,
+}
+
+impl<C, Inner: BatchPublishLayer<C>, Outer: BatchPublishLayer<C>> BatchPublishLayer<C>
+    for BatchPublishStack<Inner, Outer>
+{
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>) {
+        self.inner.apply(out, cx);
+        self.outer.apply(out, cx);
+    }
+}
+
+/// Adapts a per-message [`PublishLayer`] into a [`BatchPublishLayer`], applying it to each reply of
+/// a batch. Built by [`for_batch`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForBatch<L>(L);
+
+impl<C, L: PublishLayer<C>> BatchPublishLayer<C> for ForBatch<L> {
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>) {
+        self.0.apply(out, cx);
+    }
+}
+
+/// Lifts a per-message [`PublishLayer`] onto the batch path so the same transform can be added with
+/// [`TypedPublisher::batch_layer`] without a second implementation.
+///
+/// ```
+/// # #[cfg(all(feature = "memory", feature = "json"))]
+/// # {
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::runtime::{for_batch, Outgoing, PublishContext, PublishLayer, TypedPublisher};
+///
+/// struct Stamp;
+/// impl<C> PublishLayer<C> for Stamp {
+///     fn apply(&self, out: &mut Outgoing<'_>, _cx: &PublishContext<'_, C>) {
+///         out.headers_mut().insert("x-stamp", b"1".to_vec());
+///     }
+/// }
+///
+/// let broker = MemoryBroker::new();
+/// // The same `Stamp` on both paths: per message, and batched.
+/// let publisher = TypedPublisher::new(broker.publisher())
+///     .layer(Stamp)
+///     .batch_layer(for_batch(Stamp));
+/// # let _ = publisher;
+/// # }
+/// ```
+#[must_use]
+pub fn for_batch<L>(layer: L) -> ForBatch<L> {
+    ForBatch(layer)
+}
+
 /// A byte [`Publisher`] paired with a [`Codec`] and a static [`PublishLayer`] stack, ready to send
 /// typed values.
 ///
@@ -263,13 +345,14 @@ impl<C, Inner: PublishLayer<C>, Outer: PublishLayer<C>> PublishLayer<C>
 /// ```
 ///
 /// [macro]: crate::subscriber
-pub struct TypedPublisher<P, C, PL = PublishIdentity> {
+pub struct TypedPublisher<P, C, PL = PublishIdentity, BL = BatchIdentity> {
     publisher: P,
     codec: C,
     layers: PL,
+    batch_layers: BL,
 }
 
-impl<P, C> TypedPublisher<P, C, PublishIdentity> {
+impl<P, C> TypedPublisher<P, C, PublishIdentity, BatchIdentity> {
     /// Pairs `publisher` with an explicit `codec` and no static transforms.
     #[must_use]
     pub fn with_codec(publisher: P, codec: C) -> Self {
@@ -277,12 +360,13 @@ impl<P, C> TypedPublisher<P, C, PublishIdentity> {
             publisher,
             codec,
             layers: PublishIdentity,
+            batch_layers: BatchIdentity,
         }
     }
 }
 
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
-impl<P> TypedPublisher<P, DefaultCodec, PublishIdentity> {
+impl<P> TypedPublisher<P, DefaultCodec, PublishIdentity, BatchIdentity> {
     /// Pairs `publisher` with the [`DefaultCodec`](DefaultCodec) and no static
     /// transforms. Use [`with_codec`](Self::with_codec) to name a codec explicitly.
     #[must_use]
@@ -291,22 +375,44 @@ impl<P> TypedPublisher<P, DefaultCodec, PublishIdentity> {
     }
 }
 
-impl<P, C, PL> TypedPublisher<P, C, PL> {
+impl<P, C, PL, BL> TypedPublisher<P, C, PL, BL> {
     /// The codec this publisher encodes replies with. Lets the runtime reuse it as the decode
     /// codec when a publishing handler is mounted without an explicit one.
     pub(crate) const fn codec(&self) -> &C {
         &self.codec
     }
 
-    /// Adds a static [`PublishLayer`], applied to every outgoing message from this publisher. The
-    /// first one added runs first (closest to the encoded value).
+    /// Adds a static [`PublishLayer`], applied to every single-message reply from this publisher
+    /// (a `#[subscriber(.., publish(..))]` handler). It does not run on the batch path; use
+    /// [`batch_layer`](Self::batch_layer) for that. The first one added runs first (closest to the
+    /// encoded value).
     #[must_use]
-    pub fn layer<N>(self, layer: N) -> TypedPublisher<P, C, PublishStack<PL, N>> {
+    pub fn layer<N>(self, layer: N) -> TypedPublisher<P, C, PublishStack<PL, N>, BL> {
         TypedPublisher {
             publisher: self.publisher,
             codec: self.codec,
             layers: PublishStack {
                 inner: self.layers,
+                outer: layer,
+            },
+            batch_layers: self.batch_layers,
+        }
+    }
+
+    /// Adds a static [`BatchPublishLayer`], applied to every reply of a
+    /// `#[subscriber(batch(..), publish(..))]` handler only (after the per-message
+    /// [`PublishLayer`] stack), never to a single-message reply. Wrap a per-message
+    /// [`PublishLayer`] with [`for_batch`] to reuse it here. The single-message mounts reject a
+    /// publisher carrying a non-trivial batch stack, so a batch-only transform cannot leak onto the
+    /// single path.
+    #[must_use]
+    pub fn batch_layer<N>(self, layer: N) -> TypedPublisher<P, C, PL, BatchPublishStack<BL, N>> {
+        TypedPublisher {
+            publisher: self.publisher,
+            codec: self.codec,
+            layers: self.layers,
+            batch_layers: BatchPublishStack {
+                inner: self.batch_layers,
                 outer: layer,
             },
         }
@@ -323,7 +429,7 @@ impl<P, C, PL> TypedPublisher<P, C, PL> {
     /// round-trips for no atomicity gain, so the single-message `include_publishing` forms keep
     /// taking a plain [`TypedPublisher`].
     #[must_use]
-    pub fn transactional(self) -> Transactional<P, C, PL>
+    pub fn transactional(self) -> Transactional<P, C, PL, BL>
     where
         P: TransactionalPublisher,
     {
@@ -331,7 +437,7 @@ impl<P, C, PL> TypedPublisher<P, C, PL> {
     }
 }
 
-impl<P: Publisher, C: Codec, PL> TypedPublisher<P, C, PL> {
+impl<P: Publisher, C: Codec, PL, BL> TypedPublisher<P, C, PL, BL> {
     /// Encodes `value`, applies the static transforms (reading the originating delivery through
     /// `cx`), then publishes to `name` through `pipeline`.
     pub(crate) async fn publish<T: Serialize + Sync, Cx>(
@@ -343,6 +449,7 @@ impl<P: Publisher, C: Codec, PL> TypedPublisher<P, C, PL> {
     ) -> Result<(), BoxError>
     where
         PL: PublishLayer<Cx>,
+        BL: Sync,
         Cx: Sync,
     {
         let payload = self
@@ -353,9 +460,34 @@ impl<P: Publisher, C: Codec, PL> TypedPublisher<P, C, PL> {
         self.layers.apply(&mut out, cx);
         run_publish(pipeline, &self.publisher, &mut out).await
     }
+
+    /// Like [`publish`](Self::publish), but applies the batch-only [`BatchPublishLayer`] stack
+    /// instead of the per-message [`PublishLayer`] one. Used per reply on the batch path: the
+    /// per-message transforms do not run for batched replies (a transform wanted on both paths is
+    /// added to each, reusing it on the batch side with [`for_batch`]).
+    pub(crate) async fn publish_batched<T: Serialize + Sync, Cx>(
+        &self,
+        name: &str,
+        value: &T,
+        pipeline: &[Arc<dyn PublishMiddleware>],
+        cx: &PublishContext<'_, Cx>,
+    ) -> Result<(), BoxError>
+    where
+        PL: Sync,
+        BL: BatchPublishLayer<Cx>,
+        Cx: Sync,
+    {
+        let payload = self
+            .codec
+            .encode(value)
+            .map_err(|e| Box::new(e) as BoxError)?;
+        let mut out = Outgoing::new(name, payload);
+        self.batch_layers.apply(&mut out, cx);
+        run_publish(pipeline, &self.publisher, &mut out).await
+    }
 }
 
-impl<P, C, PL> std::fmt::Debug for TypedPublisher<P, C, PL> {
+impl<P, C, PL, BL> std::fmt::Debug for TypedPublisher<P, C, PL, BL> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TypedPublisher").finish_non_exhaustive()
     }
@@ -367,11 +499,11 @@ impl<P, C, PL> std::fmt::Debug for TypedPublisher<P, C, PL> {
 /// `include_batch_publishing` mounts. Per batch, the runtime begins a transaction, publishes
 /// every reply, then commits before the incoming batch is acked; any failure aborts the
 /// transaction and the batch is retried, so replies are never half-visible.
-pub struct Transactional<P, C, PL = PublishIdentity> {
-    inner: TypedPublisher<P, C, PL>,
+pub struct Transactional<P, C, PL = PublishIdentity, BL = BatchIdentity> {
+    inner: TypedPublisher<P, C, PL, BL>,
 }
 
-impl<P, C, PL> std::fmt::Debug for Transactional<P, C, PL> {
+impl<P, C, PL, BL> std::fmt::Debug for Transactional<P, C, PL, BL> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Transactional").finish_non_exhaustive()
     }
@@ -382,8 +514,8 @@ mod sealed {
     /// two wirings above, not an extension point.
     pub trait Sealed {}
 
-    impl<P, C, PL> Sealed for super::TypedPublisher<P, C, PL> {}
-    impl<P, C, PL> Sealed for super::Transactional<P, C, PL> {}
+    impl<P, C, PL, BL> Sealed for super::TypedPublisher<P, C, PL, BL> {}
+    impl<P, C, PL, BL> Sealed for super::Transactional<P, C, PL, BL> {}
 }
 
 /// The reply wiring accepted by the `include_batch_publishing` mounts.
@@ -415,11 +547,12 @@ pub trait ReplyPublisher<Cx = ()>: Sealed + Send + Sync {
         T: Serialize + Sync;
 }
 
-impl<P, C, PL, Cx> ReplyPublisher<Cx> for TypedPublisher<P, C, PL>
+impl<P, C, PL, BL, Cx> ReplyPublisher<Cx> for TypedPublisher<P, C, PL, BL>
 where
     P: Publisher,
     C: Codec,
-    PL: PublishLayer<Cx>,
+    PL: Send + Sync,
+    BL: BatchPublishLayer<Cx>,
     Cx: Sync,
 {
     type Codec = C;
@@ -441,17 +574,18 @@ where
         T: Serialize + Sync,
     {
         for reply in replies {
-            self.publish(name, reply, pipeline, cx).await?;
+            self.publish_batched(name, reply, pipeline, cx).await?;
         }
         Ok(())
     }
 }
 
-impl<P, C, PL, Cx> ReplyPublisher<Cx> for Transactional<P, C, PL>
+impl<P, C, PL, BL, Cx> ReplyPublisher<Cx> for Transactional<P, C, PL, BL>
 where
     P: TransactionalPublisher,
     C: Codec,
-    PL: PublishLayer<Cx>,
+    PL: Send + Sync,
+    BL: BatchPublishLayer<Cx>,
     Cx: Sync,
 {
     type Codec = C;
@@ -478,7 +612,7 @@ where
             .await
             .map_err(|e| Box::new(e) as BoxError)?;
         for reply in replies {
-            if let Err(err) = self.inner.publish(name, reply, pipeline, cx).await {
+            if let Err(err) = self.inner.publish_batched(name, reply, pipeline, cx).await {
                 abort_quietly(publisher).await;
                 return Err(err);
             }

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -93,60 +93,117 @@ impl<'a> Outgoing<'a> {
     }
 }
 
+/// A static, app-wide publish pipeline: an around-style chain of [`PublishMiddleware`] ending in
+/// the broker send.
+///
+/// The publish-side analog of the consume-side static [`Stack`](super::Stack) / [`Identity`]: the
+/// app's publish middleware (added with
+/// [`RustStream::publish_layer`](super::RustStream::publish_layer)) compose into a concrete type, so
+/// the default path ([`PublishEnd`], no middleware) is a zero-cost direct send with no `dyn`
+/// dispatch. You rarely name this trait; it is built for you. (A runtime-composed escape hatch, the
+/// publish counterpart of [`DynStack`](super::DynStack), can be layered in later without changing
+/// this contract.)
+pub trait PublishPipeline: Send + Sync {
+    /// Runs `out` through the remaining middleware, then sends it via `send`.
+    fn run<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        send: &'a dyn ErasedPublisher,
+    ) -> PublishFut<'a>;
+}
+
+/// The terminal [`PublishPipeline`]: no middleware, just the broker send. The default for an app
+/// with no [`publish_layer`](super::RustStream::publish_layer).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PublishEnd;
+
+impl PublishPipeline for PublishEnd {
+    fn run<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        send: &'a dyn ErasedPublisher,
+    ) -> PublishFut<'a> {
+        send.publish_message(out.name(), out.payload(), out.headers())
+    }
+}
+
+// Lets the app store the composed chain boxed once behind a single indirection (the middleware
+// inside it stay statically composed) and lets each `publish_layer` prepend to that boxed tail.
+impl PublishPipeline for Arc<dyn PublishPipeline> {
+    fn run<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        send: &'a dyn ErasedPublisher,
+    ) -> PublishFut<'a> {
+        (**self).run(out, send)
+    }
+}
+
+/// Prepends a [`PublishMiddleware`] `Head` to a [`PublishPipeline`] `Tail`. Built by
+/// [`RustStream::publish_layer`](super::RustStream::publish_layer); you rarely name it directly.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PublishCons<Head, Tail> {
+    head: Head,
+    tail: Tail,
+}
+
+impl<Head, Tail> PublishCons<Head, Tail> {
+    /// Composes `head` in front of `tail`.
+    pub(crate) const fn new(head: Head, tail: Tail) -> Self {
+        Self { head, tail }
+    }
+}
+
+impl<Head: PublishMiddleware, Tail: PublishPipeline> PublishPipeline for PublishCons<Head, Tail> {
+    fn run<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        send: &'a dyn ErasedPublisher,
+    ) -> PublishFut<'a> {
+        self.head.on_publish(
+            out,
+            PublishNext {
+                tail: &self.tail,
+                send,
+            },
+        )
+    }
+}
+
 /// Middleware that transforms (or observes) an [`Outgoing`] message before it is published.
 ///
 /// Each middleware inspects / mutates `out`, then calls [`PublishNext::run`] to continue; the chain
-/// ends in the actual broker publish.
+/// ends in the actual broker publish. Static (no `dyn` dispatch): a middleware is generic over the
+/// rest of the pipeline `N`, so the whole chain monomorphizes. Added app-wide with
+/// [`RustStream::publish_layer`](super::RustStream::publish_layer).
 pub trait PublishMiddleware: Send + Sync {
     /// Handle the outgoing message, calling `next` to continue the pipeline.
-    fn on_publish<'a>(&'a self, out: &'a mut Outgoing<'a>, next: PublishNext<'a>)
-    -> PublishFut<'a>;
+    fn on_publish<'a, N: PublishPipeline>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishNext<'a, N>,
+    ) -> PublishFut<'a>;
 }
 
-/// A cursor over the remaining publish middleware, ending in the broker publisher.
-pub struct PublishNext<'a> {
-    rest: &'a [Arc<dyn PublishMiddleware>],
-    publisher: &'a dyn ErasedPublisher,
+/// A cursor over the rest of the publish pipeline, ending in the broker send. Handed to a
+/// [`PublishMiddleware`]; call [`run`](Self::run) to continue.
+pub struct PublishNext<'a, N> {
+    tail: &'a N,
+    send: &'a dyn ErasedPublisher,
 }
 
-impl<'a> PublishNext<'a> {
-    /// Runs the next middleware, or sends the message if the pipeline is exhausted.
+impl<'a, N: PublishPipeline> PublishNext<'a, N> {
+    /// Runs the rest of the pipeline (the remaining middleware, then the send).
     #[must_use]
     pub fn run(self, out: &'a mut Outgoing<'a>) -> PublishFut<'a> {
-        match self.rest.split_first() {
-            Some((middleware, rest)) => middleware.on_publish(
-                out,
-                PublishNext {
-                    rest,
-                    publisher: self.publisher,
-                },
-            ),
-            None => self
-                .publisher
-                .publish_message(out.name(), out.payload(), out.headers()),
-        }
+        self.tail.run(out, self.send)
     }
 }
 
-impl std::fmt::Debug for PublishNext<'_> {
+impl<N> std::fmt::Debug for PublishNext<'_, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PublishNext")
-            .field("remaining", &self.rest.len())
-            .finish_non_exhaustive()
+        f.debug_struct("PublishNext").finish_non_exhaustive()
     }
-}
-
-/// Runs `out` through `pipeline`, then publishes it via `publisher`.
-pub(crate) fn run_publish<'a>(
-    pipeline: &'a [Arc<dyn PublishMiddleware>],
-    publisher: &'a dyn ErasedPublisher,
-    out: &'a mut Outgoing<'a>,
-) -> PublishFut<'a> {
-    PublishNext {
-        rest: pipeline,
-        publisher,
-    }
-    .run(out)
 }
 
 /// A read-only view of the originating delivery, handed to a [`PublishLayer`].
@@ -444,7 +501,7 @@ impl<P: Publisher, C: Codec, PL, BL> TypedPublisher<P, C, PL, BL> {
         &self,
         name: &str,
         value: &T,
-        pipeline: &[Arc<dyn PublishMiddleware>],
+        pipeline: &dyn PublishPipeline,
         cx: &PublishContext<'_, Cx>,
     ) -> Result<(), BoxError>
     where
@@ -458,7 +515,7 @@ impl<P: Publisher, C: Codec, PL, BL> TypedPublisher<P, C, PL, BL> {
             .map_err(|e| Box::new(e) as BoxError)?;
         let mut out = Outgoing::new(name, payload);
         self.layers.apply(&mut out, cx);
-        run_publish(pipeline, &self.publisher, &mut out).await
+        pipeline.run(&mut out, &self.publisher).await
     }
 
     /// Like [`publish`](Self::publish), but applies the batch-only [`BatchPublishLayer`] stack
@@ -469,7 +526,7 @@ impl<P: Publisher, C: Codec, PL, BL> TypedPublisher<P, C, PL, BL> {
         &self,
         name: &str,
         value: &T,
-        pipeline: &[Arc<dyn PublishMiddleware>],
+        pipeline: &dyn PublishPipeline,
         cx: &PublishContext<'_, Cx>,
     ) -> Result<(), BoxError>
     where
@@ -483,7 +540,7 @@ impl<P: Publisher, C: Codec, PL, BL> TypedPublisher<P, C, PL, BL> {
             .map_err(|e| Box::new(e) as BoxError)?;
         let mut out = Outgoing::new(name, payload);
         self.batch_layers.apply(&mut out, cx);
-        run_publish(pipeline, &self.publisher, &mut out).await
+        pipeline.run(&mut out, &self.publisher).await
     }
 }
 
@@ -540,7 +597,7 @@ pub trait ReplyPublisher<Cx = ()>: Sealed + Send + Sync {
         &'a self,
         name: &'a str,
         replies: &'a [T],
-        pipeline: &'a [Arc<dyn PublishMiddleware>],
+        pipeline: &'a dyn PublishPipeline,
         cx: &'a PublishContext<'a, Cx>,
     ) -> impl Future<Output = Result<(), BoxError>> + Send
     where
@@ -567,7 +624,7 @@ where
         &'a self,
         name: &'a str,
         replies: &'a [T],
-        pipeline: &'a [Arc<dyn PublishMiddleware>],
+        pipeline: &'a dyn PublishPipeline,
         cx: &'a PublishContext<'a, Cx>,
     ) -> Result<(), BoxError>
     where
@@ -600,7 +657,7 @@ where
         &'a self,
         name: &'a str,
         replies: &'a [T],
-        pipeline: &'a [Arc<dyn PublishMiddleware>],
+        pipeline: &'a dyn PublishPipeline,
         cx: &'a PublishContext<'a, Cx>,
     ) -> Result<(), BoxError>
     where

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -206,6 +206,120 @@ impl<N> std::fmt::Debug for PublishNext<'_, N> {
     }
 }
 
+/// An object-safe publish middleware, for a [`PublishDynStack`].
+///
+/// The dynamic counterpart of [`PublishMiddleware`]: it cannot name the rest of the pipeline as a
+/// type parameter (that is what keeps it object-safe and lets a heterogeneous, runtime-built list
+/// live in one [`PublishDynStack`]), so it continues through the type-erased [`PublishDynNext`]
+/// instead. Use it only when the middleware set is decided at runtime; otherwise a static
+/// [`PublishMiddleware`] is zero-cost.
+pub trait DynPublishMiddleware: Send + Sync {
+    /// Handle the outgoing message, calling `next` to continue.
+    fn on_publish<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishDynNext<'a>,
+    ) -> PublishFut<'a>;
+}
+
+/// A cursor over the rest of a [`PublishDynStack`], ending in the surrounding static pipeline.
+///
+/// Mirrors [`PublishNext`] for the dynamic list: [`run`](Self::run) advances to the next
+/// [`DynPublishMiddleware`], or hands control back to the static chain once the list is exhausted.
+pub struct PublishDynNext<'a> {
+    rest: &'a [Arc<dyn DynPublishMiddleware>],
+    // The surrounding static `PublishNext::run`, erased so this cursor need not carry its type. A
+    // one-shot continuation: `run` is called exactly once per published message.
+    tail: Box<dyn FnOnce(&'a mut Outgoing<'a>) -> PublishFut<'a> + Send + 'a>,
+}
+
+impl<'a> PublishDynNext<'a> {
+    /// Runs the next dynamic middleware, or the surrounding static pipeline if the list is done.
+    #[must_use]
+    pub fn run(self, out: &'a mut Outgoing<'a>) -> PublishFut<'a> {
+        match self.rest.split_first() {
+            Some((middleware, rest)) => middleware.on_publish(
+                out,
+                PublishDynNext {
+                    rest,
+                    tail: self.tail,
+                },
+            ),
+            None => (self.tail)(out),
+        }
+    }
+}
+
+impl std::fmt::Debug for PublishDynNext<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublishDynNext")
+            .field("remaining", &self.rest.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A single static [`PublishMiddleware`] wrapping a runtime-built, frozen list of
+/// [`DynPublishMiddleware`].
+///
+/// The publish-side counterpart of the consume-side [`DynStack`](super::DynStack): the opt-in
+/// escape hatch for a middleware set decided at runtime (from config, a loop, feature flags) that
+/// therefore cannot be a compile-time [`publish_layer`](super::RustStream::publish_layer) chain.
+/// Add it like any other middleware; only the middleware inside it pay one boxed future per layer.
+///
+/// ```
+/// # #[cfg(all(feature = "memory", feature = "json"))]
+/// # {
+/// use std::sync::Arc;
+/// use ruststream::runtime::{DynPublishMiddleware, PublishDynStack};
+///
+/// fn stack(
+///     middleware: Vec<Arc<dyn DynPublishMiddleware>>,
+/// ) -> PublishDynStack {
+///     PublishDynStack::new(middleware)
+/// }
+/// # }
+/// ```
+pub struct PublishDynStack(Arc<[Arc<dyn DynPublishMiddleware>]>);
+
+// Manual `Clone`: the field is an `Arc`, so a clone is a refcount bump regardless of the contents.
+impl Clone for PublishDynStack {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl PublishDynStack {
+    /// Builds a stack from a list of middleware, applied in iteration order (first runs outermost).
+    #[must_use]
+    pub fn new(middleware: impl IntoIterator<Item = Arc<dyn DynPublishMiddleware>>) -> Self {
+        Self(middleware.into_iter().collect())
+    }
+}
+
+impl std::fmt::Debug for PublishDynStack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublishDynStack")
+            .field("middleware", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PublishMiddleware for PublishDynStack {
+    fn on_publish<'a, N: PublishPipeline>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishNext<'a, N>,
+    ) -> PublishFut<'a> {
+        // Erase the static continuation into a one-shot closure so the object-safe walker can end
+        // by handing control back to the surrounding static pipeline.
+        PublishDynNext {
+            rest: &self.0,
+            tail: Box::new(move |out| next.run(out)),
+        }
+        .run(out)
+    }
+}
+
 /// A read-only view of the originating delivery, handed to a [`PublishLayer`].
 ///
 /// A reply is published from inside a handler, so the static publish transform can read the

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -149,26 +149,77 @@ pub(crate) fn run_publish<'a>(
     .run(out)
 }
 
-/// A static, compile-time publish transform: mutates an [`Outgoing`] before it is sent.
+/// A read-only view of the originating delivery, handed to a [`PublishLayer`].
+///
+/// A reply is published from inside a handler, so the static publish transform can read the
+/// delivery that produced it: its channel [`name`](Self::name), the incoming
+/// [`headers`](Self::headers) (a W3C `traceparent`, a correlation id), and the broker's typed
+/// per-delivery [`context`](Self::context) by [`Field`] key. This is how a trace / correlation id
+/// propagates from the incoming message onto the reply (the static, zero-cost path; the dynamic
+/// [`PublishMiddleware`] stays context-agnostic, like a [`DynStack`](super::DynStack)). `C` is the
+/// handler's context type (`()` when it names none).
+pub struct PublishContext<'a, C = ()> {
+    name: &'a str,
+    headers: &'a Headers,
+    cx: &'a C,
+}
+
+impl<'a, C> PublishContext<'a, C> {
+    /// Builds the view from the parts the runtime already holds at publish time.
+    pub(crate) fn new(name: &'a str, headers: &'a Headers, cx: &'a C) -> Self {
+        Self { name, headers, cx }
+    }
+
+    /// The channel the originating message was delivered on.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    /// The originating message's headers (the working copy the handler saw).
+    #[must_use]
+    pub fn headers(&self) -> &Headers {
+        self.headers
+    }
+
+    /// Reads a broker-supplied per-delivery field off the typed context by compile-time `key`,
+    /// mirroring [`Context::context`](super::Context::context).
+    pub fn context<K: crate::Field<C>>(&self, key: K) -> K::Value<'_> {
+        key.get(self.cx)
+    }
+}
+
+impl<C> std::fmt::Debug for PublishContext<'_, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublishContext")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A static, compile-time publish transform: mutates an [`Outgoing`] before it is sent, with
+/// read access to the originating delivery through [`PublishContext`].
 ///
 /// The publish-side counterpart to the consume-side [`Layer`](super::Layer): zero-cost composition,
 /// no `dyn` dispatch. Baked onto a [`TypedPublisher`] with [`TypedPublisher::layer`]. Use for
 /// per-destination transforms that belong to the publisher itself - a Confluent / Avro envelope, a
-/// fixed content-type header. For cross-cutting *observation* across every publish (metrics), use
-/// the dynamic [`PublishMiddleware`] via
+/// fixed content-type header, or stamping the delivery's trace / correlation id onto the reply
+/// (read it from `cx`). The `C` parameter is the originating handler's context type; a layer that
+/// ignores the context is generic over it (mounts on any handler). For cross-cutting *observation*
+/// across every publish (metrics), use the dynamic [`PublishMiddleware`] via
 /// [`RustStream::publish_layer`](super::RustStream::publish_layer) instead; the static transforms
 /// run first (closest to the value), then the dynamic pipeline, then the send.
-pub trait PublishLayer: Send + Sync {
-    /// Transforms `out` in place before it is sent.
-    fn apply(&self, out: &mut Outgoing<'_>);
+pub trait PublishLayer<C = ()>: Send + Sync {
+    /// Transforms `out` in place before it is sent, reading the delivery through `cx`.
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>);
 }
 
 /// The no-op [`PublishLayer`]: the default for a [`TypedPublisher`] with no static transforms.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PublishIdentity;
 
-impl PublishLayer for PublishIdentity {
-    fn apply(&self, _out: &mut Outgoing<'_>) {}
+impl<C> PublishLayer<C> for PublishIdentity {
+    fn apply(&self, _out: &mut Outgoing<'_>, _cx: &PublishContext<'_, C>) {}
 }
 
 /// Composes two [`PublishLayer`]s: `inner` runs first, then `outer`. Built by
@@ -179,10 +230,12 @@ pub struct PublishStack<Inner, Outer> {
     outer: Outer,
 }
 
-impl<Inner: PublishLayer, Outer: PublishLayer> PublishLayer for PublishStack<Inner, Outer> {
-    fn apply(&self, out: &mut Outgoing<'_>) {
-        self.inner.apply(out);
-        self.outer.apply(out);
+impl<C, Inner: PublishLayer<C>, Outer: PublishLayer<C>> PublishLayer<C>
+    for PublishStack<Inner, Outer>
+{
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>) {
+        self.inner.apply(out, cx);
+        self.outer.apply(out, cx);
     }
 }
 
@@ -278,20 +331,26 @@ impl<P, C, PL> TypedPublisher<P, C, PL> {
     }
 }
 
-impl<P: Publisher, C: Codec, PL: PublishLayer> TypedPublisher<P, C, PL> {
-    /// Encodes `value`, applies the static transforms, then publishes to `name` through `pipeline`.
-    pub(crate) async fn publish<T: Serialize + Sync>(
+impl<P: Publisher, C: Codec, PL> TypedPublisher<P, C, PL> {
+    /// Encodes `value`, applies the static transforms (reading the originating delivery through
+    /// `cx`), then publishes to `name` through `pipeline`.
+    pub(crate) async fn publish<T: Serialize + Sync, Cx>(
         &self,
         name: &str,
         value: &T,
         pipeline: &[Arc<dyn PublishMiddleware>],
-    ) -> Result<(), BoxError> {
+        cx: &PublishContext<'_, Cx>,
+    ) -> Result<(), BoxError>
+    where
+        PL: PublishLayer<Cx>,
+        Cx: Sync,
+    {
         let payload = self
             .codec
             .encode(value)
             .map_err(|e| Box::new(e) as BoxError)?;
         let mut out = Outgoing::new(name, payload);
-        self.layers.apply(&mut out);
+        self.layers.apply(&mut out, cx);
         run_publish(pipeline, &self.publisher, &mut out).await
     }
 }
@@ -331,8 +390,9 @@ mod sealed {
 ///
 /// Implemented by a plain [`TypedPublisher`] (each reply published independently) and by a
 /// [`Transactional`] one (all replies of a batch inside one transaction). Sealed: implemented by
-/// exactly those two types.
-pub trait ReplyPublisher: Sealed + Send + Sync {
+/// exactly those two types. `Cx` is the originating batch handler's context type, threaded so the
+/// static [`PublishLayer`] reads the delivery while publishing each reply.
+pub trait ReplyPublisher<Cx = ()>: Sealed + Send + Sync {
     /// The codec replies are encoded with (also reused as the decode codec when a batch
     /// publishing handler is mounted without an explicit one).
     type Codec: Codec;
@@ -341,23 +401,26 @@ pub trait ReplyPublisher: Sealed + Send + Sync {
     #[doc(hidden)]
     fn reply_codec(&self) -> &Self::Codec;
 
-    /// Publishes one batch's replies to `name` through `pipeline`.
+    /// Publishes one batch's replies to `name` through `pipeline`, reading the originating
+    /// delivery through `cx`.
     #[doc(hidden)]
     fn publish_batch<'a, T>(
         &'a self,
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        cx: &'a PublishContext<'a, Cx>,
     ) -> impl Future<Output = Result<(), BoxError>> + Send
     where
         T: Serialize + Sync;
 }
 
-impl<P, C, PL> ReplyPublisher for TypedPublisher<P, C, PL>
+impl<P, C, PL, Cx> ReplyPublisher<Cx> for TypedPublisher<P, C, PL>
 where
     P: Publisher,
     C: Codec,
-    PL: PublishLayer,
+    PL: PublishLayer<Cx>,
+    Cx: Sync,
 {
     type Codec = C;
 
@@ -372,22 +435,24 @@ where
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        cx: &'a PublishContext<'a, Cx>,
     ) -> Result<(), BoxError>
     where
         T: Serialize + Sync,
     {
         for reply in replies {
-            self.publish(name, reply, pipeline).await?;
+            self.publish(name, reply, pipeline, cx).await?;
         }
         Ok(())
     }
 }
 
-impl<P, C, PL> ReplyPublisher for Transactional<P, C, PL>
+impl<P, C, PL, Cx> ReplyPublisher<Cx> for Transactional<P, C, PL>
 where
     P: TransactionalPublisher,
     C: Codec,
-    PL: PublishLayer,
+    PL: PublishLayer<Cx>,
+    Cx: Sync,
 {
     type Codec = C;
 
@@ -402,6 +467,7 @@ where
         name: &'a str,
         replies: &'a [T],
         pipeline: &'a [Arc<dyn PublishMiddleware>],
+        cx: &'a PublishContext<'a, Cx>,
     ) -> Result<(), BoxError>
     where
         T: Serialize + Sync,
@@ -412,7 +478,7 @@ where
             .await
             .map_err(|e| Box::new(e) as BoxError)?;
         for reply in replies {
-            if let Err(err) = self.inner.publish(name, reply, pipeline).await {
+            if let Err(err) = self.inner.publish(name, reply, pipeline, cx).await {
                 abort_quietly(publisher).await;
                 return Err(err);
             }

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -18,7 +18,7 @@ use super::dispatch::Workers;
 use super::failure::{FailurePolicies, FailurePolicy};
 use super::handler::{Handler, HandlerResult, Settle};
 use super::metadata::HandlerMetadata;
-use super::publish::{PublishContext, PublishLayer, PublishMiddleware, TypedPublisher};
+use super::publish::{PublishContext, PublishLayer, PublishPipeline, TypedPublisher};
 
 /// A subscriber definition that produces a reply to publish.
 ///
@@ -128,7 +128,7 @@ pub struct PublishingHandler<D, C, P, PC, PL> {
     pub(crate) def: D,
     pub(crate) codec: C,
     pub(crate) publisher: TypedPublisher<P, PC, PL>,
-    pub(crate) pipeline: Arc<[Arc<dyn PublishMiddleware>]>,
+    pub(crate) pipeline: Arc<dyn PublishPipeline>,
     pub(crate) decode: FailurePolicy,
 }
 
@@ -184,7 +184,9 @@ where
         };
         let name = self.def.reply_name();
         let pubcx = PublishContext::new(ctx.name(), ctx.headers(), ctx.cx_ref());
-        let publish = self.publisher.publish(name, &reply, &self.pipeline, &pubcx);
+        let publish = self
+            .publisher
+            .publish(name, &reply, &*self.pipeline, &pubcx);
         if let Err(err) = publish.await {
             warn!(
                 target: "ruststream::dispatch",

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -18,7 +18,7 @@ use super::dispatch::Workers;
 use super::failure::{FailurePolicies, FailurePolicy};
 use super::handler::{Handler, HandlerResult, Settle};
 use super::metadata::HandlerMetadata;
-use super::publish::{PublishLayer, PublishMiddleware, TypedPublisher};
+use super::publish::{PublishContext, PublishLayer, PublishMiddleware, TypedPublisher};
 
 /// A subscriber definition that produces a reply to publish.
 ///
@@ -31,6 +31,13 @@ pub trait PublishingDef: Send + Sync {
 
     /// The reply type the handler produces, encoded and published.
     type Reply;
+
+    /// The broker's typed per-delivery context the handler reads by key, mirroring
+    /// [`SubscriberDef::Context`](super::SubscriberDef::Context) (`()` when the handler names
+    /// none). It is threaded onto the reply's static
+    /// [`PublishLayer`](super::PublishLayer) so a publish transform can stamp the delivery's trace
+    /// or correlation id on the reply.
+    type Context;
 
     /// The subscription source this handler binds to (see
     /// [`SubscriberDef::Source`](super::SubscriberDef::Source)).
@@ -94,7 +101,7 @@ pub trait PublishingCall<S>: PublishingDef {
     fn call(
         &self,
         input: &Self::Input,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, Self::Context, S>,
     ) -> impl Future<Output = Result<Self::Reply, HandlerResult>> + Send;
 }
 
@@ -133,19 +140,20 @@ impl<D, C, P, PC, PL> std::fmt::Debug for PublishingHandler<D, C, P, PC, PL> {
     }
 }
 
-impl<M, D, C, P, PC, PL, S> Handler<M, (), S> for PublishingHandler<D, C, P, PC, PL>
+impl<M, D, C, P, PC, PL, S> Handler<M, D::Context, S> for PublishingHandler<D, C, P, PC, PL>
 where
     M: IncomingMessage,
     D: PublishingCall<S>,
     D::Input: DeserializeOwned + Send + Sync,
     D::Reply: Serialize + Send + Sync,
+    D::Context: Send + Sync,
     C: Codec,
     P: Publisher,
     PC: Codec,
-    PL: PublishLayer,
+    PL: PublishLayer<D::Context>,
     S: Send + Sync,
 {
-    async fn handle(&self, msg: &M, ctx: &mut Context<'_, (), S>) -> Settle {
+    async fn handle(&self, msg: &M, ctx: &mut Context<'_, D::Context, S>) -> Settle {
         // The publishing path settles by a bare outcome (no per-element continuation): decode,
         // run, publish the reply, then ack. It converts to `Settle` with no `and_after`.
         let input = match self.codec.decode::<D::Input>(msg.payload()) {
@@ -175,7 +183,8 @@ where
             Err(result) => return result.into(),
         };
         let name = self.def.reply_name();
-        let publish = self.publisher.publish(name, &reply, &self.pipeline);
+        let pubcx = PublishContext::new(ctx.name(), ctx.headers(), ctx.cx_ref());
+        let publish = self.publisher.publish(name, &reply, &self.pipeline, &pubcx);
         if let Err(err) = publish.await {
             warn!(
                 target: "ruststream::dispatch",
@@ -207,6 +216,7 @@ mod tests {
     impl PublishingDef for ManualPub {
         type Input = u32;
         type Reply = u32;
+        type Context = ();
         type Source = Name;
 
         fn source(&self) -> Name {

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -18,7 +18,9 @@ use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{BlanketLayer, Identity, Stack};
-use crate::runtime::publish::{PublishLayer, PublishMiddleware, ReplyPublisher, TypedPublisher};
+use crate::runtime::publish::{
+    PublishEnd, PublishLayer, PublishPipeline, ReplyPublisher, TypedPublisher,
+};
 use crate::runtime::publishing::{PublishingDef, PublishingHandler, publishing_metadata};
 use crate::runtime::subscriber_def::{SubscriberDef, subscriber_metadata};
 use crate::runtime::typed::typed;
@@ -344,7 +346,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         let meta = batch_publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
         let workers = def.workers();
-        let pipeline: Arc<[Arc<dyn PublishMiddleware>]> = Arc::from([]);
+        let pipeline: Arc<dyn PublishPipeline> = Arc::new(PublishEnd);
         let handler = BatchPublishingHandler {
             def,
             codec,
@@ -392,7 +394,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         let meta = publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
         let workers = def.workers();
-        let pipeline: Arc<[Arc<dyn PublishMiddleware>]> = Arc::from([]);
+        let pipeline: Arc<dyn PublishPipeline> = Arc::new(PublishEnd);
         let handler = PublishingHandler {
             def,
             codec,

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -311,8 +311,8 @@ async fn scope_default_codec_drops_per_call_codec() {
 /// A static (zero-cost) publish transform baked onto the `TypedPublisher`.
 struct StaticEnvelope;
 
-impl PublishLayer for StaticEnvelope {
-    fn apply(&self, out: &mut Outgoing<'_>) {
+impl<C> PublishLayer<C> for StaticEnvelope {
+    fn apply(&self, out: &mut Outgoing<'_>, _cx: &ruststream::runtime::PublishContext<'_, C>) {
         out.headers_mut().insert("x-static", b"1".to_vec());
     }
 }

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -398,10 +398,10 @@ static REPLY_TAGGED: AtomicU32 = AtomicU32::new(0);
 struct Tagger;
 
 impl PublishMiddleware for Tagger {
-    fn on_publish<'a>(
+    fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a>,
+        next: PublishNext<'a, N>,
     ) -> Pin<
         Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
     > {

--- a/tests/opentelemetry.rs
+++ b/tests/opentelemetry.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
 use ruststream::opentelemetry::{OpenTelemetry, TraceContext};
-use ruststream::runtime::{AppInfo, Context, RustStream, TypedPublisher};
+use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
 use ruststream::{Headers, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
@@ -45,17 +45,21 @@ async fn capture(_resp: &Resp, ctx: &mut Context<'_>) {
 /// captured reply `traceparent`.
 async fn run_and_capture(incoming: Option<&'static str>) -> TraceContext {
     *CAPTURED.lock().expect("poisoned") = None;
+    // --8<-- [start:wiring]
     let otel = OpenTelemetry::new();
     let broker = MemoryBroker::new();
     let ingress = broker.publisher();
+    // The publisher propagates the delivery's trace context onto each reply.
     let reply_pub = TypedPublisher::new(broker.publisher()).layer(otel.propagation());
 
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        // The consume layer opens a span per delivery and records the consumer's trace context.
         .layer(otel.consume_layer())
         .with_broker(broker, |b| {
             b.include_publishing(echo, reply_pub);
             b.include(capture);
         });
+    // --8<-- [end:wiring]
 
     let shutdown = Arc::new(Notify::new());
     let signal = Arc::clone(&shutdown);

--- a/tests/opentelemetry.rs
+++ b/tests/opentelemetry.rs
@@ -1,0 +1,123 @@
+//! End-to-end W3C trace context propagation: the consume layer stamps the consumer span and the
+//! publish layer carries it onto the reply (the `opentelemetry` feature, built on #103).
+#![cfg(all(
+    feature = "opentelemetry",
+    feature = "macros",
+    feature = "memory",
+    feature = "json"
+))]
+
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::opentelemetry::{OpenTelemetry, TraceContext};
+use ruststream::runtime::{AppInfo, Context, RustStream, TypedPublisher};
+use ruststream::{Headers, OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Serialize, Deserialize)]
+struct Req {
+    n: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Resp {
+    n: u32,
+}
+
+#[subscriber("in", publish("out"))]
+async fn echo(req: &Req) -> Resp {
+    Resp { n: req.n }
+}
+
+static CAPTURED: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+static GOT: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("out")]
+async fn capture(_resp: &Resp, ctx: &mut Context<'_>) {
+    *CAPTURED.lock().expect("poisoned") = ctx.headers().get_str("traceparent").map(str::to_owned);
+    GOT.notify_one();
+}
+
+/// Drives the app until the reply lands, re-publishing to defeat the startup race, and returns the
+/// captured reply `traceparent`.
+async fn run_and_capture(incoming: Option<&'static str>) -> TraceContext {
+    *CAPTURED.lock().expect("poisoned") = None;
+    let otel = OpenTelemetry::new();
+    let broker = MemoryBroker::new();
+    let ingress = broker.publisher();
+    let reply_pub = TypedPublisher::new(broker.publisher()).layer(otel.propagation());
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .layer(otel.consume_layer())
+        .with_broker(broker, |b| {
+            b.include_publishing(echo, reply_pub);
+            b.include(capture);
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Req { n: 1 }).expect("encode");
+    let captured = tokio::time::timeout(Duration::from_secs(2), async {
+        let notified = GOT.notified();
+        tokio::pin!(notified);
+        loop {
+            let mut headers = Headers::new();
+            if let Some(tp) = incoming {
+                headers.insert("traceparent", tp);
+            }
+            ingress
+                .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
+                .await
+                .expect("publish");
+            tokio::select! {
+                () = &mut notified => break,
+                () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(captured.is_ok(), "reply never captured");
+
+    shutdown.notify_one();
+    run.await.expect("join").expect("run");
+
+    let header = CAPTURED
+        .lock()
+        .expect("poisoned")
+        .clone()
+        .expect("reply carried a traceparent");
+    TraceContext::parse(&header).expect("reply traceparent is valid")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn incoming_trace_continues_onto_the_reply() {
+    let incoming = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    let parsed = TraceContext::parse(incoming).unwrap();
+
+    let reply = run_and_capture(Some(incoming)).await;
+
+    assert_eq!(
+        reply.trace_id(),
+        parsed.trace_id(),
+        "the reply stays in the incoming trace"
+    );
+    assert_ne!(
+        reply.span_id(),
+        parsed.span_id(),
+        "the reply's parent is the consumer span, not the upstream one"
+    );
+    assert!(reply.sampled());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_trace_is_started_when_none_arrives() {
+    let reply = run_and_capture(None).await;
+    // A fresh, sampled root trace was started for the untraced delivery.
+    assert!(reply.sampled());
+    assert_eq!(reply.trace_id().len(), 32);
+}

--- a/tests/publish_context.rs
+++ b/tests/publish_context.rs
@@ -2,12 +2,15 @@
 //! originating delivery (issue #103) and stamps the reply, propagating a correlation id.
 #![cfg(all(feature = "macros", feature = "memory", feature = "json"))]
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use ruststream::memory::{MemoryBroker, MemoryMessage};
 use ruststream::runtime::{
-    AppInfo, Outgoing, PublishContext, PublishLayer, RustStream, TypedPublisher, for_batch,
+    AppInfo, DynPublishMiddleware, Outgoing, PublishContext, PublishDynNext, PublishDynStack,
+    PublishLayer, RustStream, TypedPublisher, for_batch,
 };
 use ruststream::{
     BuildContext, Field, Headers, IncomingMessage, OutgoingMessage, Publisher, subscriber,
@@ -191,6 +194,85 @@ async fn batch_layer_runs_only_on_batched_replies() {
         *BATCHED.lock().expect("poisoned"),
         Some(true),
         "the batch layer should stamp every batched reply"
+    );
+
+    shutdown.notify_one();
+    run.await.expect("join").expect("run");
+}
+
+/// A dynamic, runtime-built publish middleware: stamps a header, then continues.
+struct StampDyn;
+
+impl DynPublishMiddleware for StampDyn {
+    fn on_publish<'a>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishDynNext<'a>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            out.headers_mut().insert("x-dyn", b"1".to_vec());
+            next.run(out).await
+        })
+    }
+}
+
+#[subscriber("dyn-in", publish("dyn-out"))]
+async fn dyn_echo(req: &Req) -> Resp {
+    Resp { n: req.n }
+}
+
+static DYN_SEEN: LazyLock<Mutex<Option<bool>>> = LazyLock::new(|| Mutex::new(None));
+static DYN_GOT: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("dyn-out")]
+async fn dyn_capture(_resp: &Resp, ctx: &mut Context<'_>) {
+    *DYN_SEEN.lock().expect("poisoned") = Some(ctx.headers().get("x-dyn").is_some());
+    DYN_GOT.notify_one();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dyn_stack_runs_a_runtime_built_middleware() {
+    let broker = MemoryBroker::new();
+    let ingress_pub = broker.publisher();
+    // The middleware set is decided at runtime and inserted as one static layer.
+    let stack = PublishDynStack::new([Arc::new(StampDyn) as Arc<dyn DynPublishMiddleware>]);
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .publish_layer(stack)
+        .with_broker(broker, |b| {
+            let reply_pub = TypedPublisher::new(b.broker().publisher());
+            b.include_publishing(dyn_echo, reply_pub);
+            b.include(dyn_capture);
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Req { n: 3 }).expect("encode");
+    let captured = tokio::time::timeout(Duration::from_secs(2), async {
+        let notified = DYN_GOT.notified();
+        tokio::pin!(notified);
+        loop {
+            ingress_pub
+                .publish(OutgoingMessage::new("dyn-in", &payload))
+                .await
+                .expect("publish");
+            tokio::select! {
+                () = &mut notified => break,
+                () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(captured.is_ok(), "reply never captured");
+
+    assert_eq!(
+        *DYN_SEEN.lock().expect("poisoned"),
+        Some(true),
+        "the dynamic stack middleware should run and stamp the reply"
     );
 
     shutdown.notify_one();

--- a/tests/publish_context.rs
+++ b/tests/publish_context.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use ruststream::memory::{MemoryBroker, MemoryMessage};
 use ruststream::runtime::{
-    AppInfo, Outgoing, PublishContext, PublishLayer, RustStream, TypedPublisher,
+    AppInfo, Outgoing, PublishContext, PublishLayer, RustStream, TypedPublisher, for_batch,
 };
 use ruststream::{
     BuildContext, Field, Headers, IncomingMessage, OutgoingMessage, Publisher, subscriber,
@@ -123,6 +123,74 @@ async fn delivery_context_propagates_to_the_reply() {
         CAPTURED.lock().expect("poisoned").as_deref(),
         Some("trace-abc"),
         "the reply should carry the delivery's correlation id, stamped by the publish layer"
+    );
+
+    shutdown.notify_one();
+    run.await.expect("join").expect("run");
+}
+
+/// A batch-only transform: marks every batched reply, never a single-message one.
+struct MarkBatched;
+
+impl<C> PublishLayer<C> for MarkBatched {
+    fn apply(&self, out: &mut Outgoing<'_>, _cx: &PublishContext<'_, C>) {
+        out.headers_mut().insert("x-batched", b"1".to_vec());
+    }
+}
+
+#[subscriber(batch("batch-in"), publish("batch-out"))]
+async fn batch_echo(reqs: &[Req]) -> Vec<Resp> {
+    reqs.iter().map(|r| Resp { n: r.n }).collect()
+}
+
+static BATCHED: LazyLock<Mutex<Option<bool>>> = LazyLock::new(|| Mutex::new(None));
+static BATCH_GOT: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("batch-out")]
+async fn batch_capture(_resp: &Resp, ctx: &mut Context<'_>) {
+    *BATCHED.lock().expect("poisoned") = Some(ctx.headers().get("x-batched").is_some());
+    BATCH_GOT.notify_one();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_layer_runs_only_on_batched_replies() {
+    let broker = MemoryBroker::new();
+    let ingress_pub = broker.publisher();
+    // The same `MarkBatched` transform, reused on the batch path through `for_batch`; the
+    // single-message mounts would reject a publisher carrying it.
+    let reply_pub = TypedPublisher::new(broker.publisher()).batch_layer(for_batch(MarkBatched));
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include_batch_publishing(batch_echo, reply_pub);
+        b.include(batch_capture);
+    });
+
+    let shutdown = Arc::new(Notify::new());
+    let signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Req { n: 1 }).expect("encode");
+    let captured = tokio::time::timeout(Duration::from_secs(2), async {
+        let notified = BATCH_GOT.notified();
+        tokio::pin!(notified);
+        loop {
+            ingress_pub
+                .publish(OutgoingMessage::new("batch-in", &payload))
+                .await
+                .expect("publish");
+            tokio::select! {
+                () = &mut notified => break,
+                () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(captured.is_ok(), "batched reply never captured");
+
+    assert_eq!(
+        *BATCHED.lock().expect("poisoned"),
+        Some(true),
+        "the batch layer should stamp every batched reply"
     );
 
     shutdown.notify_one();

--- a/tests/publish_context.rs
+++ b/tests/publish_context.rs
@@ -1,0 +1,130 @@
+//! The typed per-delivery context reaches the publish path: a static `PublishLayer` reads the
+//! originating delivery (issue #103) and stamps the reply, propagating a correlation id.
+#![cfg(all(feature = "macros", feature = "memory", feature = "json"))]
+
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use ruststream::memory::{MemoryBroker, MemoryMessage};
+use ruststream::runtime::{
+    AppInfo, Outgoing, PublishContext, PublishLayer, RustStream, TypedPublisher,
+};
+use ruststream::{
+    BuildContext, Field, Headers, IncomingMessage, OutgoingMessage, Publisher, subscriber,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+#[derive(Serialize, Deserialize)]
+struct Req {
+    n: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Resp {
+    n: u32,
+}
+
+/// A broker context built from the incoming message: it lifts the correlation id off the headers so
+/// the handler (and the publish layer) can read it by key instead of re-parsing the headers.
+#[derive(Default)]
+struct TraceCtx {
+    correlation: Option<String>,
+}
+
+impl BuildContext<MemoryMessage> for TraceCtx {
+    fn build(msg: &MemoryMessage) -> Self {
+        Self {
+            correlation: msg.headers().correlation_id().map(str::to_owned),
+        }
+    }
+}
+
+/// The compile-time key that reads [`TraceCtx::correlation`].
+#[derive(Clone, Copy)]
+struct Correlation;
+
+impl Field<TraceCtx> for Correlation {
+    type Value<'a> = Option<&'a str>;
+    fn get(self, c: &TraceCtx) -> Option<&str> {
+        c.correlation.as_deref()
+    }
+}
+
+/// A static, zero-cost publish transform: stamps the originating delivery's correlation id onto the
+/// reply, read off the typed context through [`PublishContext`].
+struct PropagateCorrelation;
+
+impl PublishLayer<TraceCtx> for PropagateCorrelation {
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, TraceCtx>) {
+        if let Some(id) = cx.context(Correlation) {
+            out.headers_mut()
+                .insert("correlation-id", id.as_bytes().to_vec());
+        }
+    }
+}
+
+#[subscriber("in", publish("out"))]
+async fn echo(req: &Req, _ctx: &mut Context<'_, TraceCtx>) -> Resp {
+    Resp { n: req.n }
+}
+
+static CAPTURED: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+static GOT: LazyLock<Notify> = LazyLock::new(Notify::new);
+
+#[subscriber("out")]
+async fn capture(_resp: &Resp, ctx: &mut Context<'_>) {
+    *CAPTURED.lock().expect("poisoned") = ctx.headers().correlation_id().map(str::to_owned);
+    GOT.notify_one();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delivery_context_propagates_to_the_reply() {
+    let ingress = MemoryBroker::new();
+    let egress = MemoryBroker::new();
+    let ingress_pub = ingress.publisher();
+    let egress_pub = TypedPublisher::new(egress.publisher()).layer(PropagateCorrelation);
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(ingress, |b| {
+            b.include_publishing(echo, egress_pub);
+        })
+        .with_broker(egress, |b| {
+            b.include(capture);
+        });
+
+    let shutdown = Arc::new(Notify::new());
+    let signal = Arc::clone(&shutdown);
+    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+
+    let payload = serde_json::to_vec(&Req { n: 7 }).expect("encode");
+    // Re-publish until the reaction lands: the first sends can race subscription startup, and the
+    // in-memory broker drops a message with no subscriber yet (see the metrics publish test).
+    let captured = tokio::time::timeout(Duration::from_secs(2), async {
+        let notified = GOT.notified();
+        tokio::pin!(notified);
+        loop {
+            let mut headers = Headers::new();
+            headers.insert("correlation-id", "trace-abc");
+            ingress_pub
+                .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
+                .await
+                .expect("publish");
+            tokio::select! {
+                () = &mut notified => break,
+                () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(captured.is_ok(), "reply never captured");
+
+    assert_eq!(
+        CAPTURED.lock().expect("poisoned").as_deref(),
+        Some("trace-abc"),
+        "the reply should carry the delivery's correlation id, stamped by the publish layer"
+    );
+
+    shutdown.notify_one();
+    run.await.expect("join").expect("run");
+}


### PR DESCRIPTION
# Description

Per-delivery context on the publish path, so a trace / correlation id flows from an incoming message
onto the replies it produces, plus the OpenTelemetry integration that consumes it (issue #103, both
pieces). Along the way the publish-middleware pipeline is made static, mirroring the consume side.

The typed context reaches the publish path on the **static** layer, not via a new `Any` seam:

- **Single-message publish context.** `PublishingDef` gains `type Context` (the macro fills it from
  the handler's `ctx: &mut Context<'_, C>`); the static `PublishLayer<C>` now takes a read-only
  `PublishContext` view of the originating delivery (its channel, the incoming headers, and the
  broker's typed per-delivery context by `Field` key), so a transform can stamp the delivery's trace
  / correlation id onto the reply. The dynamic pipeline stays context-agnostic, like a `DynStack`.
- **Batch publish layers.** `BatchPublishLayer` is a distinct, batch-only transform added with
  `TypedPublisher::batch_layer`; the per-message `.layer(..)` stack and the batch stack are
  independent (neither leaks onto the other path, enforced at compile time), and `for_batch(layer)`
  reuses a per-message `PublishLayer` on the batch path without a second impl.
- **Static publish pipeline.** The app-wide `&[Arc<dyn PublishMiddleware>]` (a vtable call per layer
  per message) becomes a statically composed `PublishCons` / `PublishEnd` chain; `PublishMiddleware`
  is generic over the rest of the pipeline. The composed chain is boxed once into a single
  `Arc<dyn PublishPipeline>` (one indirection for the whole pipeline, forced only by the router
  storing handlers type-erased - tracked in #113). `PublishDynStack` is the opt-in runtime-composed
  escape hatch, the publish counterpart of `DynStack`.
- **OpenTelemetry (`opentelemetry` feature).** `OpenTelemetry::consume_layer()` opens a `tracing`
  span per delivery and records the consumer's W3C trace context on the working headers;
  `OpenTelemetry::propagation()` is a static `PublishLayer` that copies it onto every reply.
  Dependency-light (W3C `TraceContext` + `tracing` spans; span ids from a per-process `RandomState`,
  no rng dep), leaving the OTLP export to the binary's subscriber, as `logging` does.

Follow-up #113 (filed, v0.5 milestone) tracks making routers static to drop the last
`Arc<dyn PublishPipeline>` indirection end to end.

Fixes #103

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (`PublishingDef::Context`; `PublishLayer::apply` gains a `PublishContext`
      argument; `PublishMiddleware::on_publish` / `PublishNext` gain a pipeline type parameter;
      `TypedPublisher` / `Transactional` gain a defaulted type parameter; `ReplyPublisher` is
      parameterized by the context type - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc, the `opentelemetry` guide,
      `publishing.md`, CLAUDE.md)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature (`tests/publish_context.rs`,
      `tests/opentelemetry.rs`, plus unit tests / doctests)
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      the docs site
