### PR TITLE
docs: list ruststream-lapin in the Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Full compiling example: `examples/asyncapi_http.rs`.
   JetStream).
 - [`ruststream-fred`](https://github.com/powersemmi/ruststream-fred): the Redis broker (Redis Streams
   with consumer groups; standalone, cluster, and sentinel topologies) via the `fred` client.
+- [`ruststream-lapin`](https://github.com/powersemmi/ruststream-lapin): the RabbitMQ broker (AMQP
+  0.9.1: topology descriptors, native dead-letter and delayed retry, keyed worker lanes, publisher
+  confirms and server-side transactions) via the `lapin` client.
 
 Concrete brokers live in their own crates and pull `ruststream` from crates.io.
 


### PR DESCRIPTION
# Description

The RabbitMQ broker (`ruststream-lapin`) is published on crates.io, so list it in the README's
Ecosystem section alongside the NATS and Redis brokers. Docs-only, no code change.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (README-only; no code, tests, or public API touched)
