### PR TITLE
style: merge the stray std import into the top use block in routed_service

### DIFF
--- a/examples/routed_service/main.rs
+++ b/examples/routed_service/main.rs
@@ -28,14 +28,13 @@ mod orders;
 mod payments;
 mod routes;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ruststream::ServerSpec;
 use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
 use ruststream::runtime::{App, AppInfo, RustStream};
-
-use std::sync::Arc;
 
 use crate::domain::{Repository, ServiceError};
 use crate::observability::Observe;


### PR DESCRIPTION
examples/routed_service/main.rs grew a second std use block (`use std::sync::Arc;`) between the crate imports and the crate-local ones; this folds it into the std group at the top, so the file's dependencies read in one place. No code changes beyond import placement.