### PR TITLE
ci: bounded gh-pages history, coverage and downloads badges, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Daily dependency updates. Version bumps arrive as PRs (minor and patch bumps grouped into
+# one PR to keep the queue small); vulnerability reports come from Dependabot security alerts,
+# which are a repository setting (Settings -> Advanced Security), not part of this file.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,16 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
+      # Feeds the README coverage badge. Coveralls accepts the default GITHUB_TOKEN for public
+      # repositories, so no extra secret is required; uploaded even when the gate fails so the
+      # badge reflects reality rather than the last green run.
+      - name: Upload to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@v2
+        with:
+          file: lcov.info
+          format: lcov
+
   package:
     name: Package (publish dry-run)
     needs: changes

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -44,5 +44,17 @@ jobs:
       - name: Deploy with mike
         run: |
           version="$(sed -nE 's/^version = "([0-9]+)\.([0-9]+).*/\1.\2/p' Cargo.toml | head -1)"
-          mike deploy --push --update-aliases "$version" latest
-          mike set-default --push latest
+          mike deploy --update-aliases "$version" latest
+          mike set-default latest
+
+      # mike records every deploy as a new commit on gh-pages, and each commit carries a full
+      # copy of the rendered site, so the branch grows without bound (GitHub keeps the whole
+      # history). Serving only needs the latest tree: rewrite the branch to a single commit
+      # holding the current site and force-push, the same fix faststream applies to its docs
+      # pipeline. mike itself only reads the branch tree (all deployed versions live side by
+      # side in it), never the history, so squashing is invisible to the next deploy.
+      - name: Squash gh-pages history and push
+        run: |
+          git checkout gh-pages
+          git reset --hard "$(git commit-tree -m 'docs: deploy' 'HEAD^{tree}')"
+          git push --force origin gh-pages

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 <p align="center">
   <a href="https://github.com/powersemmi/ruststream/actions/workflows/ci.yml"><img src="https://github.com/powersemmi/ruststream/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://coveralls.io/github/powersemmi/ruststream?branch=main"><img src="https://coveralls.io/repos/github/powersemmi/ruststream/badge.svg?branch=main" alt="Coverage"></a>
   <a href="https://crates.io/crates/ruststream"><img src="https://img.shields.io/crates/v/ruststream.svg" alt="crates.io"></a>
+  <a href="https://crates.io/crates/ruststream"><img src="https://img.shields.io/crates/dr/ruststream" alt="Recent downloads"></a>
   <a href="https://docs.rs/ruststream"><img src="https://img.shields.io/docsrs/ruststream" alt="docs.rs"></a>
   <img src="https://img.shields.io/badge/MSRV-1.85-blue.svg" alt="MSRV 1.85">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License">


### PR DESCRIPTION
# Description

Infrastructure round-up: keeps the docs branch from growing forever, surfaces test coverage and crate downloads in the README, and turns on daily dependency updates.

- **Docs deploy no longer grows gh-pages without bound.** mike records every deploy as a new commit carrying a full copy of the rendered site, so the branch (and the repository) inflates on each push. The deploy now runs mike locally, rewrites gh-pages to a single commit holding the current tree, and force-pushes - the same fix faststream applies to its docs pipeline. mike only reads the branch tree (all deployed versions live side by side in it), never its history, so versioned docs keep working.
- **Coverage badge.** The coverage job already produces an lcov report; it is now uploaded to Coveralls (the default `GITHUB_TOKEN` is enough for a public repository, no new secret) and the percentage is shown as a README badge.
- **Recent-downloads badge.** crates.io exposes total and recent (last 90 days) download counts, not per-month; the badge shows the recent count.
- **Dependabot.** Daily version updates for cargo and github-actions, with minor/patch cargo bumps grouped into one PR to keep the queue manageable. Vulnerability reporting comes from Dependabot security alerts, enabled in the repository settings.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)

(No Rust surface is touched: the change is workflows, dependabot config, and README badges.)