### PR TITLE
docs: fix two broken docs-site links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ ruststream asyncapi gen        # print the AsyncAPI document
 
 Scaffold a fresh project with `cargo generate --git https://github.com/powersemmi/ruststream
 templates/memory --name my-service` (each broker crate ships its own template). See the
-[quick start](https://powersemmi.github.io/ruststream/getting-started/quickstart/).
+[quick start](https://powersemmi.github.io/ruststream/latest/getting-started/quickstart/).
 
 ## Testing the service
 
@@ -157,7 +157,7 @@ tb.broker::<MemoryBroker>()
 ```
 
 Full compiling example: `examples/testing.rs`. See the
-[testing guide](https://powersemmi.github.io/ruststream/guides/testing/).
+[testing guide](https://powersemmi.github.io/ruststream/latest/guides/testing/).
 
 ## Project documentation
 


### PR DESCRIPTION
# Description

Two docs-site links in the README 404: the quickstart link under `Run it` and the testing-guide link under `Testing the service` both pointed at subpaths without the version segment. The site is published with `mike`, where `latest` is a real directory, so subpaths only resolve under `/latest/` (the root serves the latest index, but subpaths are not aliased at the root). The rest of the README already uses the `/latest/` form for its docs links; these two were missed.

Repoint both to the `/latest/` form:

- `…/ruststream/getting-started/quickstart/` -> `…/ruststream/latest/getting-started/quickstart/`
- `…/ruststream/guides/testing/` -> `…/ruststream/latest/guides/testing/`

Both now return 200.

Docs-only; no code change.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [ ] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable