### PR TITLE
test(ui): fix the app-macro error snapshot for the impl App message

### DIFF
--- a/tests/ui/app_async_builder.stderr
+++ b/tests/ui/app_async_builder.stderr
@@ -1,4 +1,4 @@
-error: #[ruststream::app] requires a synchronous builder returning `RustStream`
+error: #[ruststream::app] requires a synchronous builder returning `impl App` or `RustStream`
  --> tests/ui/app_async_builder.rs:5:1
   |
 5 | async fn build() -> u8 {


### PR DESCRIPTION
The `App` trait work (#115) changed the `#[ruststream::app]` error message to mention `impl App`, but the trybuild `.stderr` snapshot still expected the old "returning `RustStream`" wording. The `ui` test fails under `RUN_UI_TESTS=1` (the release CI on #102). This updates the snapshot to match. Validated: `RUN_UI_TESTS=1 cargo test --test ui` passes. Unblocks the v0.5 / #102 CI.