### PR TITLE
docs: link the ruststream-rdkafka docs like the other brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Full compiling example: `examples/asyncapi_http.rs`.
 - [`ruststream-lapin`](https://github.com/powersemmi/ruststream-lapin): the RabbitMQ broker (AMQP
   0.9.1: topology descriptors, native dead-letter and delayed retry, keyed worker lanes, publisher
   confirms and server-side transactions) via the `lapin` client.
+- [`ruststream-rdkafka`](https://github.com/powersemmi/ruststream-rdkafka): the Apache Kafka broker
+  (consumer groups, tracked and transactional commits, retry and dead-letter topics, partition-scoped
+  transactions and exactly-once pipelines, a service template) via the `rdkafka` client.
 
 Concrete brokers live in their own crates and pull `ruststream` from crates.io.
 

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -14,6 +14,7 @@ Each broker crate has its own documentation site, linked below and from the **Br
 | NATS | [`ruststream-nats`](https://github.com/powersemmi/ruststream-nats) | Core NATS and JetStream | [powersemmi.github.io/ruststream-nats](https://powersemmi.github.io/ruststream-nats/) |
 | Redis | [`ruststream-fred`](https://github.com/powersemmi/ruststream-fred) | Redis Streams (standalone, cluster, sentinel) | [powersemmi.github.io/ruststream-fred](https://powersemmi.github.io/ruststream-fred/) |
 | RabbitMQ | [`ruststream-lapin`](https://github.com/powersemmi/ruststream-lapin) | AMQP 0.9.1 (queues, exchanges, publisher confirms, direct reply-to) | [powersemmi.github.io/ruststream-lapin](https://powersemmi.github.io/ruststream-lapin/) |
+| Kafka | [`ruststream-rdkafka`](https://github.com/powersemmi/ruststream-rdkafka) | Apache Kafka (consumer groups, tracked commits, transactions, exactly-once pipelines) | [powersemmi.github.io/ruststream-rdkafka](https://powersemmi.github.io/ruststream-rdkafka/) |
 
 To implement a broker for another transport, see [Broker authors](../broker-authors/index.md).
 
@@ -82,6 +83,25 @@ differs by one line inside `with_broker`.
             .with_broker(LapinBroker::new("amqp://localhost:5672"), |b| {
                 b.include_router(routes::orders())
             })
+    }
+    ```
+
+=== "Kafka"
+
+    <!-- inline-rust: Kafka half of the broker-switch comparison; depends on the external ruststream-rdkafka crate, no in-repo compiled home -->
+    ```rust
+    use ruststream::runtime::{AppInfo, RustStream};
+    use ruststream_rdkafka::KafkaBroker;
+
+    #[ruststream::app]
+    fn app() -> RustStream {
+        RustStream::new(AppInfo::new("orders", "0.1.0"))
+            .with_broker(
+                KafkaBroker::new(["localhost:9092"]).default_group("orders"),
+                |b| {
+                    b.include_router(routes::orders())
+                },
+            )
     }
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - NATS: https://powersemmi.github.io/ruststream-nats/
       - Redis: https://powersemmi.github.io/ruststream-fred/
       - RabbitMQ: https://powersemmi.github.io/ruststream-lapin/
+      - Kafka: https://powersemmi.github.io/ruststream-rdkafka/
   - Broker authors:
       - broker-authors/index.md
       - broker-authors/example-nats.md


### PR DESCRIPTION
Closes #76 - the crate itself shipped (0.5.x on crates.io with its own docs site); this adds the core-side references, mirroring the other brokers:

- the **Brokers** nav links the Kafka site;
- the brokers page gains the table row and a Kafka tab in the broker-switch comparison;
- the README ecosystem section lists the crate.

mkdocs --strict and the doc-fence lint pass.