### PR TITLE
feat: security schemes on ServerSpec for AsyncAPI servers

### DIFF
--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -77,7 +77,29 @@ Build a `ServerSpec` directly:
 ```
 
 A broker crate may also implement the `DescribeServer` capability, in which case
-`broker.describe_server()` produces the spec for you (none of the shipped brokers do yet).
+`broker.describe_server()` produces the spec for you (the shipped brokers all do), and
+`with_broker_labeled` records it automatically under the broker's label.
+
+## Server security
+
+Declare how clients authenticate with `ServerSpec::with_security`; each scheme lands in
+`components.securitySchemes` and is referenced from the server's `security` list:
+
+```rust
+--8<-- "examples/asyncapi_http.rs:security"
+```
+
+`SecurityScheme` has constructors for the AsyncAPI 3.0 scheme kinds - `user_password`, `plain`,
+`scram_sha256` / `scram_sha512`, `gssapi`, `api_key`, `x509`, `http`, `http_api_key`,
+`open_id_connect`, and `oauth2` (which takes the flows object as raw JSON) - plus
+`SecurityScheme::custom(json)` as the escape hatch for anything they do not model. Without
+`with_security` the document carries no security sections at all.
+
+Security is deliberately the service author's statement, not the broker's: the same broker is
+deployed publicly and internally with different authentication, so `DescribeServer` never reports
+it. To secure a server a broker registered automatically (`with_broker_labeled`), declare it
+explicitly instead: `.server(label, broker.describe_server().with_security(..))` with the same
+label.
 
 ## Serving the document
 

--- a/examples/asyncapi_http.rs
+++ b/examples/asyncapi_http.rs
@@ -17,12 +17,13 @@ use axum::routing::get;
 use ruststream::asyncapi::{ViewerOptions, build_spec, render_viewer_html};
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
-use ruststream::subscriber;
+use ruststream::schemars::JsonSchema;
+use ruststream::{Message, SecurityScheme, ServerSpec, subscriber};
 use serde::Deserialize;
 
 // --8<-- [start:payload]
 /// An order placed by a customer.
-#[derive(Debug, Deserialize, ruststream::Message, ruststream::schemars::JsonSchema)]
+#[derive(Debug, Deserialize, Message, JsonSchema)]
 struct Order {
     id: u64,
     item: String,
@@ -42,11 +43,18 @@ fn service() -> RustStream {
     // spec - here the in-memory broker, which describes itself as an in-process "memory" server
     // with no host. A broker without a `DescribeServer` impl is instead declared explicitly with
     // `.server(name, spec)` alongside a plain `with_broker`.
-    RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker_labeled(
-        "in-process",
-        MemoryBroker::new(),
-        |b| b.include(handle),
-    )
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        // --8<-- [start:security]
+        // A described external server. Security is the author's statement, not the broker's:
+        // the same broker is deployed publicly and internally with different authentication,
+        // so the scheme is attached to the spec at registration and brokers never set it.
+        .server(
+            "kafka",
+            ServerSpec::new("kafka.example.com:9093", "kafka")
+                .with_security(SecurityScheme::scram_sha512().with_description("SASL over TLS")),
+        )
+        // --8<-- [end:security]
+        .with_broker_labeled("in-process", MemoryBroker::new(), |b| b.include(handle))
 }
 // --8<-- [end:server]
 

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -69,6 +69,11 @@ pub struct Server {
     /// Optional human description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// References into `components.securitySchemes` describing how clients authenticate. Empty
+    /// (and absent from the document) unless the service author attached schemes with
+    /// [`ServerSpec::with_security`](crate::ServerSpec::with_security).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<Reference>,
 }
 
 /// `AsyncAPI` `Info` object: service title, version, and optional description.
@@ -116,6 +121,10 @@ pub struct Components {
     /// Message definitions, keyed by message name.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub messages: BTreeMap<String, MessageObject>,
+    /// Security scheme definitions the servers reference, keyed by scheme name (the server's
+    /// name, `-N`-suffixed when a server declares several).
+    #[serde(rename = "securitySchemes", skip_serializing_if = "BTreeMap::is_empty")]
+    pub security_schemes: BTreeMap<String, Value>,
 }
 
 /// An `AsyncAPI` message definition.
@@ -190,16 +199,32 @@ pub fn build_spec<A: App>(app: &A) -> Spec {
         description: app.info().description.clone(),
     };
 
+    let mut security_schemes = BTreeMap::new();
     let servers = app
         .servers()
         .iter()
         .map(|(name, spec)| {
+            let security = spec
+                .security
+                .iter()
+                .enumerate()
+                .map(|(index, scheme)| {
+                    let key = if index == 0 {
+                        name.clone()
+                    } else {
+                        format!("{name}-{index}")
+                    };
+                    security_schemes.insert(key.clone(), security_scheme_object(scheme));
+                    Reference::new(format!("#/components/securitySchemes/{key}"))
+                })
+                .collect();
             (
                 name.clone(),
                 Server {
                     host: spec.host.clone(),
                     protocol: spec.protocol.clone(),
                     description: spec.description.clone(),
+                    security,
                 },
             )
         })
@@ -277,8 +302,47 @@ pub fn build_spec<A: App>(app: &A) -> Spec {
         servers,
         channels,
         operations,
-        components: Components { messages },
+        components: Components {
+            messages,
+            security_schemes,
+        },
     }
+}
+
+/// Renders a [`SecurityScheme`](crate::SecurityScheme) as its `AsyncAPI` security scheme object.
+fn security_scheme_object(scheme: &crate::SecurityScheme) -> Value {
+    use crate::capability::SecuritySchemeKind as Kind;
+
+    // Raw payloads round-trip through the string the constructor serialized, so parsing them
+    // back cannot fail; Null is the unreachable fallback, not an error path.
+    let parse = |raw: &str| serde_json::from_str::<Value>(raw).unwrap_or(Value::Null);
+    let mut object = match &scheme.kind {
+        Kind::UserPassword => serde_json::json!({ "type": "userPassword" }),
+        Kind::ApiKey { location } => {
+            serde_json::json!({ "type": "apiKey", "in": location.as_api() })
+        }
+        Kind::X509 => serde_json::json!({ "type": "X509" }),
+        Kind::Plain => serde_json::json!({ "type": "plain" }),
+        Kind::ScramSha256 => serde_json::json!({ "type": "scramSha256" }),
+        Kind::ScramSha512 => serde_json::json!({ "type": "scramSha512" }),
+        Kind::Gssapi => serde_json::json!({ "type": "gssapi" }),
+        Kind::Http { scheme } => serde_json::json!({ "type": "http", "scheme": scheme }),
+        Kind::HttpApiKey { name, location } => serde_json::json!({
+            "type": "httpApiKey",
+            "name": name,
+            "in": location.as_api(),
+        }),
+        Kind::OpenIdConnect { url } => serde_json::json!({
+            "type": "openIdConnect",
+            "openIdConnectUrl": url,
+        }),
+        Kind::Oauth2 { flows } => serde_json::json!({ "type": "oauth2", "flows": parse(flows) }),
+        Kind::Custom { object } => parse(object),
+    };
+    if let (Some(description), Some(fields)) = (&scheme.description, object.as_object_mut()) {
+        fields.insert("description".to_owned(), Value::String(description.clone()));
+    }
+    object
 }
 
 /// Renders a self-contained HTML page that displays `spec_url` using the `AsyncAPI` React component.

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -439,3 +439,76 @@ fn operation_id(name: &str) -> String {
         .collect();
     format!("receive_{sanitized}")
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{ApiKeyLocation, HttpApiKeyLocation, SecurityScheme};
+
+    use super::security_scheme_object;
+
+    #[test]
+    fn every_scheme_kind_renders_its_document_object() {
+        let cases = [
+            (
+                SecurityScheme::user_password(),
+                serde_json::json!({ "type": "userPassword" }),
+            ),
+            (
+                SecurityScheme::api_key(ApiKeyLocation::Password),
+                serde_json::json!({ "type": "apiKey", "in": "password" }),
+            ),
+            (
+                SecurityScheme::x509(),
+                serde_json::json!({ "type": "X509" }),
+            ),
+            (
+                SecurityScheme::plain(),
+                serde_json::json!({ "type": "plain" }),
+            ),
+            (
+                SecurityScheme::scram_sha256(),
+                serde_json::json!({ "type": "scramSha256" }),
+            ),
+            (
+                SecurityScheme::scram_sha512(),
+                serde_json::json!({ "type": "scramSha512" }),
+            ),
+            (
+                SecurityScheme::gssapi(),
+                serde_json::json!({ "type": "gssapi" }),
+            ),
+            (
+                SecurityScheme::http("bearer"),
+                serde_json::json!({ "type": "http", "scheme": "bearer" }),
+            ),
+            (
+                SecurityScheme::http_api_key("X-Api-Key", HttpApiKeyLocation::Header),
+                serde_json::json!({ "type": "httpApiKey", "name": "X-Api-Key", "in": "header" }),
+            ),
+            (
+                SecurityScheme::open_id_connect("https://idp.example.com/.well-known"),
+                serde_json::json!({
+                    "type": "openIdConnect",
+                    "openIdConnectUrl": "https://idp.example.com/.well-known",
+                }),
+            ),
+            (
+                SecurityScheme::oauth2(serde_json::json!({ "clientCredentials": {} })),
+                serde_json::json!({ "type": "oauth2", "flows": { "clientCredentials": {} } }),
+            ),
+            (
+                SecurityScheme::custom(serde_json::json!({ "type": "symmetricEncryption" })),
+                serde_json::json!({ "type": "symmetricEncryption" }),
+            ),
+        ];
+        for (scheme, expected) in cases {
+            assert_eq!(security_scheme_object(&scheme), expected);
+        }
+    }
+
+    #[test]
+    fn description_lands_in_the_rendered_object() {
+        let object = security_scheme_object(&SecurityScheme::plain().with_description("over TLS"));
+        assert_eq!(object["description"], "over TLS");
+    }
+}

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -153,6 +153,11 @@ pub struct ServerSpec {
     pub protocol: String,
     /// An optional human description of this server.
     pub description: Option<String>,
+    /// How clients authenticate to this server, emitted as the `AsyncAPI` server's `security`
+    /// list. Empty by default: authentication is a property of the described deployment (the same
+    /// broker is deployed publicly and internally with different schemes), so the service author
+    /// states it at registration ([`with_security`](Self::with_security)); brokers never set it.
+    pub security: Vec<SecurityScheme>,
 }
 
 impl ServerSpec {
@@ -163,6 +168,7 @@ impl ServerSpec {
             host: Some(host.into()),
             protocol: protocol.into(),
             description: None,
+            security: Vec::new(),
         }
     }
 
@@ -177,10 +183,348 @@ impl ServerSpec {
             host: None,
             protocol: protocol.into(),
             description: None,
+            security: Vec::new(),
         }
     }
 
     /// Builder-style setter for the server description.
+    #[must_use]
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Adds a security scheme clients use to authenticate to this server. Call repeatedly to
+    /// declare alternatives; without any call the generated document carries no security
+    /// sections, exactly as before.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::{SecurityScheme, ServerSpec};
+    ///
+    /// let spec = ServerSpec::new("kafka.example.com:9093", "kafka")
+    ///     .with_security(SecurityScheme::scram_sha512().with_description("SASL over TLS"));
+    /// assert_eq!(spec.security.len(), 1);
+    /// ```
+    #[must_use]
+    pub fn with_security(mut self, scheme: SecurityScheme) -> Self {
+        self.security.push(scheme);
+        self
+    }
+}
+
+/// How clients authenticate to an [`AsyncAPI` server](ServerSpec), per the `AsyncAPI` 3.0
+/// security scheme types.
+///
+/// Constructed with the per-kind constructors ([`scram_sha512`](Self::scram_sha512),
+/// [`user_password`](Self::user_password), ...) and attached to a server with
+/// [`ServerSpec::with_security`]. For a scheme shape the constructors do not model, use
+/// [`custom`](Self::custom) with the raw `AsyncAPI` security scheme object.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::SecurityScheme;
+///
+/// let scheme = SecurityScheme::user_password().with_description("service credentials");
+/// # let _ = scheme;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecurityScheme {
+    pub(crate) kind: SecuritySchemeKind,
+    pub(crate) description: Option<String>,
+}
+
+/// The scheme kind and its type-specific fields. Raw JSON payloads (`oauth2` flows, `custom`)
+/// are stored as serialized text so the containing types stay `Eq`.
+// Only the asyncapi module reads the fields (into the generated document); without that feature
+// they are write-only, which is fine - the data still travels through ServerSpec equality.
+#[cfg_attr(not(feature = "asyncapi"), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SecuritySchemeKind {
+    UserPassword,
+    ApiKey {
+        location: ApiKeyLocation,
+    },
+    X509,
+    Plain,
+    ScramSha256,
+    ScramSha512,
+    Gssapi,
+    Http {
+        scheme: String,
+    },
+    HttpApiKey {
+        name: String,
+        location: HttpApiKeyLocation,
+    },
+    OpenIdConnect {
+        url: String,
+    },
+    Oauth2 {
+        flows: String,
+    },
+    Custom {
+        object: String,
+    },
+}
+
+/// Where an `apiKey` scheme carries the key, per `AsyncAPI` 3.0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiKeyLocation {
+    /// The key rides in the user field of the transport's credentials.
+    User,
+    /// The key rides in the password field of the transport's credentials.
+    Password,
+}
+
+impl ApiKeyLocation {
+    /// The `AsyncAPI` document value; read by the asyncapi module only.
+    #[cfg_attr(not(feature = "asyncapi"), allow(dead_code))]
+    pub(crate) fn as_api(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Password => "password",
+        }
+    }
+}
+
+/// Where an `httpApiKey` scheme carries the key, per `AsyncAPI` 3.0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpApiKeyLocation {
+    /// A query parameter.
+    Query,
+    /// An HTTP header.
+    Header,
+    /// A cookie.
+    Cookie,
+}
+
+impl HttpApiKeyLocation {
+    /// The `AsyncAPI` document value; read by the asyncapi module only.
+    #[cfg_attr(not(feature = "asyncapi"), allow(dead_code))]
+    pub(crate) fn as_api(self) -> &'static str {
+        match self {
+            Self::Query => "query",
+            Self::Header => "header",
+            Self::Cookie => "cookie",
+        }
+    }
+}
+
+impl SecurityScheme {
+    fn of(kind: SecuritySchemeKind) -> Self {
+        Self {
+            kind,
+            description: None,
+        }
+    }
+
+    /// Username and password credentials (`userPassword`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::user_password();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn user_password() -> Self {
+        Self::of(SecuritySchemeKind::UserPassword)
+    }
+
+    /// An API key carried in the transport credentials (`apiKey`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::{ApiKeyLocation, SecurityScheme};
+    /// let scheme = SecurityScheme::api_key(ApiKeyLocation::User);
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn api_key(location: ApiKeyLocation) -> Self {
+        Self::of(SecuritySchemeKind::ApiKey { location })
+    }
+
+    /// Mutual TLS with client certificates (`X509`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::x509();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn x509() -> Self {
+        Self::of(SecuritySchemeKind::X509)
+    }
+
+    /// SASL PLAIN (`plain`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::plain();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn plain() -> Self {
+        Self::of(SecuritySchemeKind::Plain)
+    }
+
+    /// SASL SCRAM-SHA-256 (`scramSha256`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::scram_sha256();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn scram_sha256() -> Self {
+        Self::of(SecuritySchemeKind::ScramSha256)
+    }
+
+    /// SASL SCRAM-SHA-512 (`scramSha512`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::scram_sha512();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn scram_sha512() -> Self {
+        Self::of(SecuritySchemeKind::ScramSha512)
+    }
+
+    /// SASL GSSAPI / Kerberos (`gssapi`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::gssapi();
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn gssapi() -> Self {
+        Self::of(SecuritySchemeKind::Gssapi)
+    }
+
+    /// An HTTP authentication scheme (`http`), e.g. `"basic"` or `"bearer"` - for brokers with
+    /// HTTP-based control or connection endpoints.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::http("bearer");
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn http(scheme: impl Into<String>) -> Self {
+        Self::of(SecuritySchemeKind::Http {
+            scheme: scheme.into(),
+        })
+    }
+
+    /// An API key in an HTTP query parameter, header, or cookie (`httpApiKey`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::{HttpApiKeyLocation, SecurityScheme};
+    /// let scheme = SecurityScheme::http_api_key("X-Api-Key", HttpApiKeyLocation::Header);
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn http_api_key(name: impl Into<String>, location: HttpApiKeyLocation) -> Self {
+        Self::of(SecuritySchemeKind::HttpApiKey {
+            name: name.into(),
+            location,
+        })
+    }
+
+    /// `OpenID Connect` discovery (`openIdConnect`), pointing at the provider's discovery URL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::open_id_connect("https://idp.example.com/.well-known/openid-configuration");
+    /// # let _ = scheme;
+    /// ```
+    #[must_use]
+    pub fn open_id_connect(url: impl Into<String>) -> Self {
+        Self::of(SecuritySchemeKind::OpenIdConnect { url: url.into() })
+    }
+
+    /// `OAuth2` (`oauth2`) with the given `AsyncAPI` flows object, passed as raw JSON (the flows
+    /// shape is deep and deployment-specific, so it is not modeled field by field).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    ///
+    /// let scheme = SecurityScheme::oauth2(serde_json::json!({
+    ///     "clientCredentials": {
+    ///         "tokenUrl": "https://idp.example.com/token",
+    ///         "availableScopes": { "kafka:write": "produce" },
+    ///     }
+    /// }));
+    /// # let _ = scheme;
+    /// ```
+    #[cfg(feature = "json")]
+    #[must_use]
+    // By-value keeps the natural `oauth2(json!(..))` call shape; the value is serialized on the
+    // spot, so borrowing would only force callers to hold a temporary.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn oauth2(flows: serde_json::Value) -> Self {
+        Self::of(SecuritySchemeKind::Oauth2 {
+            flows: flows.to_string(),
+        })
+    }
+
+    /// An arbitrary `AsyncAPI` security scheme object, emitted as-is - the escape hatch for
+    /// kinds or fields the constructors do not model.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    ///
+    /// let scheme = SecurityScheme::custom(serde_json::json!({ "type": "symmetricEncryption" }));
+    /// # let _ = scheme;
+    /// ```
+    #[cfg(feature = "json")]
+    #[must_use]
+    // By-value keeps the natural `custom(json!(..))` call shape; the value is serialized on the
+    // spot, so borrowing would only force callers to hold a temporary.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom(object: serde_json::Value) -> Self {
+        Self::of(SecuritySchemeKind::Custom {
+            object: object.to_string(),
+        })
+    }
+
+    /// Builder-style setter for the scheme description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::SecurityScheme;
+    /// let scheme = SecurityScheme::plain().with_description("SASL over TLS");
+    /// # let _ = scheme;
+    /// ```
     #[must_use]
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -554,3 +554,113 @@ pub trait DescribeServer: Broker {
     /// Returns the server coordinates for this broker.
     fn describe_server(&self) -> ServerSpec;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_security_accumulates_schemes_in_order() {
+        let spec = ServerSpec::new("kafka.example.com:9093", "kafka")
+            .with_security(SecurityScheme::scram_sha512())
+            .with_security(SecurityScheme::x509());
+        assert_eq!(spec.security.len(), 2);
+        assert_eq!(spec.security[0].kind, SecuritySchemeKind::ScramSha512);
+        assert_eq!(spec.security[1].kind, SecuritySchemeKind::X509);
+    }
+
+    #[test]
+    fn in_process_spec_starts_without_security() {
+        let spec = ServerSpec::in_process("memory");
+        assert!(spec.security.is_empty());
+    }
+
+    #[test]
+    fn constructors_produce_their_kind() {
+        let cases = [
+            (
+                SecurityScheme::user_password(),
+                SecuritySchemeKind::UserPassword,
+            ),
+            (
+                SecurityScheme::api_key(ApiKeyLocation::User),
+                SecuritySchemeKind::ApiKey {
+                    location: ApiKeyLocation::User,
+                },
+            ),
+            (SecurityScheme::x509(), SecuritySchemeKind::X509),
+            (SecurityScheme::plain(), SecuritySchemeKind::Plain),
+            (
+                SecurityScheme::scram_sha256(),
+                SecuritySchemeKind::ScramSha256,
+            ),
+            (
+                SecurityScheme::scram_sha512(),
+                SecuritySchemeKind::ScramSha512,
+            ),
+            (SecurityScheme::gssapi(), SecuritySchemeKind::Gssapi),
+            (
+                SecurityScheme::http("bearer"),
+                SecuritySchemeKind::Http {
+                    scheme: "bearer".into(),
+                },
+            ),
+            (
+                SecurityScheme::http_api_key("X-Api-Key", HttpApiKeyLocation::Header),
+                SecuritySchemeKind::HttpApiKey {
+                    name: "X-Api-Key".into(),
+                    location: HttpApiKeyLocation::Header,
+                },
+            ),
+            (
+                SecurityScheme::open_id_connect("https://idp.example.com/.well-known"),
+                SecuritySchemeKind::OpenIdConnect {
+                    url: "https://idp.example.com/.well-known".into(),
+                },
+            ),
+        ];
+        for (scheme, kind) in cases {
+            assert_eq!(scheme.kind, kind);
+            assert_eq!(scheme.description, None);
+        }
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn json_backed_constructors_serialize_their_payload() {
+        let oauth2 = SecurityScheme::oauth2(serde_json::json!({ "clientCredentials": {} }));
+        assert_eq!(
+            oauth2.kind,
+            SecuritySchemeKind::Oauth2 {
+                flows: r#"{"clientCredentials":{}}"#.into(),
+            }
+        );
+
+        let custom = SecurityScheme::custom(serde_json::json!({ "type": "symmetricEncryption" }));
+        assert_eq!(
+            custom.kind,
+            SecuritySchemeKind::Custom {
+                object: r#"{"type":"symmetricEncryption"}"#.into(),
+            }
+        );
+    }
+
+    #[test]
+    fn with_description_sets_the_description() {
+        let scheme = SecurityScheme::plain().with_description("SASL over TLS");
+        assert_eq!(scheme.description.as_deref(), Some("SASL over TLS"));
+    }
+
+    #[test]
+    fn api_key_locations_map_to_document_values() {
+        assert_eq!(ApiKeyLocation::User.as_api(), "user");
+        assert_eq!(ApiKeyLocation::Password.as_api(), "password");
+    }
+
+    #[test]
+    fn http_api_key_locations_map_to_document_values() {
+        assert_eq!(HttpApiKeyLocation::Query.as_api(), "query");
+        assert_eq!(HttpApiKeyLocation::Header.as_api(), "header");
+        assert_eq!(HttpApiKeyLocation::Cookie.as_api(), "cookie");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub use inventory;
 pub use broker::Broker;
 pub use buffered::{Buffered, BufferedSubscriber};
 pub use capability::{
-    BatchSubscriber, DescribeServer, Partitioned, RequestReply, ServerSpec, Subscribe,
-    TransactionalPublisher,
+    ApiKeyLocation, BatchSubscriber, DescribeServer, HttpApiKeyLocation, Partitioned, RequestReply,
+    SecurityScheme, ServerSpec, Subscribe, TransactionalPublisher,
 };
 pub use error::AckError;
 pub use field::{BuildContext, ContextField, Field, FieldMut};

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -1,10 +1,10 @@
 //! Integration test for `AsyncAPI` document generation.
 #![cfg(all(feature = "asyncapi", feature = "memory"))]
 
-use ruststream::ServerSpec;
 use ruststream::asyncapi::{ViewerOptions, build_spec, render_viewer_html};
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, RustStream};
+use ruststream::{SecurityScheme, ServerSpec};
 
 #[test]
 fn build_spec_describes_handlers() {
@@ -308,4 +308,49 @@ fn schema_doc_comment_feeds_message_metadata() {
         spec.operations["receive_shipments"].description.as_deref(),
         Some("Receives shipments."),
     );
+}
+
+#[test]
+fn server_security_lands_in_components_and_refs() {
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0"))
+        .server(
+            "kafka",
+            ServerSpec::new("kafka.example.com:9093", "kafka")
+                .with_security(SecurityScheme::scram_sha512().with_description("SASL over TLS"))
+                .with_security(SecurityScheme::custom(
+                    serde_json::json!({ "type": "gssapi" }),
+                )),
+        )
+        .server("nats", ServerSpec::new("nats.example.com:4222", "nats"));
+
+    let spec = build_spec(&app);
+
+    // Each scheme becomes a components entry named after the server (suffixed past the first),
+    // and the server references them in order.
+    let kafka = &spec.servers["kafka"];
+    assert_eq!(
+        kafka.security[0].reference,
+        "#/components/securitySchemes/kafka"
+    );
+    assert_eq!(
+        kafka.security[1].reference,
+        "#/components/securitySchemes/kafka-1"
+    );
+    let schemes = &spec.components.security_schemes;
+    assert_eq!(schemes["kafka"]["type"], "scramSha512");
+    assert_eq!(schemes["kafka"]["description"], "SASL over TLS");
+    assert_eq!(schemes["kafka-1"]["type"], "gssapi");
+
+    // A server without schemes emits no `security` key; the untouched default document stays
+    // security-free entirely.
+    let json = spec.to_json().unwrap();
+    assert!(json.contains("\"securitySchemes\""));
+    let doc: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(doc["servers"]["nats"].get("security").is_none());
+
+    let bare = build_spec(
+        &RustStream::new(AppInfo::new("svc", "1.0.0"))
+            .server("nats", ServerSpec::new("nats.example.com:4222", "nats")),
+    );
+    assert!(!bare.to_json().unwrap().contains("security"));
 }


### PR DESCRIPTION
# Description

Adds a way to declare how clients authenticate to a broker in the generated AsyncAPI document. `ServerSpec` gains a `security` list filled with the new `SecurityScheme` type via `with_security`; `build_spec` emits each scheme into `components.securitySchemes` and references it from the server's `security` list.

Authentication is deliberately the service author's statement, not the broker's: the same broker is deployed publicly and internally with different schemes, so `DescribeServer` never reports security and broker crates require no changes (they build `ServerSpec` through its constructors and never see the new field). To secure an auto-registered (`with_broker_labeled`) server, the author declares it explicitly with `.server(label, broker.describe_server().with_security(..))`, which wins over the derived entry.

`SecurityScheme` provides constructors for the AsyncAPI 3.0 scheme kinds (`user_password`, `plain`, `scram_sha256` / `scram_sha512`, `gssapi`, `api_key`, `x509`, `http`, `http_api_key`, `open_id_connect`, and `oauth2` taking the flows object as raw JSON), plus `custom(json)` as the escape hatch. Raw JSON payloads are stored serialized so `ServerSpec` keeps its `Eq`. Without `with_security` the document carries no security sections, exactly as before.

The docs AsyncAPI guide gains a "Server security" section with a compiled snippet from the `asyncapi_http` example, and a stale note about no shipped broker implementing `DescribeServer` is corrected along the way.

Fixes #142

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable