### PR TITLE
Forbid unsafe across all crates and document 100% safe Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://docs.rs/ruststream"><img src="https://img.shields.io/docsrs/ruststream" alt="docs.rs"></a>
   <img src="https://img.shields.io/badge/MSRV-1.85-blue.svg" alt="MSRV 1.85">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License">
+  <img src="https://img.shields.io/badge/unsafe-none-success.svg" alt="100% safe Rust">
   <a href="https://t.me/ruststream_community"><img src="https://img.shields.io/badge/-Telegram-blue?logo=telegram&label=News" alt="Telegram news channel"></a>
   <a href="https://t.me/ruststream_communuty_ru_chat"><img src="https://img.shields.io/badge/-Telegram-blue?logo=telegram&label=RU" alt="Telegram RU chat"></a>
   <a href="https://context7.com/powersemmi/ruststream"><img src="https://img.shields.io/badge/Context7-Ask_AI-ff5722" alt="Ask AI"></a>
@@ -25,6 +26,9 @@ RustStream connects your service to a message broker through a small set of gene
 gives you a router, middleware, codecs, and tooling on top. The core depends on no broker, so each
 broker is an independent crate held to one contract; broker-specific configuration never leaks into
 the framework.
+
+The core is 100% safe Rust: every crate carries `#![forbid(unsafe_code)]` and CI rejects any `unsafe`
+block, so the guarantee cannot regress.
 
 ## Features
 

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -3,6 +3,8 @@
 //! Re-exported from the `ruststream` crate under the `macros` feature; depend on that rather than
 //! on this crate directly.
 
+#![forbid(unsafe_code)]
+
 mod expand;
 mod from_ref;
 mod parse;

--- a/src/bin/ruststream/main.rs
+++ b/src/bin/ruststream/main.rs
@@ -9,6 +9,8 @@
 //! Scaffolding a new project is `cargo generate` against a template (the in-memory starter lives in
 //! this repo under `templates/memory`; brokers own theirs); this tool no longer ships its own `new`.
 
+#![forbid(unsafe_code)]
+
 use std::path::PathBuf;
 
 use anyhow::Result;


### PR DESCRIPTION
# Description

Add `#![forbid(unsafe_code)]` to the proc-macro crate (`ruststream-macros`) and the CLI binary crate root (`src/bin/ruststream/main.rs`), so every crate in the workspace forbids `unsafe`, matching the core crate. The guarantee is compiler-enforced through the existing clippy and check steps (which build `--workspace --all-targets --all-features` and `--no-default-features`), so no separate CI gate is added: a stray `unsafe` block fails the build.

State the guarantee in the README with a "100% safe Rust" badge and a one-line note, so the property is visible to users.

No `unsafe` exists in the source today, so this is enforcement and documentation, not a refactor. Additive; no API or behavior change. Follows sqlx's stance of enforcing `#![forbid(unsafe_code)]` across all crates.

Fixes #128

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [ ] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable