### PR TITLE
test(batch): fix flaky batch ordering assertion (startup race)

### DIFF
--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -73,9 +73,15 @@ async fn batch_macro_def_receives_batches() {
     .await;
     assert!(result.is_ok(), "no batch arrived within the deadline");
 
-    // Order within and across batches must follow publish order.
+    // Order within and across batches must follow publish order. The subscription opens inside
+    // run(), so the first publish round can be partly dropped (sent before the subscriber is
+    // ready); the surviving stream still follows the repeating 0,1,2 publish cycle, so assert each
+    // consecutive pair advances the cycle rather than requiring the stream to start at 0.
     let flattened: Vec<u32> = BATCHES.lock().unwrap().iter().flatten().copied().collect();
-    assert!(flattened.starts_with(&[0, 1, 2]), "got {flattened:?}");
+    assert!(
+        flattened.windows(2).all(|w| w[1] == (w[0] + 1) % 3),
+        "deliveries out of publish order: {flattened:?}",
+    );
     assert!(
         BATCHES
             .lock()


### PR DESCRIPTION
# Description

`batch_macro_def_receives_batches` (`tests/batch_subscriber.rs`) flaked on the release PR (#102) on **Rust stable** while every pinned toolchain (1.85-1.95) passed - a timing flake, not a logic bug.

The subscription opens inside `run()`, so the first publish round can be partly dropped (sent before the subscriber is ready). The retry-publish loop re-sends `0,1,2` each round, so the surviving stream still follows the repeating publish order but can **start mid-cycle**, e.g. `[1, 2, 0, 1, 2]`. The old assertion required the stream to *start* with `[0, 1, 2]`, rejecting that correct ordering and flaking on faster runtimes (CI hit it on stable 1.96).

Fix: assert each consecutive pair advances the `0->1->2->0` publish cycle (`w[1] == (w[0] + 1) % 3`) rather than requiring a `0` start. This captures the intended "order follows publish order" invariant while tolerating the startup-race drop.

Validated locally: the test passes 8/8 runs.

Unblocks #102.

## Type of change

- [x] Test-only fix (no library change)

## Checklist

- [x] `cargo fmt --check` clean
- [x] `batch_macro_def_receives_batches` passes repeatedly (8/8)