### PR TITLE
feat: Ctx extractor - broker context fields as handler parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/ruststream-macros"]
 exclude = ["templates"]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -87,6 +87,10 @@ name = "from_context"
 required-features = ["testing", "macros", "memory", "json"]
 
 [[example]]
+name = "ctx_extractor"
+required-features = ["testing", "macros", "memory", "json"]
+
+[[example]]
 name = "lifespan"
 required-features = ["macros", "memory", "json"]
 
@@ -144,6 +148,10 @@ required-features = ["macros", "memory", "json"]
 
 [[test]]
 name = "from_context"
+required-features = ["macros", "memory", "json", "testing"]
+
+[[test]]
+name = "ctx_extractor"
 required-features = ["macros", "memory", "json", "testing"]
 
 [[test]]

--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -43,17 +43,18 @@ struct HandlerParts<'a> {
     failure_method: TokenStream2,
 }
 
-/// The per-delivery context type the handler named in its `ctx: &mut Context<'_, C>` parameter, or
-/// `()` when it named none. Threaded into the single-subscriber `SubscriberDef::Context` so a
-/// macro handler can read broker fields by key.
+/// The per-delivery context type the handler named in its `ctx: &mut Context<'_, C>` parameter,
+/// projected from the first `Ctx<K>` extractor's key when there is no ctx parameter, or `()`
+/// when neither names one. Threaded into the single-subscriber `SubscriberDef::Context` so a
+/// macro handler can read broker fields by key or take them as parameters.
 fn context_type(func: &ItemFn) -> TokenStream2 {
     let Some(FnArg::Typed(PatType { ty, .. })) = func.sig.inputs.get(1) else {
         return quote!(());
     };
     // The second parameter is the context only when it is `&mut Context<..>`; otherwise it is an
-    // extractor, so the handler named no context type.
+    // extractor, so the handler named no context type explicitly.
     if !is_context_param(ty) {
-        return quote!(());
+        return inferred_context_type(func);
     }
     // Dig the second generic argument (after the lifetime) out of `&mut Context<'_, C>`.
     if let Type::Reference(reference) = &**ty
@@ -68,6 +69,45 @@ fn context_type(func: &ItemFn) -> TokenStream2 {
         }
     }
     quote!(())
+}
+
+/// The context type projected from the first `Ctx<K>` extractor parameter's key, for handlers
+/// without a `&mut Context` parameter. Emitted as `<K as ContextField>::Context`, so the
+/// compiler resolves the type; further `Ctx` keys are checked against it by the extractor
+/// bounds. Purely syntactic (the last path segment `Ctx` with exactly one type argument): a
+/// type alias hides the shape and falls back to `()`.
+fn inferred_context_type(func: &ItemFn) -> TokenStream2 {
+    for arg in func.sig.inputs.iter().skip(1) {
+        if let FnArg::Typed(PatType { ty, .. }) = arg
+            && let Some(key) = ctx_extractor_key(ty)
+        {
+            return quote!(<#key as ::ruststream::ContextField>::Context);
+        }
+    }
+    quote!(())
+}
+
+/// The key type `K` of a `Ctx<K>`-shaped parameter type, when the type has that shape.
+fn ctx_extractor_key(ty: &Type) -> Option<&Type> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    let segment = path.path.segments.last()?;
+    if segment.ident != "Ctx" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let mut types = args.args.iter().filter_map(|arg| match arg {
+        syn::GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    });
+    let key = types.next()?;
+    if types.next().is_some() {
+        return None;
+    }
+    Some(key)
 }
 
 /// The application-state type the handler named as the third generic of its

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -104,11 +104,38 @@ carry its field, so an inapplicable key is a compile error rather than a runtime
 
 The context type is built from the message by `BuildContext`, which the runtime calls once per
 delivery; a broker with no per-delivery fields uses `()`, the default (so a `#[subscriber]` handler
-that names no context type sees `Context<'_>`). Middleware can also carry a typed scratch value to a
+that names no context type - and takes no [`Ctx` extractor](#context-fields-as-parameters) - sees
+`Context<'_>`). Middleware can also carry a typed scratch value to a
 downstream handler: a writable key (`FieldMut`) lets a layer `ctx.set(KEY, value)` and the handler
 `ctx.context(KEY)` it back - a correlation id, an authenticated user a layer resolved - without
 serializing it into the headers. The context is built fresh per delivery, so one delivery's values
 never leak into the next.
+
+## Context fields as parameters
+
+A field can also arrive as a handler argument, the way `State<T>` injects a state component: the
+`Ctx<K>` extractor binds the value the key `K` reads. The key implements `ContextField` - a
+`Field`-style trait that additionally names the context type it reads from and yields an owned
+value - so the handler needs no `&mut Context` parameter at all: the `#[subscriber]` macro projects
+the subscription's context type from the first `Ctx` key in the signature.
+
+```rust
+--8<-- "examples/ctx_extractor.rs:key"
+```
+
+```rust
+--8<-- "examples/ctx_extractor.rs:handler"
+```
+
+Three things to know:
+
+- Values are owned (`ContextField::Value` is `'static`): extractor values bind before the handler
+  body runs, so borrowing from the context is not an option. Keys yielding borrowed values (a name
+  as `&str`) stay readable through `ctx.context(KEY)` with a declared ctx parameter.
+- With a `&mut Context<'_, C>` parameter also present, every `Ctx` key must read that same `C`;
+  the compiler enforces it through the extractor bounds.
+- The projection is syntactic: the macro recognizes the literal `Ctx<K>` shape (any path ending in
+  `Ctx` with one type argument). A type alias hides it, and the context type falls back to `()`.
 
 ## The headers working copy
 

--- a/examples/ctx_extractor.rs
+++ b/examples/ctx_extractor.rs
@@ -1,0 +1,73 @@
+//! The `Ctx<K>` extractor: a broker context field arrives as a handler argument, like `State`
+//! does for the application state. The key implements `ContextField`, which names the context
+//! type it reads - so the handler needs no `&mut Context` parameter, and the `#[subscriber]`
+//! macro projects the subscription's context type from the key. Driven through the real
+//! dispatch path with the in-process `TestApp` harness.
+//!
+//! ```text
+//! cargo run --example ctx_extractor --features testing,macros,memory,json
+//! ```
+
+use ruststream::memory::{MemoryBroker, MemoryMessage};
+use ruststream::runtime::{AppInfo, Ctx, HandlerResult, RustStream};
+use ruststream::testing::TestApp;
+use ruststream::{BuildContext, ContextField, IncomingMessage, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Order {
+    id: u64,
+}
+
+// --8<-- [start:key]
+// The broker's per-delivery context, built once per delivery; here it carries the payload
+// size, standing in for an offset, a partition, or a delivery tag a real broker exposes.
+struct DeliveryMeta {
+    payload_len: usize,
+}
+
+impl BuildContext<MemoryMessage> for DeliveryMeta {
+    fn build(msg: &MemoryMessage) -> Self {
+        Self {
+            payload_len: msg.payload().len(),
+        }
+    }
+}
+
+// The key: `ContextField` names the context it reads and yields an owned value, which is what
+// lets it work as an extractor. Broker crates ship these next to their `Field` keys.
+#[derive(Clone, Copy, Default)]
+struct PayloadLen;
+
+impl ContextField for PayloadLen {
+    type Context = DeliveryMeta;
+    type Value = usize;
+    fn read(self, src: &DeliveryMeta) -> usize {
+        src.payload_len
+    }
+}
+// --8<-- [end:key]
+
+// --8<-- [start:handler]
+// The field arrives as an argument; no `&mut Context` parameter, no context type named - the
+// macro projects it from the key.
+#[subscriber("orders")]
+async fn audit(order: &Order, Ctx(len): Ctx<PayloadLen>) -> HandlerResult {
+    println!("order {} arrived as {len} bytes", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:handler]
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(audit));
+
+    let tb = TestApp::start(app).await?;
+    tb.broker::<MemoryBroker>()
+        .publish("orders", &Order { id: 40 })
+        .await?;
+
+    println!("done");
+    Ok(())
+}

--- a/src/field.rs
+++ b/src/field.rs
@@ -45,6 +45,53 @@ pub trait Field<Src: ?Sized> {
     fn get(self, src: &Src) -> Self::Value<'_>;
 }
 
+/// A [`Field`]-style key that also names its context type and yields an owned value.
+///
+/// It powers the [`Ctx`](crate::runtime::Ctx) extractor: because the key carries its context
+/// as an associated type, a handler taking `Ctx(value): Ctx<Key>` needs no `&mut Context`
+/// parameter at all - the `#[subscriber]` macro projects the subscription's context type from
+/// the first `Ctx` key it sees. The value is owned (`'static`) on purpose: extractor values
+/// bind before the handler body runs, so borrowing from the context is not an option. Borrowed
+/// keys keep working through [`Field`] and `ctx.context(KEY)`.
+///
+/// Broker crates implement it next to [`Field`] on the same zero-sized keys; a key typically
+/// implements both, so it works as a context read and as an extractor.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::ContextField;
+///
+/// struct Delivery {
+///     sequence: u64,
+/// }
+///
+/// #[derive(Clone, Copy, Default)]
+/// struct Sequence;
+///
+/// impl ContextField for Sequence {
+///     type Context = Delivery;
+///     type Value = u64;
+///     fn read(self, src: &Delivery) -> u64 {
+///         src.sequence
+///     }
+/// }
+///
+/// let delivery = Delivery { sequence: 7 };
+/// assert_eq!(Sequence.read(&delivery), 7);
+/// ```
+pub trait ContextField: Default {
+    /// The per-delivery context type this key reads from.
+    type Context;
+
+    /// The owned value the key yields.
+    type Value: Send + 'static;
+
+    /// Reads this key's field out of `src`. Named apart from [`Field::get`] so a key
+    /// implementing both traits stays unambiguous to call.
+    fn read(self, src: &Self::Context) -> Self::Value;
+}
+
 /// A [`Field`] key middleware can also write, for per-delivery scratch values.
 ///
 /// The read side ([`Field::get`]) is typically `Option<&T>` (the value may not have been set yet),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use capability::{
     TransactionalPublisher,
 };
 pub use error::AckError;
-pub use field::{BuildContext, Field, FieldMut};
+pub use field::{BuildContext, ContextField, Field, FieldMut};
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::Publisher;

--- a/src/runtime/extract.rs
+++ b/src/runtime/extract.rs
@@ -9,7 +9,10 @@
 //! extraction short-circuits the delivery with the rejection's [`HandlerResult`].
 
 use std::convert::Infallible;
+use std::fmt;
 use std::future::Future;
+
+use crate::ContextField;
 
 use super::context::Context;
 use super::handler::HandlerResult;
@@ -136,6 +139,71 @@ where
         ctx: &mut Context<'_, C, S>,
     ) -> impl Future<Output = Result<Self, Infallible>> + Send {
         let value = T::from_ref(ctx.state());
+        async move { Ok(Self(value)) }
+    }
+}
+
+/// Extractor that injects one broker context field into a handler, by its key.
+///
+/// Where [`State<T>`](State) pulls a value out of the shared application state, `Ctx<K>` pulls
+/// one field out of the broker's per-delivery context: `Ctx(offset): Ctx<Offset>` binds the
+/// value the key `Offset` reads. The key implements [`ContextField`], which names the context
+/// type it reads from - so a handler using only `Ctx` extractors needs no `&mut Context`
+/// parameter at all: the `#[subscriber]` macro projects the subscription's context type from
+/// the first `Ctx` key in the signature. With a `&mut Context<'_, C>` parameter also present,
+/// the keys must read that same `C` (the compiler enforces it).
+///
+/// Values are owned ([`ContextField::Value`] is `'static`): extractors bind before the handler
+/// body runs, so borrowing from the context is not an option. Keys yielding borrowed values
+/// stay readable through `ctx.context(KEY)`.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::ContextField;
+/// use ruststream::runtime::Ctx;
+///
+/// struct Delivery {
+///     offset: u64,
+/// }
+///
+/// #[derive(Clone, Copy, Default)]
+/// struct Offset;
+///
+/// impl ContextField for Offset {
+///     type Context = Delivery;
+///     type Value = u64;
+///     fn read(self, src: &Delivery) -> u64 {
+///         src.offset
+///     }
+/// }
+///
+/// // In a handler: `async fn handle(msg: &M, Ctx(offset): Ctx<Offset>) -> HandlerResult`.
+/// let extracted = Ctx::<Offset>(42);
+/// assert_eq!(extracted.0, 42);
+/// ```
+pub struct Ctx<K: ContextField>(pub K::Value);
+
+impl<K: ContextField> fmt::Debug for Ctx<K>
+where
+    K::Value: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Ctx").field(&self.0).finish()
+    }
+}
+
+impl<S, K> FromContext<K::Context, S> for Ctx<K>
+where
+    K: ContextField,
+    K::Context: Send,
+    S: Sync,
+{
+    type Rejection = Infallible;
+    fn from_context(
+        ctx: &mut Context<'_, K::Context, S>,
+    ) -> impl Future<Output = Result<Self, Infallible>> + Send {
+        let value = K::default().read(ctx.cx_ref());
         async move { Ok(Self(value)) }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -28,7 +28,7 @@ pub use batch_publishing::{BatchPublishingCall, BatchPublishingDef, BatchPublish
 pub use context::{After, Context};
 pub use dispatch::{RETRY_COUNT_HEADER, Workers};
 pub use dynstack::{DynMiddleware, DynStack, DynStackHandler, Next};
-pub use extract::{FromContext, FromRef, State};
+pub use extract::{Ctx, FromContext, FromRef, State};
 #[cfg(feature = "testing")]
 pub(crate) use failure::ErrorShutdown;
 pub use failure::{FailurePolicies, FailurePolicy};

--- a/tests/ctx_extractor.rs
+++ b/tests/ctx_extractor.rs
@@ -1,0 +1,162 @@
+//! The `Ctx<K>` extractor: a broker context field injected as a handler parameter, with the
+//! subscription's context type projected from the key - no `&mut Context` parameter needed.
+//! Also the mixed form (an explicit ctx parameter plus a `Ctx` extractor reading the same
+//! context) and the state-composition form (`Ctx` next to `State`).
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+use ruststream::memory::{MemoryBroker, MemoryMessage};
+use ruststream::runtime::{AppInfo, Ctx, HandlerResult, RustStream, State};
+use ruststream::testing::TestApp;
+use ruststream::{BuildContext, ContextField, Field, FromRef, IncomingMessage, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Order {
+    id: u64,
+}
+
+/// A broker-style per-delivery context, built from the message: it carries the payload length,
+/// standing in for an offset / partition / delivery tag a real broker would expose.
+struct DeliveryMeta {
+    payload_len: usize,
+}
+
+impl BuildContext<MemoryMessage> for DeliveryMeta {
+    fn build(msg: &MemoryMessage) -> Self {
+        Self {
+            payload_len: msg.payload().len(),
+        }
+    }
+}
+
+/// The zero-sized key reading the payload length; `ContextField` names its context, `Field`
+/// keeps the `ctx.context(KEY)` read working for the mixed test.
+#[derive(Clone, Copy, Default)]
+struct PayloadLen;
+
+impl ContextField for PayloadLen {
+    type Context = DeliveryMeta;
+    type Value = usize;
+    fn read(self, src: &DeliveryMeta) -> usize {
+        src.payload_len
+    }
+}
+
+impl Field<DeliveryMeta> for PayloadLen {
+    type Value<'a> = usize;
+    fn get(self, src: &DeliveryMeta) -> usize {
+        src.payload_len
+    }
+}
+
+// --- the pure DI form: no ctx parameter, the key projects the context type ---
+
+static SEEN_LEN: AtomicUsize = AtomicUsize::new(0);
+
+#[subscriber("orders")]
+async fn measure(_order: &Order, Ctx(len): Ctx<PayloadLen>) -> HandlerResult {
+    SEEN_LEN.store(len, Ordering::Relaxed);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ctx_extractor_projects_the_context_from_its_key() {
+    let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(measure));
+
+    let tb = TestApp::start(app).await.expect("start");
+    tb.broker::<MemoryBroker>()
+        .publish("orders", &Order { id: 7 })
+        .await
+        .expect("publish");
+
+    tb.broker::<MemoryBroker>()
+        .subscriber("orders")
+        .assert_called_once()
+        .settled(HandlerResult::Ack);
+    let expected = serde_json::to_vec(&Order { id: 7 }).expect("encode").len();
+    assert_eq!(
+        SEEN_LEN.load(Ordering::Relaxed),
+        expected,
+        "the extracted field must come from this delivery's context",
+    );
+}
+
+// --- the mixed form: an explicit ctx parameter, plus the extractor reading the same C ---
+
+#[subscriber("mixed")]
+async fn both(
+    _order: &Order,
+    ctx: &mut Context<'_, DeliveryMeta>,
+    Ctx(len): Ctx<PayloadLen>,
+) -> HandlerResult {
+    assert_eq!(
+        ctx.context(PayloadLen),
+        len,
+        "the extractor and the key read must agree",
+    );
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ctx_extractor_composes_with_an_explicit_ctx_parameter() {
+    let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(both));
+
+    let tb = TestApp::start(app).await.expect("start");
+    tb.broker::<MemoryBroker>()
+        .publish("mixed", &Order { id: 1 })
+        .await
+        .expect("publish");
+
+    tb.broker::<MemoryBroker>()
+        .subscriber("mixed")
+        .assert_called_once()
+        .settled(HandlerResult::Ack);
+}
+
+// --- composition with State: broker field and state component side by side ---
+
+#[derive(Clone)]
+struct Hits(Arc<AtomicU32>);
+
+#[derive(FromRef)]
+struct AppState {
+    hits: Hits,
+}
+
+#[subscriber("counted")]
+async fn count(
+    _order: &Order,
+    Ctx(len): Ctx<PayloadLen>,
+    State(hits): State<Hits>,
+) -> HandlerResult {
+    if len > 0 {
+        hits.0.fetch_add(1, Ordering::Relaxed);
+    }
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ctx_extractor_composes_with_state() {
+    let hits = Arc::new(AtomicU32::new(0));
+    let state_hits = Hits(hits.clone());
+    let app = RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .on_startup(move |()| async move { Ok::<_, Infallible>(AppState { hits: state_hits }) })
+        .with_broker(MemoryBroker::new(), |b| b.include(count));
+
+    let tb = TestApp::start(app).await.expect("start");
+    tb.broker::<MemoryBroker>()
+        .publish("counted", &Order { id: 2 })
+        .await
+        .expect("publish");
+
+    tb.broker::<MemoryBroker>()
+        .subscriber("counted")
+        .assert_called_once()
+        .settled(HandlerResult::Ack);
+    assert_eq!(hits.load(Ordering::Relaxed), 1);
+}


### PR DESCRIPTION
Closes #137. Ships as 0.5.2 (the version bump is included; everything is additive).

`ContextField` is a `Field`-style key trait that also names the context type it reads (an associated type) and yields an owned value; `Ctx<K>` is the extractor over it, injecting one broker context field into a handler the way `State<T>` injects a state component:

```rust
#[subscriber("orders")]
async fn audit(order: &Order, Ctx(len): Ctx<PayloadLen>) -> HandlerResult { ... }
```

Because the key carries its context, the handler needs no `&mut Context` parameter and names no context type anywhere: the `#[subscriber]` macro projects the subscription's context type from the first `Ctx` key in the signature, emitting `<K as ContextField>::Context` - a type projection the compiler resolves, not the macro. With an explicit ctx parameter present it keeps priority, and every `Ctx` key must read that same context (enforced by the extractor bounds).

Values are owned on purpose (extractors bind before the body; borrowing from the context is not an option); borrowed keys stay readable through `ctx.context(KEY)`. The projection is syntactic - the literal `Ctx<K>` shape - with the same precedent as the existing `&mut Context` parameter detection, and the guide documents the type-alias caveat.

Broker crates only implement `ContextField` on the field keys they already ship; the follow-ups are filed (rdkafka#18, nats#17, fred#20, lapin#17).

Docs: a "Context fields as parameters" section in the Context guide with snippets from the new `ctx_extractor` example. Tests: the pure DI form (projected context reaches the handler), the mixed form (explicit ctx parameter + extractor agree), and composition with `State`; the package dry-run passes for both crates.