### PR TITLE
feat: background start with a handle - app.start() -> RunningApp

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,7 +9,7 @@ on:
     # deployed by the next docs change or manually via workflow_dispatch.
     paths:
       - docs/**
-      - mkdocs.yml
+      - properdocs.yml
       - overrides/**
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths: &docs-paths
       - docs/**
-      - mkdocs.yml
+      - properdocs.yml
       - overrides/**
       - examples/**
       # the testing and conformance guides embed their snippets from these test files
@@ -45,4 +45,4 @@ jobs:
         run: python3 scripts/lint_doc_fences.py
 
       - name: Build site (strict)
-        run: mkdocs build --strict
+        run: properdocs build --strict

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ name = "metrics_http"
 required-features = ["macros", "memory", "metrics"]
 
 [[example]]
+name = "http_outbox"
+required-features = ["macros", "memory", "json"]
+
+[[example]]
 name = "logging"
 required-features = ["macros", "memory", "json", "logging"]
 

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -4,7 +4,7 @@ The conformance harness proves a broker honours the core contract. It has two en
 which panic with a descriptive message on the first failure:
 
 - `harness::run_suite` checks the **routing surface** against your in-process transport (the
-  [`TestableBroker`](../guides/testing.md#for-broker-authors) you ship).
+  [`TestableBroker`](index.md#test-support) you ship).
 - `harness::lifecycle` checks the **lazy-startup contract** end to end against a connected broker.
 
 Run both: `run_suite` for the dispatch guarantees, `lifecycle` to prove `new` -> `connect` ->

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -154,5 +154,17 @@ Ship an in-process transport implementing `TestableBroker` under a `testing` fea
 harness. The transport does **core routing only**: it dispatches published messages to matching
 subscribers and treats ack/nack as effectively a no-op. Do not simulate broker-specific semantics
 (durable cursors, redelivery timers, offsets, dead-letter routing) in it; those are verified end to
-end against a real server. See [Testing](../guides/testing.md) for the user-facing side, and
-[Conformance](conformance.md) to prove the implementation.
+end against a real server.
+
+The reference is `MemoryBroker`'s own implementation:
+
+```rust
+--8<-- "src/memory/mod.rs:testable"
+```
+
+The transport calls `Coordinator::enqueued` on every enqueue into a subscriber and
+`Coordinator::consumed` when a delivery is settled or dropped (so the harness can tell when the
+reaction has settled), and routes delayed redeliveries through `Coordinator::schedule_redelivery`.
+That one type then works with both `TestApp` and the conformance suite. See
+[Testing](../guides/testing.md) for the user-facing side, and [Conformance](conformance.md) to
+prove the implementation with `run_suite` and the lazy-startup `lifecycle` check.

--- a/docs/broker-authors/templates.md
+++ b/docs/broker-authors/templates.md
@@ -2,7 +2,7 @@
 
 How a crate ships a [`cargo generate`](https://github.com/cargo-generate/cargo-generate) scaffold
 that stays in sync with its API. The contract is the scaffolding parallel of the
-[conformance harness](../broker-authors/conformance.md): a template is a CI-compiled artifact owned by the
+[conformance harness](conformance.md): a template is a CI-compiled artifact owned by the
 crate whose broker it wires, not hand-maintained strings in the core CLI. Core ships only the
 in-memory `templates/memory`; each broker crate owns the templates for its transports.
 

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -105,6 +105,7 @@ differs by one line inside `with_broker`.
     }
     ```
 
-Subscriptions that need broker-specific options (consumer groups, durable names) use that broker's
-descriptor in the `#[subscriber(..)]` decorator; see
+Each broker crate documents its own `Config` and connection options. Subscriptions that need
+broker-specific options (consumer groups, durable names) use that broker's descriptor in the
+`#[subscriber(..)]` decorator; see
 [broker-specific descriptors](../guides/subscribers.md#broker-specific-descriptors).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,22 +48,10 @@ ruststream = { version = "0.4", default-features = false }
 
 ## The CLI
 
-The `ruststream` binary ships with the crate behind the `cli` feature. Install it to drive `cargo`
-with the framework's subcommands (`run`, `asyncapi gen`):
-
-```bash
-cargo install ruststream --features cli
-```
-
-Scaffolding a new project is `cargo generate` against a template (no `ruststream` install required):
-
-```bash
-cargo install cargo-generate
-cargo generate --git https://github.com/powersemmi/ruststream templates/memory --name my-service
-```
-
-See the [CLI guide](../guides/cli.md) and the [template contract](../guides/templates.md), or jump
-straight to the [quick start](quickstart.md).
+The optional `ruststream` binary ships with the crate behind the `cli` cargo feature and drives
+`cargo` with the framework's subcommands (`run`, `asyncapi gen`); installation and commands are in
+the [CLI guide](../guides/cli.md). Scaffolding a new project does not need it - that is `cargo
+generate` against a template, covered in the [quick start](quickstart.md).
 
 ## Concrete brokers
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,9 +10,10 @@ cargo generate --git https://github.com/powersemmi/ruststream templates/memory -
 cd my-service
 ```
 
-`templates/memory` is the in-memory starter (no external broker); each broker crate ships its own
-template (for example `--git https://github.com/powersemmi/ruststream-nats templates/nats`). This
-writes an idiomatic, multi-file project:
+Scaffolding needs only `cargo generate`, not the `ruststream` CLI. `templates/memory` is the
+in-memory starter (no external broker); each broker crate ships its own template (for example
+`--git https://github.com/powersemmi/ruststream-nats templates/nats`). This writes an idiomatic,
+multi-file project:
 
 ```
 my-service/
@@ -38,10 +39,11 @@ so it runs with no external dependencies.
 ## Generate the AsyncAPI document
 
 ```bash
-cargo run -- asyncapi gen                 # prints JSON to stdout
-cargo run -- asyncapi gen -o asyncapi.json
-cargo run -- asyncapi gen --yaml
+cargo run -- asyncapi gen
 ```
+
+This prints the AsyncAPI document as JSON; the output flags (`-o`, `--yaml`) and the document
+itself are covered in the [AsyncAPI guide](../guides/asyncapi.md).
 
 ## What the entry point looks like
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -104,46 +104,20 @@ As handlers grow, keep them in their own module and collect them into a
 ## 6. Inspect the AsyncAPI document
 
 ```bash
-cargo run -- asyncapi gen --yaml
+cargo run -- asyncapi gen
 ```
 
 Every subscriber becomes a channel and a `receive` operation; payload types that derive
-`schemars::JsonSchema` also contribute schemas. See [AsyncAPI](../guides/asyncapi.md).
+`schemars::JsonSchema` also contribute schemas. The output flags (`-o`, `--yaml`) and the document
+itself are covered in [AsyncAPI](../guides/asyncapi.md).
 
 ## 7. Swap in a real broker
 
-Nothing above is tied to the in-memory broker. The handlers, router, and codecs are unchanged; only
-the broker construction differs. Add the broker crate as a dependency and swap the `with_broker`
-line:
-
-=== "Memory"
-
-    <!-- inline-rust: side-by-side broker-swap comparison; the NATS half depends on the external ruststream-nats crate and has no in-repo compiled home, so both halves stay inline to read in parallel -->
-    ```rust
-    use ruststream::memory::MemoryBroker;
-
-    .with_broker(MemoryBroker::new(), |b| {
-        let router = routes::orders(b.broker());
-        b.include_router(router);
-    })
-    ```
-
-=== "NATS"
-
-    <!-- inline-rust: NATS half of the broker-swap comparison; depends on the external ruststream-nats crate, no in-repo compiled home -->
-    ```rust
-    use ruststream_nats::NatsBroker;
-
-    .with_broker(NatsBroker::new("nats://localhost:4222"), |b| {
-        let router = routes::orders(b.broker());
-        b.include_router(router);
-    })
-    ```
-
-Each broker crate documents its own `Config`. Subscriptions that need broker-specific options
-(consumer groups, durable names) use that broker's descriptor in the decorator, see
-[broker-specific descriptors](../guides/subscribers.md#broker-specific-descriptors). The available
-brokers are listed under [Brokers](../brokers/index.md).
+Nothing above is tied to the in-memory broker. The broker is chosen at `with_broker`, so swapping
+is a one-line change: add the broker crate as a dependency and construct it there (for example
+`NatsBroker::new("nats://localhost:4222")` instead of `MemoryBroker::new()`); the handlers, router,
+and codecs are unchanged. The available brokers and the side-by-side swap for each of them are in
+[Brokers](../brokers/index.md#switching-brokers).
 
 !!! info "The complete service is a compiled example"
     Every snippet on this page is embedded from

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -45,31 +45,8 @@ crate and forwards the command to `cargo`.
 ## Scaffolding
 
 New projects are generated with [`cargo generate`](https://github.com/cargo-generate/cargo-generate)
-from a template. Templates are owned by the crate whose broker they wire: the in-memory starter lives
-in this repo, and each broker crate ships its own.
-
-```bash
-cargo install cargo-generate
-
-# in-memory starter (no external broker)
-cargo generate --git https://github.com/powersemmi/ruststream templates/memory --name my-service
-
-# a broker template (owned by the broker repo)
-cargo generate --git https://github.com/powersemmi/ruststream-nats templates/nats --name my-service
-```
-
-Each template writes a multi-file project so a fresh service starts idiomatic rather than as a single
-dumping-ground file:
-
-```
-my-service/
-├── Cargo.toml
-└── src/
-    ├── main.rs      # #[ruststream::app], mounts the router
-    ├── orders.rs    # #[subscriber] handlers, one with a reply
-    └── routes.rs    # a Router collecting the handlers
-```
-
-A broker repo typically ships one template per transport or topology (for example `nats` vs
-`nats-js`). See the [quick start](../getting-started/quickstart.md) to scaffold and run one;
-authoring a template for a new broker follows the [template contract](templates.md).
+from a template, not by this tool; the command and the project it writes are in the
+[quick start](../getting-started/quickstart.md). Templates are owned by the crate whose broker they
+wire: the in-memory starter lives in this repo, and each broker repo ships its own, typically one
+per transport or topology (for example `nats` vs `nats-js`). Authoring a template for a new broker
+follows the [template contract](../broker-authors/templates.md).

--- a/docs/guides/codecs.md
+++ b/docs/guides/codecs.md
@@ -72,11 +72,10 @@ property of the mounting, not of the type.
 
 ## Decode failures
 
-When decoding fails, the message is dropped by default (a nack without requeue). The policy is
-configurable on the typed adapter when you build handlers by hand: `typed(codec, handler)` returns
-a `Typed` wrapper whose `on_decode_failure` accepts a `FailurePolicy` (`Drop`, `Retry`,
-`RetryAfter(..)`, `Skip`, or `FailFast`). On a macro handler the same policy is set with the
-`on_failure(decode = ..)` clause (see the failure-policy guide).
+When decoding fails, the failure policy decides what happens to the message; by default it is
+dropped (a nack without requeue). On a macro handler the policy is set with the
+`on_failure(decode = ..)` clause; when building handlers by hand, the `Typed` wrapper returned by
+`typed(codec, handler)` takes the same policy through `on_decode_failure`:
 
 ```rust
 use ruststream::runtime::{FailurePolicy, typed};
@@ -85,8 +84,8 @@ use ruststream::runtime::{FailurePolicy, typed};
 --8<-- "examples/codecs.rs:decode_failure"
 ```
 
-Retry with care: a payload that can never decode will redeliver forever unless the broker has a
-dead-letter or max-deliveries policy. The codec examples above are
+The policy values (`Drop`, `Retry`, `RetryAfter(..)`, `Skip`, `FailFast`), the defaults, and the
+retry caveats live in [Failure policy](failure-policy.md). The codec examples above are
 [`examples/codecs.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/codecs.rs).
 
 ## Custom codecs

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -25,10 +25,17 @@ fixing the app's state type:
 The state type is checked at compile time: a `#[subscriber]` handler that reads state names it as
 the third `Context` generic (`Context<'_, C, S>`), and the runtime only lets that handler mount on
 an app whose state type matches. A handler that names no state type is generic over it, so it mounts
-on any app - this holds for `publish(..)` handlers too: one that ignores the state omits the
-`Context` parameter entirely and still mounts on a stateful app. The state is shared behind an `Arc` once the service runs, so handlers get cheap shared
-references, not copies; interior mutability (an `AtomicU64`, a mutex-guarded map) is the tool when a
-shared value must change at runtime. See [Lifespan](lifespan.md) for the startup-hook contract.
+on any app. `publish(..)` handlers follow the same rule with one twist: one that ignores the state
+omits the `Context` parameter entirely and still mounts on a stateful app, but one that declares a
+`Context` without naming a state type pins the state to `()`, so name the app's state type
+explicitly to mount such a handler on a stateful app.
+
+Handlers borrow the state with `ctx.state()`, which returns `&S`, the typed state itself - no
+lookup, no `Option`, no downcast. The state is shared behind an `Arc` once the service runs, so
+handlers get cheap shared references, not copies; interior mutability (an `AtomicU64`, a
+mutex-guarded map) is the tool when a shared value must change at runtime. For data scoped to one
+message rather than the whole service, use the [per-delivery context](#per-delivery-context)
+instead. See [Lifespan](lifespan.md) for the startup-hook contract.
 
 ```rust
 --8<-- "examples/context.rs:state"
@@ -167,21 +174,16 @@ Two boundaries to keep in mind:
 
 To publish from inside a handler (beyond the `publish(..)` reply form), put the publisher in the
 typed application state and reach it with `ctx.state()` - it stays typed, so the handler uses its
-own API directly:
-
-```rust
---8<-- "examples/publishing.rs:forward"
-```
-
-A closure handler cannot return a future that borrows the context across `.await`; publish from a
-`#[subscriber]` handler or a struct handler with `async fn handle`, both of which own the borrow.
-See [Publishing](publishing.md#publishing-from-inside-a-handler).
+own API directly. A closure handler cannot return a future that borrows the context across
+`.await`; publish from a `#[subscriber]` handler or a struct handler with `async fn handle`, both
+of which own the borrow. The full pattern and its snippet live in
+[Publishing from inside a handler](publishing.md#publishing-from-inside-a-handler).
 
 ## Post-settle hooks
 
 Sometimes a handler needs a side effect to fire *after* the message has been settled - a
-non-critical notification, slow follow-up work - without it gating the ack decision or affecting
-redelivery. Register one on the context:
+non-critical notification, slow follow-up work, a cache warm-up - without it gating the ack
+decision or affecting redelivery. Register one on the context:
 
 ```rust
 --8<-- "examples/context.rs:handler"
@@ -199,10 +201,17 @@ Three forms, all additive:
 - `ctx.after_ack(fut)` - sugar for `ctx.after(HandlerResult::Ack).then(fut)`.
 - `ctx.after_settle(fut)` - runs after the message settles, whatever the outcome.
 
-Multiple registrations accumulate and every matching one runs. The semantics are **at-most-once**:
-the message is already settled before any hook runs, so a hook that panics, or that is lost when the
-process crashes, never causes a redelivery. A graceful shutdown drains in-flight hooks (bounded by
-`shutdown_timeout`); an aborted shutdown may drop them.
+A handler can also attach a continuation through its return value: any outcome converts into a
+`Settle` with `.and_after(fut)`, which is how a batch handler gets per-element continuations. See
+[Post-settle continuations](subscribers.md#post-settle-continuations) for that form; the semantics
+below apply to both.
+
+Multiple registrations accumulate and every matching one runs, on a tracked task set off the
+delivery path. The semantics are **at-most-once**: the message is already settled before any hook
+runs, so a hook that panics, or that is lost when the process crashes, never causes a redelivery.
+Do not put work whose loss must redeliver the message in a hook; settle by outcome and let the
+broker retry instead. A graceful shutdown drains in-flight hooks (bounded by `shutdown_timeout`);
+an aborted shutdown may drop them.
 
 On the batch path a `Context` is one per *batch*, so a hook runs after the whole batch has settled.
 Because a batch has per-element outcomes, the outcome gate is ill-defined there: only

--- a/docs/guides/failure-policy.md
+++ b/docs/guides/failure-policy.md
@@ -42,7 +42,9 @@ The policy values are:
 | `skip`                | Acknowledge the failed message to move past it. Not success: the message is gone, unprocessed. |
 
 `skip` is the deliberate poison-message escape hatch: it advances past a message that cannot be
-processed rather than dropping or retrying it.
+processed rather than dropping or retrying it. Pick `retry` for decode failures with care: a
+payload that can never decode will redeliver forever unless the broker has a dead-letter or
+max-deliveries policy.
 
 ```rust
 --8<-- "examples/failure_policy.rs:skip"
@@ -55,8 +57,9 @@ processed rather than dropping or retrying it.
   restart; under the other policies it is settled and the subscriber keeps consuming. Catching only
   applies under an unwinding panic profile; with `panic = "abort"` the process is already gone.
 - A decode failure surfaces as a `Result`, so no unwinding is involved; the `decode` policy settles
-  the message directly. The same `on_decode_failure` policy can also be set when building a handler
-  by hand through the typed adapter (see [Codecs](codecs.md)).
+  the message directly. The same policy can also be set when building a handler by hand: the typed
+  adapter `typed(codec, handler)` returns a `Typed` wrapper whose `on_decode_failure` accepts a
+  `FailurePolicy` (see [Codecs](codecs.md#decode-failures)).
 - On the batch path the policy applies per batch decode (each element decodes independently) and to
   a panic in the batch handler. Per-element panic handling is out of scope.
 

--- a/docs/guides/http.md
+++ b/docs/guides/http.md
@@ -1,0 +1,94 @@
+# HTTP frameworks
+
+RustStream is not an HTTP framework and does not try to become one. When a service exposes a
+synchronous HTTP API and consumes messages, the HTTP framework (axum, actix-web, or any other
+tokio-based stack) runs beside the RustStream app in the same process and runtime. This page shows
+the wiring on axum and the pattern that makes the combination reliable: a transactional outbox.
+
+The full compiled example lives at
+[`examples/http_outbox.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/http_outbox.rs):
+
+```text
+cargo run --example http_outbox --features macros,memory,json
+```
+
+## Running beside an HTTP server
+
+Both sides come up in `main`. `start()` brings the messaging side up in the background - the
+state producer, broker connects, subscription opens - and resolves once the service is running,
+so a startup failure surfaces before the HTTP side accepts traffic. The returned `RunningApp`
+handle coordinates the two lifetimes: `stopping()` is an owned future that resolves if the
+messaging side tears itself down (a fail-fast failure), which plugs straight into axum's
+`with_graceful_shutdown` so the process does not keep serving HTTP with a dead consumer; and
+`shutdown()` is the explicit graceful teardown - the `on_shutdown` hooks, a drain of in-flight
+handlers bounded by the [shutdown timeout](lifespan.md#shutdown-timeout), broker shutdown - once
+the HTTP server has stopped. A publisher is taken from the broker before the app consumes it; it
+is a plain value, safe to clone into whatever state the HTTP framework carries:
+
+```rust
+--8<-- "examples/http_outbox.rs:wiring"
+```
+
+The subscriber side is an ordinary handler; the same service consumes what its HTTP endpoints
+produce, and any other service subscribed to the broker sees the events too:
+
+```rust
+--8<-- "examples/http_outbox.rs:handler"
+```
+
+## Publishing straight from a request
+
+The simplest integration puts the publisher into the HTTP framework's state and publishes on the
+request path, exactly like [publishing from inside a handler](publishing.md): encode with the
+codec, build an `OutgoingMessage`, and await the publish. The
+[metrics guide's complete server](metrics.md) does this to drive its counters.
+
+The trade-off is coupling: a broker outage now fails or stalls HTTP requests, and a crash after
+the database write but before the publish loses the event (or publishes an event for a write that
+rolled back, in the opposite order). If the endpoint also writes to a database, that gap is a
+consistency bug waiting for a deploy window. The fix is the transactional outbox.
+
+## Transactional outbox
+
+Instead of publishing on the request path, the endpoint records the event next to the business
+write, atomically. A relay then moves recorded events to the broker:
+
+```rust
+--8<-- "examples/http_outbox.rs:event"
+```
+
+```rust
+--8<-- "examples/http_outbox.rs:store"
+```
+
+The endpoint only writes to the store. Recording the order and queueing its event is one atomic
+step, and no broker I/O can fail or stall the HTTP response:
+
+```rust
+--8<-- "examples/http_outbox.rs:endpoint"
+```
+
+A background task drains the outbox into the broker. A row is removed only after its publish
+succeeds, so a broker outage delays events instead of losing them; a crash between the publish and
+the removal re-publishes the row on restart. Consumers therefore see at-least-once delivery, the
+usual contract of an outbox, and handle duplicates the same way they handle redeliveries from the
+broker itself:
+
+```rust
+--8<-- "examples/http_outbox.rs:relay"
+```
+
+With a real database the `Store` is a table plus an `outbox` table written in one SQL
+transaction, and the relay reads `outbox` rows in insertion order, publishes, and deletes them.
+Everything else stays as shown: the broker, the publisher, and the subscriber do not know the
+outbox exists.
+
+## Try it
+
+```text
+curl -X POST http://127.0.0.1:8080/orders \
+  -H 'content-type: application/json' -d '{"id":1,"item":"book"}'
+```
+
+The response returns as soon as the store commits; the `fulfil` handler logs the order a moment
+later, when the relay has published the event.

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -76,6 +76,31 @@ the one shared instance through `ctx.state()` - no per-message connection setup.
 program is
 [`examples/lifespan.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/lifespan.rs).
 
+## Running beside another server
+
+`run` owns the whole process: it installs the signal handlers and returns only when the service
+has stopped. A service that shares its process with another foreground server (an HTTP framework,
+typically) brings the messaging side up with `start` instead. It performs the same startup
+sequence and resolves once subscriptions are open - so a startup failure surfaces before the host
+starts accepting traffic - and installs no signal handlers: the host decides what stops the
+service. The returned `RunningApp` handle drives the rest of the lifecycle:
+
+```rust
+--8<-- "tests/app_start.rs:handle"
+```
+
+- `stopping()` returns an owned future that resolves when the service tears itself down on a
+  fail-fast failure; plug it into the host's graceful shutdown (axum's `with_graceful_shutdown`)
+  so the process stops serving when the messaging side dies.
+- `shutdown()` is the explicit graceful teardown: the `on_shutdown` hooks, a drain of in-flight
+  handlers and post-settle continuations (bounded by the [shutdown timeout](#shutdown-timeout)),
+  broker shutdown in reverse registration order, then the `after_shutdown` hooks. A fail-fast
+  reason surfaces here as an error.
+
+The handle is `#[must_use]`: dropping it without calling `shutdown` detaches the service, with no
+graceful teardown. `run` and `run_until` are built on the same start/shutdown path, so all three
+forms share one startup and teardown sequence.
+
 ## Shutdown timeout
 
 By default `run` waits indefinitely for in-flight handlers to finish after shutdown is triggered.

--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -6,30 +6,12 @@ value plus lifecycle hooks that run at fixed points around the run loop.
 
 ## Shared state
 
-The application state is a single typed value of your own choosing (a struct, or `()` when the
-service needs none). It is produced by the `on_startup` hook - the value the hook returns becomes
-the state and fixes the app's state type:
-
-```rust
---8<-- "examples/lifespan.rs:hooks"
-```
-
-Read it from any handler or middleware through the `Context`, which borrows it directly:
-
-```rust
---8<-- "examples/lifespan.rs:handler"
-```
-
-`ctx.state()` returns `&S`, the typed state itself - no lookup, no `Option`, no downcast. (For data
-scoped to one message rather than the whole service, use the typed
-[per-delivery context](context.md#per-delivery-context) instead.)
-
-A `#[subscriber]` handler that reads state names it as the third `Context` generic
-(`ctx: &mut Context<'_, (), S>`); the runtime only lets that handler mount on an app whose state
-type matches, checked at compile time. A plain handler that names no state type is generic over it
-and mounts on any app; a `publish(..)` handler instead pins its state to `()` when none is named, so
-name the app's state explicitly to mount one on a stateful app. Everything else the context carries
-(the headers working copy, broker per-delivery fields) is covered in [Context and state](context.md).
+The application state is a single typed value produced by the `on_startup` hook: the value the hook
+returns becomes the state and fixes the app's state type. Any handler or middleware borrows it
+through `ctx.state()`. The full state story - the compile-time mount rules, `State<T>` injection,
+and the per-delivery context for message-scoped data - lives in
+[Context and state](context.md#application-level-typed-state); this page covers the hooks that
+produce and tear the state down.
 
 ## Lifecycle hooks
 
@@ -72,8 +54,13 @@ slots in the same way, only its `connect` / `close` calls differ:
 
 The hook's error type is inferred from the returned `Result`; it only needs to implement
 `std::error::Error + Send + Sync`. The resource is `Send + Sync`, so every concurrent handler borrows
-the one shared instance through `ctx.state()` - no per-message connection setup. The runnable
-program is
+the one shared instance through `ctx.state()` - no per-message connection setup:
+
+```rust
+--8<-- "examples/lifespan.rs:handler"
+```
+
+The runnable program is
 [`examples/lifespan.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/lifespan.rs).
 
 ## Running beside another server

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -55,9 +55,10 @@ Make publishing handlers idempotent under redelivery.
 ## Publishing from inside a handler
 
 To publish to a destination other than a single reply (fan-out, side effects, routing to a different
-broker), put the publisher in the [typed application state](lifespan.md) and reach it from the
-handler with `ctx.state()`. A publisher is a value like any other shared resource; in the state it
-stays typed, so the handler uses its own API directly, with no registry and no runtime lookup.
+broker), put the publisher in the
+[typed application state](context.md#application-level-typed-state) and reach it from the handler
+with `ctx.state()`. A publisher is a value like any other shared resource; in the state it stays
+typed, so the handler uses its own API directly, with no registry and no runtime lookup.
 
 ```rust
 use ruststream::codec::{Codec, JsonCodec};

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -33,25 +33,17 @@ Handlers that publish a reply register on the router the same way as on the scop
 
 ## Router middleware
 
-The application's global middleware (added with `RustStream::layer`) wraps router handlers too:
-`include_router` applies the app stack around each handler when the router is mounted. A layer used
-this way must be a `BlanketLayer` - the router hides its handlers' concrete types, so the wrap
-happens through one generic method; every bundled layer qualifies.
+A router can carry its own layer stack: `Router::layer` wraps every handler in that router when it
+is mounted. The application's global stack (added with `RustStream::layer`) wraps around it at
+`include_router` - scopes nest, app outermost:
 
 ```rust title="main.rs"
 --8<-- "examples/logging_middleware.rs:layered_router"
 ```
 
-A router can also carry its own stack: `Router::layer` wraps every handler in that router when it
-is mounted, inside the app's global stack (scopes nest, app outermost):
-
-```rust title="routes.rs"
---8<-- "examples/middleware_router_scope.rs:router_scope"
-```
-
-See [Middleware](middleware.md) for what a layer is and how to write one, and
-[`examples/logging_middleware.rs`](https://github.com/powersemmi/ruststream/blob/main/examples/logging_middleware.rs)
-for the app-scope side in a running service.
+Because a router hides its handlers' concrete types, a layer reaching them must be a
+`BlanketLayer`. Both scopes, the `BlanketLayer` requirement, and writing your own layer are covered
+in [Middleware](middleware.md#middleware-scopes).
 
 ## Composing and mounting
 

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -34,12 +34,18 @@ access, broker per-delivery fields - is covered in [Context and state](context.m
 
 ### Extractor parameters
 
-Any further parameter, after the message and the optional `&mut Context`, whose type implements
-`FromContext` is resolved from the delivery before the body runs, so a handler takes its
-dependencies as arguments instead of reaching through `ctx.state()`. Derive `FromRef` on the
-application state to inject its fields with `State<T>`, or implement `FromContext` for a custom
-extractor; a failed extraction settles the delivery without running the body. See
-[Injecting dependencies](context.md#injecting-dependencies-extractor-parameters).
+Any further parameter, after the message and the optional `&mut Context`, is an **extractor**:
+the runtime resolves it from the delivery before the body runs, and a failed extraction settles
+the delivery without running the body. Three kinds can appear:
+
+- `State<T>` - a field of the application state (derive `FromRef` on the state type).
+- `Ctx<K>` - a broker per-delivery field, read by its key.
+- any type implementing `FromContext` - a custom extractor (an auth guard, a request-scoped
+  resolver).
+
+The mechanics live in
+[Injecting dependencies](context.md#injecting-dependencies-extractor-parameters) and
+[Context fields as parameters](context.md#context-fields-as-parameters).
 
 ### Acking
 
@@ -61,19 +67,17 @@ On the message itself, ack consumes `self`, so the type system prevents acking t
 
 ### Post-settle continuations
 
-`HandlerResult::ack().and_after(fut)` attaches a continuation that runs *after* the message is
-settled, without gating the ack decision or affecting redelivery - a non-critical notification,
-slow follow-up work, a cache warm-up. Any outcome works (`drop().and_after(..)` is valid; the
-neutral reading is "after settle"):
+`HandlerResult::ack().and_after(fut)` attaches a continuation to the returned outcome - a
+non-critical notification, slow follow-up work, a cache warm-up. Any outcome works
+(`drop().and_after(..)` is valid; the neutral reading is "after settle"):
 
 ```rust
 --8<-- "examples/post_settle.rs:single"
 ```
 
-The continuation runs on a tracked task set that a graceful shutdown drains (bounded by
-`shutdown_timeout` when set). It is at-most-once: the message is already settled, so a continuation
-that panics or is lost on a crash never redelivers it. Do not put work whose loss must redeliver the
-message in here; settle by outcome and let the broker retry instead.
+The continuation follows the shared post-settle semantics (at-most-once, runs only after the
+ack or nack settles, drained on graceful shutdown); see
+[Post-settle hooks](context.md#post-settle-hooks).
 
 In a batch each element settles individually, so the continuation rides per element - a capability
 the per-message context hook cannot offer:

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -146,27 +146,8 @@ This mirrors faststream's `with_real=True` split: handler logic on the in-memory
 semantics on the real one. Keep both suites over the same handler modules so the production code has
 a single source of truth.
 
-## For broker authors
-
-A broker crate ships an in-process transport - a normal `Broker` that routes in memory, emulating
-the broker's Core routing (subjects, wildcards, groups) - and implements the one
-[`TestableBroker`](../broker-authors/conformance.md) contract on it:
-
-The reference is `MemoryBroker`'s own implementation:
-
-```rust
---8<-- "src/memory/mod.rs:testable"
-```
-
-The transport calls `Coordinator::enqueued` on every enqueue into a subscriber and
-`Coordinator::consumed` when a delivery is settled or dropped (so the harness can tell when the
-reaction has settled), and routes delayed redeliveries through `Coordinator::schedule_redelivery`.
-That one type then works with both `TestApp` (above) and the conformance suite. Prove its routing
-with `conformance::harness::run_suite`:
-
-```rust
---8<-- "tests/conformance_self.rs:run_suite"
-```
-
-See [Conformance](../broker-authors/conformance.md) for the full contract and the lazy-startup
-`lifecycle` check.
+!!! note "Writing a broker crate?"
+    The machinery that makes `TestApp` work against a broker - the in-process transport and the
+    `TestableBroker` contract - is the broker author's side of this story. It lives in
+    [Broker authors: test support](../broker-authors/index.md#test-support) and
+    [Conformance](../broker-authors/conformance.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Two architectural commitments shape the framework:
 - :material-rocket-launch: **[Quick start](getting-started/quickstart.md)** - scaffold a service with `cargo generate`.
 - :material-school: **[Tutorial](getting-started/tutorial.md)** - build a service step by step.
 - :material-test-tube: **[Testing](guides/testing.md)** - test handlers in-process, no server needed.
+- :material-web: **[HTTP frameworks](guides/http.md)** - run beside axum with a transactional outbox.
 - :material-transit-connection-variant: **[Brokers](brokers/index.md)** - the in-memory broker, NATS, and Redis.
 - :material-server-network: **[Broker authors](broker-authors/index.md)** - implement the contract and pass conformance.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,6 +21,7 @@ cargo doc --all-features --open
 | Item | Module | Purpose |
 |---|---|---|
 | `RustStream` | `ruststream::runtime` | the application object |
+| `RunningApp` | `ruststream::runtime` | a started service: readiness, fail-fast signal, graceful shutdown |
 | `Router` | `ruststream::runtime` | a lazily-bound group of handlers |
 | `FromContext`, `State`, `FromRef` | `ruststream::runtime` / `ruststream` | handler extractor parameters and the state-injection derive |
 | `Broker`, `Subscribe`, `Subscriber`, `Publisher`, `IncomingMessage` | `ruststream` | the broker contract |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,11 @@
 # Documentation toolchain. Install with `pip install -r docs/requirements.txt`,
-# then serve locally with `mkdocs serve`.
+# then serve locally with `properdocs serve`.
+#
+# The site builds with properdocs, the maintained continuation of MkDocs 1.x (the mkdocs
+# package itself is frozen ahead of an incompatible 2.0). mkdocs-material still declares a
+# dependency on mkdocs, so pip installs both; only the `properdocs` command is used.
+properdocs>=1.6
 mkdocs-material>=9.5
 pymdown-extensions>=10.7
-mike>=2.1
+mike>=2.2
+mkdocs-redirects>=1.2.3

--- a/examples/http_outbox.rs
+++ b/examples/http_outbox.rs
@@ -1,0 +1,134 @@
+//! Accept orders over HTTP with axum and hand them to the same service's subscriber through a
+//! transactional outbox.
+//!
+//! ```text
+//! cargo run --example http_outbox --features macros,memory,json
+//! ```
+//!
+//! Place an order and watch the subscriber pick it up:
+//!
+//! ```text
+//! curl -X POST http://127.0.0.1:8080/orders \
+//!   -H 'content-type: application/json' -d '{"id":1,"item":"book"}'
+//! ```
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use ruststream::codec::{Codec, JsonCodec};
+use ruststream::memory::{MemoryBroker, MemoryPublisher};
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+// --8<-- [start:event]
+/// The integration event the HTTP side hands to the messaging side.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OrderPlaced {
+    id: u64,
+    item: String,
+}
+// --8<-- [end:event]
+
+// --8<-- [start:handler]
+/// The same service consumes what its HTTP endpoints produce; any other service subscribed to
+/// the broker would see the event too.
+#[subscriber("orders.placed")]
+async fn fulfil(order: &OrderPlaced) -> HandlerResult {
+    println!("fulfilling order {} ({})", order.id, order.item);
+    HandlerResult::Ack
+}
+// --8<-- [end:handler]
+
+// --8<-- [start:store]
+/// The business records and the pending outbox rows, committed together. With a real database
+/// both inserts run in one SQL transaction; the mutex over the pair plays that role here, so an
+/// order is never stored without its event, and no event exists without its order.
+#[derive(Default)]
+struct Store {
+    orders: Vec<OrderPlaced>,
+    outbox: VecDeque<OrderPlaced>,
+}
+// --8<-- [end:store]
+
+// --8<-- [start:endpoint]
+/// The request path only writes to the store: recording the order and queueing its event is one
+/// atomic step, and no broker I/O can fail or stall the HTTP response.
+async fn place_order(
+    State(store): State<Arc<Mutex<Store>>>,
+    Json(order): Json<OrderPlaced>,
+) -> &'static str {
+    let mut store = store.lock().await;
+    store.orders.push(order.clone());
+    store.outbox.push_back(order);
+    "accepted\n"
+}
+// --8<-- [end:endpoint]
+
+// --8<-- [start:relay]
+/// Drains the outbox into the broker. A row is removed only after its publish succeeds, so a
+/// broker outage delays events instead of losing them; a crash between publish and removal
+/// re-publishes the row on restart, which is the usual at-least-once contract of an outbox.
+async fn relay_outbox(store: Arc<Mutex<Store>>, egress: MemoryPublisher) {
+    let mut tick = tokio::time::interval(Duration::from_millis(200));
+    loop {
+        tick.tick().await;
+        loop {
+            let Some(event) = store.lock().await.outbox.front().cloned() else {
+                break;
+            };
+            let payload = JsonCodec.encode(&event).expect("serializable");
+            let out = OutgoingMessage::new("orders.placed", payload.as_ref());
+            if egress.publish(out).await.is_err() {
+                // Keep the row and retry on the next tick.
+                break;
+            }
+            store.lock().await.outbox.pop_front();
+        }
+    }
+}
+// --8<-- [end:relay]
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --8<-- [start:wiring]
+    let broker = MemoryBroker::new();
+    // Taken from the broker before the app consumes it; resolves its connection on first use.
+    let egress = broker.publisher();
+    let app =
+        RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker(broker, |b| b.include(fulfil));
+
+    // The messaging side starts in the background; a startup failure (a broker refusing to
+    // connect, a subscription failing to open) surfaces here, before HTTP accepts traffic.
+    let running = app.start().await?;
+
+    let store = Arc::new(Mutex::new(Store::default()));
+    tokio::spawn(relay_outbox(store.clone(), egress));
+
+    let router = Router::new()
+        .route("/orders", post(place_order))
+        .with_state(store);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:8080").await?;
+    println!("orders API on http://127.0.0.1:8080/orders");
+    // The host owns the signals. HTTP stops on Ctrl+C, or when the messaging side tears itself
+    // down (fail-fast) so the process does not keep serving with a dead consumer; either way the
+    // messaging side then drains gracefully.
+    let stopping = running.stopping();
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                () = stopping => {}
+            }
+        })
+        .await?;
+    running.shutdown().await?;
+    // --8<-- [end:wiring]
+    Ok(())
+}

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -64,6 +64,10 @@ markdown_extensions:
 plugins:
   - search
   # Versioned docs are published with `mike` (see the Docs workflow and the version switcher).
+  # Pages that moved keep their old URLs alive; extend the map on any future move.
+  - redirects:
+      redirect_maps:
+        guides/templates.md: broker-authors/templates.md
 
 extra:
   version:
@@ -83,10 +87,12 @@ nav:
       - guides/publishing.md
       - guides/routing.md
       - guides/codecs.md
-      - guides/failure-policy.md
-      - guides/middleware.md
       - guides/context.md
       - guides/lifespan.md
+      - guides/middleware.md
+      - guides/failure-policy.md
+  - Integrations:
+      - guides/http.md
   - Observability:
       - guides/logging.md
       - guides/metrics.md
@@ -96,7 +102,6 @@ nav:
       - guides/testing.md
   - CLI:
       - guides/cli.md
-      - guides/templates.md
   - Brokers:
       - brokers/index.md
       - brokers/memory.md
@@ -109,4 +114,5 @@ nav:
       - broker-authors/index.md
       - broker-authors/example-nats.md
       - broker-authors/conformance.md
+      - broker-authors/templates.md
   - API reference: reference.md

--- a/src/runtime/app/app_trait.rs
+++ b/src/runtime/app/app_trait.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use crate::ServerSpec;
 use crate::runtime::metadata::HandlerMetadata;
 
-use super::{AppInfo, RustStream, RustStreamError};
+use super::{AppInfo, RunningApp, RustStream, RustStreamError};
 
 mod sealed {
     pub trait Sealed {}
@@ -57,6 +57,16 @@ pub trait App: sealed::Sealed + Sized {
     where
         F: Future<Output = ()> + Send;
 
+    /// Starts the service in the background and hands back a [`RunningApp`] handle: the
+    /// side-by-side form for hosting the service next to another foreground server. See
+    /// [`RustStream::start`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RustStreamError`] if the state producer or an `after_startup` hook fails, a
+    /// broker fails to connect, or a subscription fails to open.
+    fn start(self) -> impl Future<Output = Result<RunningApp, RustStreamError>> + Send;
+
     /// The service metadata (title, version, description): the `AsyncAPI` `info` object.
     fn info(&self) -> &AppInfo;
 
@@ -75,8 +85,10 @@ pub trait App: sealed::Sealed + Sized {
 // Each method names `RustStream` explicitly rather than `Self`: the inherent methods share these
 // names with the trait, so spelling the type makes clear the call delegates to the inherent method
 // (which wins by priority) and does not recurse into the trait method.
+// `St: 'static` mirrors the inherent impl in run.rs: every constructible app already satisfies
+// it, and `start` needs it to bind the state into the shutdown hooks.
 #[allow(clippy::use_self)]
-impl<L: Send, St: Send + Sync, PP: Send> App for RustStream<L, St, PP> {
+impl<L: Send, St: Send + Sync + 'static, PP: Send> App for RustStream<L, St, PP> {
     fn run(self) -> impl Future<Output = Result<(), RustStreamError>> + Send {
         RustStream::run(self)
     }
@@ -86,6 +98,10 @@ impl<L: Send, St: Send + Sync, PP: Send> App for RustStream<L, St, PP> {
         F: Future<Output = ()> + Send,
     {
         RustStream::run_until(self, shutdown)
+    }
+
+    fn start(self) -> impl Future<Output = Result<RunningApp, RustStreamError>> + Send {
+        RustStream::start(self)
     }
 
     fn info(&self) -> &AppInfo {

--- a/src/runtime/app/mod.rs
+++ b/src/runtime/app/mod.rs
@@ -8,6 +8,7 @@ mod scope;
 mod service;
 
 pub use app_trait::App;
+pub use run::RunningApp;
 pub use scope::BrokerScope;
 pub use service::RustStream;
 #[cfg(feature = "testing")]

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -1,5 +1,6 @@
 //! Running the service: startup sequence, signal handling and graceful shutdown.
 
+use std::fmt;
 use std::{future::Future, sync::Arc, time::Duration};
 
 #[cfg(unix)]
@@ -11,13 +12,35 @@ use tokio_util::task::TaskTracker;
 use tracing::{debug, info, warn};
 
 use crate::runtime::failure::ErrorShutdown;
+use crate::runtime::lifecycle::{BoxError, BoxFuture};
 
-use super::{RustStream, RustStreamError};
+use super::service::RegisteredBroker;
+use super::{LifecycleHook, RustStream, RustStreamError};
+
+/// A lifecycle hook with the state already bound, so [`RunningApp`] stays non-generic.
+type BoundHook = Box<dyn FnOnce() -> BoxFuture<'static, Result<(), BoxError>> + Send>;
+
+/// Binds the shared state into each hook, erasing the state type from the hook list.
+fn bind_hooks<St: Send + Sync + 'static>(
+    hooks: Vec<LifecycleHook<St>>,
+    state: &Arc<St>,
+) -> Vec<BoundHook> {
+    hooks
+        .into_iter()
+        .map(|hook| {
+            let state = Arc::clone(state);
+            Box::new(move || hook(state)) as BoundHook
+        })
+        .collect()
+}
 
 // `run`/`run_until` are routinely driven from a multi-thread runtime (`tokio::spawn`, the CLI's
 // `block_on`), so their futures must be `Send`: the shared state is held as `Arc<St>` across the
 // startup awaits (needs `St: Sync`) and the global stack `L` is carried in `self` (needs `L: Send`).
-impl<L: Send, St: Send + Sync, PP> RustStream<L, St, PP> {
+// `St: 'static` is what every constructible app already satisfies (the `on_startup` producer
+// returns the state from a `'static` boxed future); naming it here lets `start` box the shutdown
+// hooks with the state bound in.
+impl<L: Send, St: Send + Sync + 'static, PP> RustStream<L, St, PP> {
     /// Runs the service until an interrupt (`SIGINT` / `SIGTERM`) is received, then shuts down
     /// gracefully.
     ///
@@ -42,6 +65,48 @@ impl<L: Send, St: Send + Sync, PP> RustStream<L, St, PP> {
     where
         F: Future<Output = ()> + Send,
     {
+        let running = self.start().await?;
+        tokio::select! {
+            () = shutdown => info!(target: "ruststream::lifecycle", "shutdown signal received"),
+            () = running.stopping() => {
+                info!(target: "ruststream::lifecycle", "fail-fast shutdown triggered");
+            }
+        }
+        running.shutdown().await
+    }
+
+    /// Starts the service in the background and hands back a [`RunningApp`] handle.
+    ///
+    /// Performs the same startup sequence as [`run`](Self::run) - the `on_startup` state
+    /// producer, broker connects, subscription opens, `after_startup` hooks - and resolves once
+    /// the service is running, so a startup failure surfaces here, before the caller starts
+    /// accepting its own traffic. Installs no signal handlers: the caller decides what stops the
+    /// service, by calling [`RunningApp::shutdown`].
+    ///
+    /// Use this to run the service beside another foreground server (an HTTP framework) in the
+    /// same process; when the service is the whole process, [`run`](Self::run) /
+    /// [`run_until`](Self::run_until) stay the simpler form.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RustStreamError`] if the state producer or an `after_startup` hook fails, a
+    /// broker fails to connect, or a subscription fails to open.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "memory")]
+    /// # async fn run() -> Result<(), ruststream::runtime::RustStreamError> {
+    /// use ruststream::memory::MemoryBroker;
+    /// use ruststream::runtime::{AppInfo, RustStream};
+    ///
+    /// let app = RustStream::new(AppInfo::new("svc", "0.1.0")).register_broker(MemoryBroker::new());
+    /// let running = app.start().await?;
+    /// // ... serve HTTP in the foreground ...
+    /// running.shutdown().await
+    /// # }
+    /// ```
+    pub async fn start(self) -> Result<RunningApp, RustStreamError> {
         let Self {
             info,
             brokers,
@@ -84,7 +149,7 @@ impl<L: Send, St: Send + Sync, PP> RustStream<L, St, PP> {
 
         let token = CancellationToken::new();
         // Shared with every dispatch task: a fail-fast failure records its reason here and cancels
-        // the token, which both stops the loops and wakes the shutdown wait below.
+        // the token, which both stops the loops and resolves `stopping()`.
         let error_shutdown = ErrorShutdown::new(token.clone());
         let mut handles = Vec::with_capacity(starters.len());
         for (starter, meta) in starters.into_iter().zip(handlers) {
@@ -111,17 +176,103 @@ impl<L: Send, St: Send + Sync, PP> RustStream<L, St, PP> {
 
         info!(target: "ruststream::lifecycle", subscribers = handles.len(), "service running");
 
-        // Wake on either the caller's shutdown signal or a fail-fast cancellation from a dispatch
-        // task, then tear the service down the same way for both.
-        tokio::select! {
-            () = shutdown => info!(target: "ruststream::lifecycle", "shutdown signal received"),
-            () = token.cancelled() => {
-                info!(target: "ruststream::lifecycle", "fail-fast shutdown triggered");
-            }
-        }
+        Ok(RunningApp {
+            token,
+            error_shutdown,
+            handles,
+            on_shutdown: bind_hooks(on_shutdown, &state),
+            after_shutdown: bind_hooks(after_shutdown, &state),
+            brokers,
+            shutdown_timeout,
+            continuations,
+        })
+    }
+}
+
+/// A started service, handed out by [`RustStream::start`].
+///
+/// The handle owns the graceful teardown: dropping it without calling
+/// [`shutdown`](Self::shutdown) detaches the service (dispatch tasks keep running, nothing is
+/// drained), per the crate rule that destructors never block. The intended shape when running
+/// beside a foreground server:
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() -> Result<(), ruststream::runtime::RustStreamError> {
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::runtime::{AppInfo, RustStream};
+///
+/// let app = RustStream::new(AppInfo::new("svc", "0.1.0")).register_broker(MemoryBroker::new());
+/// let running = app.start().await?;
+/// // e.g. axum::serve(listener, router)
+/// //     .with_graceful_shutdown(running.stopping())
+/// //     .await?;
+/// running.shutdown().await
+/// # }
+/// ```
+#[must_use = "dropping the handle detaches the service without graceful shutdown"]
+pub struct RunningApp {
+    token: CancellationToken,
+    error_shutdown: ErrorShutdown,
+    handles: Vec<JoinHandle<()>>,
+    on_shutdown: Vec<BoundHook>,
+    after_shutdown: Vec<BoundHook>,
+    brokers: Vec<RegisteredBroker>,
+    shutdown_timeout: Option<Duration>,
+    continuations: TaskTracker,
+}
+
+impl fmt::Debug for RunningApp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RunningApp")
+            .field("subscribers", &self.handles.len())
+            .field("brokers", &self.brokers.len())
+            .field("shutdown_timeout", &self.shutdown_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RunningApp {
+    /// Resolves when the service begins stopping on its own: a subscriber hit a fail-fast
+    /// failure and tore the service down.
+    ///
+    /// The future is owned (`'static`), so it plugs directly into another server's graceful
+    /// shutdown (for example axum's `with_graceful_shutdown`), stopping the host when the
+    /// messaging side dies. It does not resolve on an orderly [`shutdown`](Self::shutdown) call -
+    /// the caller drives that path itself.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe: dropping the future loses nothing; a fresh call observes the same state.
+    pub fn stopping(&self) -> impl Future<Output = ()> + Send + 'static {
+        self.token.clone().cancelled_owned()
+    }
+
+    /// Shuts the service down gracefully.
+    ///
+    /// Runs the `on_shutdown` hooks, stops the dispatch loops, drains in-flight handlers and
+    /// post-settle continuations (bounded by the configured shutdown timeout), shuts the brokers
+    /// down in reverse registration order, then runs the `after_shutdown` hooks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RustStreamError`] if a dispatch task panicked, a broker failed to shut down, or
+    /// the service had already torn itself down on a fail-fast failure (surfaced as
+    /// [`RustStreamError::Dispatch`] so the operator sees a non-zero exit, not a silent stop).
+    pub async fn shutdown(self) -> Result<(), RustStreamError> {
+        let Self {
+            token,
+            error_shutdown,
+            handles,
+            on_shutdown,
+            after_shutdown,
+            brokers,
+            shutdown_timeout,
+            continuations,
+        } = self;
 
         for hook in on_shutdown {
-            if let Err(err) = hook(Arc::clone(&state)).await {
+            if let Err(err) = hook().await {
                 warn!(target: "ruststream::lifecycle", error = %err, "on_shutdown hook failed");
             }
         }
@@ -149,7 +300,7 @@ impl<L: Send, St: Send + Sync, PP> RustStream<L, St, PP> {
         }
 
         for hook in after_shutdown {
-            if let Err(err) = hook(Arc::clone(&state)).await {
+            if let Err(err) = hook().await {
                 warn!(target: "ruststream::lifecycle", error = %err, "after_shutdown hook failed");
             }
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,7 +20,7 @@ mod router;
 mod subscriber_def;
 mod typed;
 
-pub use app::{App, AppInfo, BrokerScope, RustStream, RustStreamError};
+pub use app::{App, AppInfo, BrokerScope, RunningApp, RustStream, RustStreamError};
 #[cfg(feature = "testing")]
 pub(crate) use app::{LifecycleHook, RegisteredBroker, Starter, TestParts};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -1,5 +1,8 @@
 //! Integration tests for `RustStream` lifecycle and dispatch, using `MemoryBroker`.
 
+mod common;
+
+use common::wait_for;
 use std::{
     sync::{
         Arc, Mutex,
@@ -605,18 +608,6 @@ fn app_records_handler_metadata() {
     );
     assert_eq!(app.handlers()[1].input_type, "bytes");
     assert_eq!(app.info().title, "svc");
-}
-
-async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
-    let result = tokio::time::timeout(timeout, async {
-        while !cond() {
-            // Yield to the scheduler; in multi-thread mode the handler runs in a different
-            // thread and updates the atomic independently - no sleep needed for correctness.
-            tokio::task::yield_now().await;
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }
 
 async fn wait_for_published(publisher: &impl Publisher, seen: &AtomicU32, timeout: Duration) {

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -60,6 +60,7 @@ async fn start_resolves_running_and_shutdown_completes() {
         .shutdown_timeout(Duration::from_secs(5))
         .with_broker(broker, |b| b.include(observe));
 
+    // --8<-- [start:handle]
     // `start` resolves only once subscriptions are open, so one publish is guaranteed to land.
     let running = app.start().await.expect("startup failed");
     publisher
@@ -71,6 +72,7 @@ async fn start_resolves_running_and_shutdown_completes() {
         .expect("handler never saw the message");
 
     running.shutdown().await.expect("graceful shutdown failed");
+    // --8<-- [end:handle]
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -1,9 +1,13 @@
 //! Integration tests for the background-start handle: `RustStream::start` -> `RunningApp`.
 //! Driven over `MemoryBroker`.
+//!
+//! These tests exercise the run machinery itself (startup, readiness, fail-fast, teardown), which
+//! is exactly what the `TestApp` harness bypasses by design - hence the raw broker + publisher
+//! wiring. `start()` resolves only after subscriptions are open, so a single publish suffices;
+//! no republish loops.
 #![cfg(feature = "macros")]
 
 use std::convert::Infallible;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -11,6 +15,7 @@ use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{App, AppInfo, HandlerResult, RustStream, RustStreamError};
 use ruststream::{OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -21,20 +26,20 @@ fn order_bytes(id: u32) -> Vec<u8> {
     serde_json::to_vec(&Order { id }).unwrap()
 }
 
-// Counters keyed per handler so the parallel tests do not interfere; each handler is used by one
-// test only.
-static SEEN: AtomicUsize = AtomicUsize::new(0);
-static TRAIT_SEEN: AtomicUsize = AtomicUsize::new(0);
+// Notifies keyed per handler so the parallel tests do not interfere; each handler is used by one
+// test only. `notify_one` stores a permit, so the handler may fire before the test awaits.
+static SEEN: Notify = Notify::const_new();
+static TRAIT_SEEN: Notify = Notify::const_new();
 
 #[subscriber("started.orders")]
 async fn observe(_order: &Order) -> HandlerResult {
-    SEEN.fetch_add(1, Ordering::SeqCst);
+    SEEN.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("started.trait")]
 async fn observe_trait(_order: &Order) -> HandlerResult {
-    TRAIT_SEEN.fetch_add(1, Ordering::SeqCst);
+    TRAIT_SEEN.notify_one();
     HandlerResult::Ack
 }
 
@@ -47,27 +52,6 @@ async fn boom(order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
-/// Republishes `payload` to `topic` until `counter` advances once, proving the subscription is live
-/// and the handler ran.
-async fn drive_until_seen(
-    publisher: &impl Publisher,
-    topic: &str,
-    payload: &[u8],
-    counter: &AtomicUsize,
-) {
-    tokio::time::timeout(Duration::from_secs(5), async {
-        let start = counter.load(Ordering::SeqCst);
-        while counter.load(Ordering::SeqCst) == start {
-            let _ = publisher
-                .publish(OutgoingMessage::new(topic, payload))
-                .await;
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("subscription never went live");
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn start_resolves_running_and_shutdown_completes() {
     let broker = MemoryBroker::new();
@@ -76,9 +60,15 @@ async fn start_resolves_running_and_shutdown_completes() {
         .shutdown_timeout(Duration::from_secs(5))
         .with_broker(broker, |b| b.include(observe));
 
-    // `start` resolves only once subscriptions are open, so the first publish can already land.
+    // `start` resolves only once subscriptions are open, so one publish is guaranteed to land.
     let running = app.start().await.expect("startup failed");
-    drive_until_seen(&publisher, "started.orders", &order_bytes(1), &SEEN).await;
+    publisher
+        .publish(OutgoingMessage::new("started.orders", &order_bytes(1)))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), SEEN.notified())
+        .await
+        .expect("handler never saw the message");
 
     running.shutdown().await.expect("graceful shutdown failed");
 }
@@ -93,25 +83,15 @@ async fn stopping_resolves_on_fail_fast_and_shutdown_surfaces_it() {
 
     let running = app.start().await.expect("startup failed");
 
-    // `stopping()` is an owned future: it stays pending while the service is healthy and
-    // resolves when the panicking handler triggers the fail-fast teardown.
-    tokio::time::timeout(Duration::from_secs(5), async {
-        let stopping = running.stopping();
-        tokio::pin!(stopping);
-        loop {
-            tokio::select! {
-                () = &mut stopping => break,
-                () = async {
-                    let _ = publisher
-                        .publish(OutgoingMessage::new("started.boom", &order_bytes(1)))
-                        .await;
-                    tokio::task::yield_now().await;
-                } => {}
-            }
-        }
-    })
-    .await
-    .expect("fail-fast never triggered");
+    // `stopping()` stays pending while the service is healthy and resolves when the panicking
+    // handler triggers the fail-fast teardown.
+    publisher
+        .publish(OutgoingMessage::new("started.boom", &order_bytes(1)))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), running.stopping())
+        .await
+        .expect("fail-fast never triggered");
 
     // The teardown reason survives until shutdown, where it surfaces as a dispatch error.
     let err = running
@@ -180,6 +160,12 @@ async fn start_is_reachable_through_the_app_trait() {
     let publisher = broker.publisher();
 
     let running = service(broker).start().await.expect("startup failed");
-    drive_until_seen(&publisher, "started.trait", &order_bytes(7), &TRAIT_SEEN).await;
+    publisher
+        .publish(OutgoingMessage::new("started.trait", &order_bytes(7)))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), TRAIT_SEEN.notified())
+        .await
+        .expect("handler never saw the message");
     running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -1,0 +1,185 @@
+//! Integration tests for the background-start handle: `RustStream::start` -> `RunningApp`.
+//! Driven over `MemoryBroker`.
+#![cfg(feature = "macros")]
+
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{App, AppInfo, HandlerResult, RustStream, RustStreamError};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+// Counters keyed per handler so the parallel tests do not interfere; each handler is used by one
+// test only.
+static SEEN: AtomicUsize = AtomicUsize::new(0);
+static TRAIT_SEEN: AtomicUsize = AtomicUsize::new(0);
+
+#[subscriber("started.orders")]
+async fn observe(_order: &Order) -> HandlerResult {
+    SEEN.fetch_add(1, Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+#[subscriber("started.trait")]
+async fn observe_trait(_order: &Order) -> HandlerResult {
+    TRAIT_SEEN.fetch_add(1, Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+/// Default policy: a panic fails fast, tearing the started service down.
+#[subscriber("started.boom")]
+async fn boom(order: &Order) -> HandlerResult {
+    // The test publishes ids other than u32::MAX, so this assertion always fails (panics); the
+    // trailing expression keeps the body typed as HandlerResult.
+    assert_eq!(order.id, u32::MAX, "handler exploded");
+    HandlerResult::Ack
+}
+
+/// Republishes `payload` to `topic` until `counter` advances once, proving the subscription is live
+/// and the handler ran.
+async fn drive_until_seen(
+    publisher: &impl Publisher,
+    topic: &str,
+    payload: &[u8],
+    counter: &AtomicUsize,
+) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let start = counter.load(Ordering::SeqCst);
+        while counter.load(Ordering::SeqCst) == start {
+            let _ = publisher
+                .publish(OutgoingMessage::new(topic, payload))
+                .await;
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("subscription never went live");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn start_resolves_running_and_shutdown_completes() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .shutdown_timeout(Duration::from_secs(5))
+        .with_broker(broker, |b| b.include(observe));
+
+    // `start` resolves only once subscriptions are open, so the first publish can already land.
+    let running = app.start().await.expect("startup failed");
+    drive_until_seen(&publisher, "started.orders", &order_bytes(1), &SEEN).await;
+
+    running.shutdown().await.expect("graceful shutdown failed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stopping_resolves_on_fail_fast_and_shutdown_surfaces_it() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .shutdown_timeout(Duration::from_secs(5))
+        .with_broker(broker, |b| b.include(boom));
+
+    let running = app.start().await.expect("startup failed");
+
+    // `stopping()` is an owned future: it stays pending while the service is healthy and
+    // resolves when the panicking handler triggers the fail-fast teardown.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let stopping = running.stopping();
+        tokio::pin!(stopping);
+        loop {
+            tokio::select! {
+                () = &mut stopping => break,
+                () = async {
+                    let _ = publisher
+                        .publish(OutgoingMessage::new("started.boom", &order_bytes(1)))
+                        .await;
+                    tokio::task::yield_now().await;
+                } => {}
+            }
+        }
+    })
+    .await
+    .expect("fail-fast never triggered");
+
+    // The teardown reason survives until shutdown, where it surfaces as a dispatch error.
+    let err = running
+        .shutdown()
+        .await
+        .expect_err("fail-fast must surface");
+    assert!(matches!(err, RustStreamError::Dispatch(_)), "got: {err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn start_and_shutdown_run_lifecycle_hooks_in_order() {
+    let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+    let (o1, o2, o3, o4) = (
+        Arc::clone(&order),
+        Arc::clone(&order),
+        Arc::clone(&order),
+        Arc::clone(&order),
+    );
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .shutdown_timeout(Duration::from_secs(5))
+        .on_startup(async move |()| {
+            o1.lock().expect("poisoned").push("startup");
+            Ok::<String, Infallible>("state".to_owned())
+        })
+        .after_startup(async move |_state: Arc<String>| {
+            o2.lock().expect("poisoned").push("after_startup");
+            Ok::<(), Infallible>(())
+        })
+        .on_shutdown(async move |_state: Arc<String>| {
+            o3.lock().expect("poisoned").push("on_shutdown");
+            Ok::<(), Infallible>(())
+        })
+        .after_shutdown(async move |state: Arc<String>| {
+            // The handle carries the state into the shutdown hooks bound at start time.
+            assert_eq!(state.as_str(), "state");
+            o4.lock().expect("poisoned").push("after_shutdown");
+            Ok::<(), Infallible>(())
+        })
+        .with_broker(MemoryBroker::new(), |_b| {});
+
+    let running = app.start().await.expect("startup failed");
+    assert_eq!(
+        *order.lock().expect("poisoned"),
+        vec!["startup", "after_startup"],
+        "start returns with the startup hooks already run",
+    );
+
+    running.shutdown().await.expect("graceful shutdown failed");
+    assert_eq!(
+        *order.lock().expect("poisoned"),
+        vec!["startup", "after_startup", "on_shutdown", "after_shutdown"],
+    );
+}
+
+// The builder hides behind `impl App`, the way `#[ruststream::app]` services are written.
+fn service(broker: MemoryBroker) -> impl App {
+    RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include(observe_trait);
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn start_is_reachable_through_the_app_trait() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let running = service(broker).start().await.expect("startup failed");
+    drive_until_seen(&publisher, "started.trait", &order_bytes(7), &TRAIT_SEEN).await;
+    running.shutdown().await.expect("graceful shutdown failed");
+}

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -1,24 +1,26 @@
 //! Integration tests for the batch subscriber pipeline: the `#[subscriber(batch(..))]` form,
 //! `include_batch` mounting, per-element decode failures, and the `Buffered` adapter.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so each
+//! message is published exactly once; the tests wait on the handlers' recorded state.
 #![cfg(feature = "macros")]
 
 mod common;
 
 use std::{
     sync::{
-        Arc, LazyLock, Mutex,
+        Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, TypedPublisher};
 use ruststream::testing::expect_published;
 use ruststream::{Buffered, Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -30,7 +32,6 @@ fn order_bytes(id: u32) -> Vec<u8> {
 }
 
 static BATCHES: Mutex<Vec<Vec<u32>>> = Mutex::new(Vec::new());
-static BILL_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Settles a whole page of orders at once.
 #[subscriber(batch("orders"))]
@@ -39,7 +40,6 @@ async fn bill(orders: &[Order]) -> HandlerResult {
         .lock()
         .unwrap()
         .push(orders.iter().map(|o| o.id).collect());
-    BILL_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -51,37 +51,25 @@ async fn batch_macro_def_receives_batches() {
     let app = RustStream::new(AppInfo::new("billing", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(bill));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // The subscription opens inside run(); retry publishing until deliveries land.
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for id in 0..3u32 {
-                let _ = publisher
-                    .publish(OutgoingMessage::new("orders", &order_bytes(id)))
-                    .await;
-            }
-            handler_signal(&BILL_NOTIFY).await;
-            let received: usize = BATCHES.lock().unwrap().iter().map(Vec::len).sum();
-            if received >= 3 {
-                break;
-            }
-        }
-    })
+    // The three publishes may buffer into one batch or arrive split across several.
+    for id in 0..3u32 {
+        publisher
+            .publish(OutgoingMessage::new("orders", &order_bytes(id)))
+            .await
+            .expect("publish failed");
+    }
+    wait_for(
+        || BATCHES.lock().unwrap().iter().map(Vec::len).sum::<usize>() >= 3,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "no batch arrived within the deadline");
 
-    // Order within and across batches must follow publish order. The subscription opens inside
-    // run(), so the first publish round can be partly dropped (sent before the subscriber is
-    // ready); the surviving stream still follows the repeating 0,1,2 publish cycle, so assert each
-    // consecutive pair advances the cycle rather than requiring the stream to start at 0.
+    // Nothing is dropped (the subscription was open before the first publish), so the flattened
+    // stream is exactly the publish order.
     let flattened: Vec<u32> = BATCHES.lock().unwrap().iter().flatten().copied().collect();
-    assert!(
-        flattened.windows(2).all(|w| w[1] == (w[0] + 1) % 3),
-        "deliveries out of publish order: {flattened:?}",
-    );
+    assert_eq!(flattened, vec![0, 1, 2], "deliveries out of publish order");
     assert!(
         BATCHES
             .lock()
@@ -91,18 +79,15 @@ async fn batch_macro_def_receives_batches() {
         "batches must not be empty",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static GOOD_IDS: Mutex<Vec<u32>> = Mutex::new(Vec::new());
-static SIFT_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Records the ids that survived decoding.
 #[subscriber(batch("mixed"))]
 async fn sift(orders: &[Order]) -> HandlerResult {
     GOOD_IDS.lock().unwrap().extend(orders.iter().map(|o| o.id));
-    SIFT_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -114,51 +99,38 @@ async fn undecodable_elements_never_reach_the_handler() {
     let app = RustStream::new(AppInfo::new("billing", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(sift));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("mixed", &order_bytes(1)))
-                .await;
-            let _ = publisher
-                .publish(OutgoingMessage::new("mixed", b"not json"))
-                .await;
-            let _ = publisher
-                .publish(OutgoingMessage::new("mixed", &order_bytes(2)))
-                .await;
-            handler_signal(&SIFT_NOTIFY).await;
-            // Subscriptions open inside run(), so the first publishes can be lost and the loop
-            // republishes; wait until both decodable ids have actually arrived rather than for a
-            // bare count, which a partial first batch would satisfy out of order.
-            let both_seen = {
-                let seen = GOOD_IDS.lock().unwrap();
-                seen.contains(&1) && seen.contains(&2)
-            };
-            if both_seen {
-                break;
-            }
-        }
-    })
+    publisher
+        .publish(OutgoingMessage::new("mixed", &order_bytes(1)))
+        .await
+        .expect("publish failed");
+    publisher
+        .publish(OutgoingMessage::new("mixed", b"not json"))
+        .await
+        .expect("publish failed");
+    publisher
+        .publish(OutgoingMessage::new("mixed", &order_bytes(2)))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || {
+            let seen = GOOD_IDS.lock().unwrap();
+            seen.contains(&1) && seen.contains(&2)
+        },
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "decodable elements did not arrive");
 
-    // The undecodable element is dropped individually, never failing the batch around it: only the
-    // two decodable ids ever reach the handler (the loop above already confirmed both did).
+    // The undecodable element is dropped individually, never failing the batch around it: exactly
+    // the two decodable ids reach the handler, in publish order.
     let ids = GOOD_IDS.lock().unwrap().clone();
-    assert!(
-        ids.iter().all(|&id| id == 1 || id == 2),
-        "an undecodable element reached the handler: {ids:?}"
-    );
+    assert_eq!(ids, vec![1, 2], "unexpected ids reached the handler");
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static BUFFERED_SEEN: AtomicUsize = AtomicUsize::new(0);
-static DRAIN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// A handler mounted on a `Buffered`-wrapped source directly in the macro. The macro recovers
 /// the source type from the constructor path, so a generic source spells its parameter
@@ -166,7 +138,6 @@ static DRAIN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 #[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(2)))]
 async fn drain(events: &[Order]) -> HandlerResult {
     BUFFERED_SEEN.fetch_add(events.len(), Ordering::SeqCst);
-    DRAIN_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -180,36 +151,28 @@ async fn buffered_adapter_batches_plain_subscribers_via_router() {
     let app = RustStream::new(AppInfo::new("events", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("events", &order_bytes(7)))
-                .await;
-            handler_signal(&DRAIN_NOTIFY).await;
-            if BUFFERED_SEEN.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
+    publisher
+        .publish(OutgoingMessage::new("events", &order_bytes(7)))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || BUFFERED_SEEN.load(Ordering::SeqCst) >= 1,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "buffered batch did not arrive");
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static SETTLED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
-static RECONCILE_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static RETRIED_ONCE: AtomicBool = AtomicBool::new(false);
 
 /// Retries order 11 on first sight; settles everything else, per element.
 #[subscriber(batch("pages"))]
 async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
-    let results = orders
+    orders
         .iter()
         .map(|o| {
             if o.id == 11 && !RETRIED_ONCE.swap(true, Ordering::SeqCst) {
@@ -219,9 +182,7 @@ async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
                 HandlerResult::Ack
             }
         })
-        .collect();
-    RECONCILE_NOTIFY.notify_one();
-    results
+        .collect()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -232,44 +193,23 @@ async fn per_element_outcomes_retry_individually() {
     let app = RustStream::new(AppInfo::new("pages", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(reconcile));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Warm up until the subscription is live, then publish the real page exactly once, so the
-    // retry accounting below is deterministic.
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pages", &order_bytes(0)))
-                .await;
-            handler_signal(&RECONCILE_NOTIFY).await;
-            if SETTLED.lock().unwrap().contains(&0) {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
-
+    // The page is published exactly once, so the retry accounting below is deterministic.
     for id in [10u32, 11, 12] {
         publisher
             .publish(OutgoingMessage::new("pages", &order_bytes(id)))
             .await
-            .unwrap();
+            .expect("publish failed");
     }
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            handler_signal(&RECONCILE_NOTIFY).await;
-            let settled = SETTLED.lock().unwrap().clone();
-            if [10, 11, 12].iter().all(|id| settled.contains(id)) {
-                break;
-            }
-        }
-    })
+    wait_for(
+        || {
+            let settled = SETTLED.lock().unwrap();
+            [10, 11, 12].iter().all(|id| settled.contains(id))
+        },
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "retried element was not redelivered");
 
     // 11 was retried exactly once and settled only on redelivery; 10 and 12 settled first try.
     assert!(RETRIED_ONCE.load(Ordering::SeqCst));
@@ -282,8 +222,7 @@ async fn per_element_outcomes_retry_individually() {
         );
     }
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -292,13 +231,10 @@ struct Confirmation {
     accepted: bool,
 }
 
-static BATCH_CONFIRM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
-
 /// Confirms a page of orders. The Result form gives explicit ack control; the whole-batch
 /// rejection path is covered by the runtime unit tests.
 #[subscriber(batch("requests"), publish("confirmations"))]
 async fn confirm(orders: &[Order]) -> Result<Vec<Confirmation>, HandlerResult> {
-    BATCH_CONFIRM_NOTIFY.notify_one();
     Ok(orders
         .iter()
         .map(|o| Confirmation {
@@ -330,38 +266,22 @@ async fn batch_replies_publish_transactionally() {
     let app = RustStream::new(AppInfo::new("confirmations", "0.1.0"))
         .with_broker(broker, |b| b.include_batch_publishing(confirm, replies));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Retry publishing until the subscription is live, waking as soon as the handler fires;
-    // the published confirmations are then awaited with expect_published's own deadline.
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("requests", &order_bytes(7)))
-                .await;
-            handler_signal(&BATCH_CONFIRM_NOTIFY).await;
-            let confirmed =
-                expect_published(&observer, "confirmations", 1, Duration::from_millis(200)).await;
-            if !confirmed.is_empty() {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "no confirmation arrived");
-
-    let confirmed =
-        expect_published(&observer, "confirmations", 1, Duration::from_millis(100)).await;
+    publisher
+        .publish(OutgoingMessage::new("requests", &order_bytes(7)))
+        .await
+        .expect("publish failed");
+    // expect_published polls under its own deadline and returns whatever arrived by then.
+    let confirmed = expect_published(&observer, "confirmations", 1, Duration::from_secs(5)).await;
+    assert!(!confirmed.is_empty(), "no confirmation arrived");
     for raw in &confirmed {
         let confirmation: Confirmation = serde_json::from_slice(raw.payload()).unwrap();
         assert_eq!(confirmation.id, 7);
         assert!(confirmation.accepted);
     }
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 #[test]
@@ -402,7 +322,6 @@ struct Tally {
 }
 
 static SCALED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
-static SCALE_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber(batch("scale"))]
 async fn scale(orders: &[Order], ctx: &mut Context<'_, (), Tally>) -> HandlerResult {
@@ -411,7 +330,6 @@ async fn scale(orders: &[Order], ctx: &mut Context<'_, (), Tally>) -> HandlerRes
         .lock()
         .unwrap()
         .extend(orders.iter().map(|o| o.id * multiplier));
-    SCALE_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -424,28 +342,15 @@ async fn batch_handler_reads_typed_state() {
         .on_startup(|()| async { Ok::<_, std::convert::Infallible>(Tally { multiplier: 10 }) })
         .with_broker(broker, |b| b.include_batch(scale));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for id in 1..4u32 {
-                let _ = publisher
-                    .publish(OutgoingMessage::new("scale", &order_bytes(id)))
-                    .await;
-            }
-            handler_signal(&SCALE_NOTIFY).await;
-            if SCALED.lock().unwrap().len() >= 3 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "no scaled batch arrived within the deadline"
-    );
+    for id in 1..4u32 {
+        publisher
+            .publish(OutgoingMessage::new("scale", &order_bytes(id)))
+            .await
+            .expect("publish failed");
+    }
+    wait_for(|| SCALED.lock().unwrap().len() >= 3, Duration::from_secs(5)).await;
 
     // Each id was multiplied by the state's multiplier (10), proving the handler read typed state.
     let scaled = SCALED.lock().unwrap().clone();
@@ -455,6 +360,5 @@ async fn batch_handler_reads_typed_state() {
     );
     assert!(scaled.contains(&10) && scaled.contains(&20) && scaled.contains(&30));
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/codecs.rs
+++ b/tests/codecs.rs
@@ -8,21 +8,15 @@
 
 mod common;
 
-use std::{
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::{CborCodec, Codec, MsgpackCodec};
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream};
 use ruststream::{OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -31,13 +25,11 @@ struct Order {
 
 static CBOR_SEEN: AtomicUsize = AtomicUsize::new(0);
 static MSGPACK_SEEN: AtomicUsize = AtomicUsize::new(0);
-static NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("orders-cbor")]
 async fn cbor_order(order: &Order) -> HandlerResult {
     assert_eq!(order.id, 7);
     CBOR_SEEN.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -45,7 +37,6 @@ async fn cbor_order(order: &Order) -> HandlerResult {
 async fn msgpack_order(order: &Order) -> HandlerResult {
     assert_eq!(order.id, 7);
     MSGPACK_SEEN.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -68,33 +59,25 @@ async fn non_default_codecs_dispatch_through_the_router() {
         b.include_router(msgpack_router);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    // `start` resolves only once subscriptions are open, so one publish per codec suffices.
+    let running = app.start().await.expect("startup failed");
 
     let cbor_bytes = CborCodec.encode(&Order { id: 7 }).unwrap();
     let msgpack_bytes = MsgpackCodec.encode(&Order { id: 7 }).unwrap();
+    publisher
+        .publish(OutgoingMessage::new("orders-cbor", &cbor_bytes))
+        .await
+        .expect("publish");
+    publisher
+        .publish(OutgoingMessage::new("orders-msgpack", &msgpack_bytes))
+        .await
+        .expect("publish");
 
-    let driven = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("orders-cbor", &cbor_bytes))
-                .await;
-            let _ = publisher
-                .publish(OutgoingMessage::new("orders-msgpack", &msgpack_bytes))
-                .await;
-            handler_signal(&NOTIFY).await;
-            if CBOR_SEEN.load(Ordering::SeqCst) >= 1 && MSGPACK_SEEN.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
+    wait_for(
+        || CBOR_SEEN.load(Ordering::SeqCst) >= 1 && MSGPACK_SEEN.load(Ordering::SeqCst) >= 1,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        driven.is_ok(),
-        "a non-default codec handler never dispatched"
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,13 +2,18 @@
 
 use std::time::Duration;
 
-use tokio::sync::Notify;
-
-/// Waits until a handler signals `notify`, but no longer than one retry interval.
+/// Waits until `cond` holds, yielding between checks, but no longer than `timeout`.
 ///
-/// Used in publish-retry loops: subscriptions open inside `run()`, so a message published too
-/// early is lost and the signal never comes. The bounded wait lets the caller publish again
-/// instead of deadlocking, while still waking immediately on the happy path.
-pub(crate) async fn handler_signal(notify: &Notify) {
-    let _ = tokio::time::timeout(Duration::from_millis(10), notify.notified()).await;
+/// The yield loop is the sanctioned no-sleep wait: in multi-thread mode the handler runs on
+/// another worker and flips the observed state independently, so yielding is enough to let it
+/// progress.
+#[allow(dead_code)] // each test binary compiles its own copy and uses what it needs
+pub(crate) async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
+    let result = tokio::time::timeout(timeout, async {
+        while !cond() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }

--- a/tests/composition_rules.rs
+++ b/tests/composition_rules.rs
@@ -2,25 +2,24 @@
 //! feature pairs (transactional x workers, Buffered x workers, publishing x workers) whose
 //! interaction is promised in prose. The remaining pairs are pinned elsewhere: workers x batch
 //! and retry x pools / lanes in `workers.rs` and `retry_semantics.rs`.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so every
+//! message is published exactly once - no republish loops.
 #![cfg(feature = "macros")]
 
 mod common;
 
 use std::{
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
 use ruststream::testing::expect_published;
 use ruststream::{Buffered, Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -37,13 +36,11 @@ fn order_bytes(id: u32) -> Vec<u8> {
 }
 
 static TX_HANDLED: AtomicUsize = AtomicUsize::new(0);
-static TX_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Each batch's replies go out in one transaction; the pool runs the batches concurrently.
 #[subscriber(batch("tx-in"), publish("tx-out"), workers(2))]
 async fn tx_confirm(orders: &[Order]) -> Vec<Receipt> {
     TX_HANDLED.fetch_add(orders.len(), Ordering::SeqCst);
-    TX_NOTIFY.notify_one();
     orders.iter().map(|o| Receipt { id: o.id }).collect()
 }
 
@@ -59,27 +56,20 @@ async fn transactional_replies_compose_with_a_batch_pool() {
     let app = RustStream::new(AppInfo::new("tx", "0.1.0"))
         .with_broker(broker, |b| b.include_batch_publishing(tx_confirm, replies));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Publish until at least four orders made it through (early publishes are lost while the
-    // subscription opens), then expect one committed receipt per handled order.
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        let mut id = 1u32;
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("tx-in", &order_bytes(id)))
-                .await;
-            id += 1;
-            handler_signal(&TX_NOTIFY).await;
-            if TX_HANDLED.load(Ordering::SeqCst) >= 4 {
-                break;
-            }
-        }
-    })
+    // Four orders, each published once; expect one committed receipt per handled order.
+    for id in 1..=4u32 {
+        publisher
+            .publish(OutgoingMessage::new("tx-in", &order_bytes(id)))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || TX_HANDLED.load(Ordering::SeqCst) >= 4,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "batches did not flow through the pool");
 
     let handled = TX_HANDLED.load(Ordering::SeqCst);
     let receipts = expect_published(&observer, "tx-out", handled, Duration::from_secs(5)).await;
@@ -90,22 +80,19 @@ async fn transactional_replies_compose_with_a_batch_pool() {
         receipts.len(),
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static BUF_SEEN: AtomicUsize = AtomicUsize::new(0);
 static BUF_BATCHES: AtomicUsize = AtomicUsize::new(0);
-static BUF_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
-/// Client-side batching under a pool: the deadline (not the pool) closes a batch.
+/// Client-side batching under a pool: the size cap or deadline (not the pool) closes a batch.
 #[subscriber(batch(Buffered::<Name>::new(Name::new("buf-in"))
     .max_size(2)
     .max_wait(Duration::from_millis(10))), workers(2))]
 async fn buffered_drain(orders: &[Order]) -> HandlerResult {
     BUF_SEEN.fetch_add(orders.len(), Ordering::SeqCst);
     BUF_BATCHES.fetch_add(1, Ordering::SeqCst);
-    BUF_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -119,39 +106,29 @@ async fn buffered_sources_compose_with_a_batch_pool() {
     let app = RustStream::new(AppInfo::new("buf", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(buffered_drain));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        let mut id = 1u32;
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("buf-in", &order_bytes(id)))
-                .await;
-            id += 1;
-            handler_signal(&BUF_NOTIFY).await;
-            if BUF_SEEN.load(Ordering::SeqCst) >= 6 {
-                break;
-            }
-        }
-    })
+    // Six deliveries against a size cap of two: they cannot all fit in one batch.
+    for id in 1..=6u32 {
+        publisher
+            .publish(OutgoingMessage::new("buf-in", &order_bytes(id)))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || BUF_SEEN.load(Ordering::SeqCst) >= 6,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        result.is_ok(),
-        "buffered batches did not drain through the pool"
-    );
     assert!(
         BUF_BATCHES.load(Ordering::SeqCst) >= 2,
         "everything arrived as a single batch; size/deadline closing did not engage",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static PUB_REPLIED: AtomicUsize = AtomicUsize::new(0);
-static PUB_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Reply publishing under a pool: replies are produced concurrently.
 #[subscriber("pub-in", publish("pub-out"), workers(3))]
@@ -162,7 +139,6 @@ async fn pooled_relay(o: &Order) -> Receipt {
 #[subscriber("pub-out")]
 async fn pooled_check(_r: &Receipt) -> HandlerResult {
     PUB_REPLIED.fetch_add(1, Ordering::SeqCst);
-    PUB_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -178,29 +154,19 @@ async fn publishing_replies_compose_with_a_worker_pool() {
         b.include(pooled_check);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        let mut id = 1u32;
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pub-in", &order_bytes(id)))
-                .await;
-            id += 1;
-            handler_signal(&PUB_NOTIFY).await;
-            if PUB_REPLIED.load(Ordering::SeqCst) >= 4 {
-                break;
-            }
-        }
-    })
+    for id in 1..=4u32 {
+        publisher
+            .publish(OutgoingMessage::new("pub-in", &order_bytes(id)))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || PUB_REPLIED.load(Ordering::SeqCst) >= 4,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        result.is_ok(),
-        "pooled publishing handler did not reply to every delivery",
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/context_extensions.rs
+++ b/tests/context_extensions.rs
@@ -4,6 +4,9 @@
 //! app state. All use the in-memory broker with hand-written handlers (which can name a context
 //! type; macro handlers use the default `()` context).
 
+mod common;
+
+use common::wait_for;
 use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -87,16 +90,6 @@ impl ruststream::Subscriber for TaggedSubscriber {
             })
         })
     }
-}
-
-async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
-    let result = tokio::time::timeout(timeout, async {
-        while !cond() {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/failure_policy.rs
+++ b/tests/failure_policy.rs
@@ -2,7 +2,10 @@
 //! by the per-subscriber `on_failure(panic = .., decode = ..)` policy. Driven over `MemoryBroker`.
 #![cfg(feature = "macros")]
 
-use std::sync::Arc;
+mod common;
+
+use common::wait_for;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -12,7 +15,6 @@ use ruststream::runtime::{
 };
 use ruststream::{OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -98,54 +100,34 @@ async fn run_until_torn_down(
     topic: &str,
     payload: Vec<u8>,
 ) -> Result<(), RustStreamError> {
-    let run = tokio::spawn(app.run_until(std::future::pending::<()>()));
-    let outcome = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new(topic, &payload))
-                .await;
-            if run.is_finished() {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-        run.await
-    })
-    .await;
-    outcome
-        .expect("service did not tear down within the deadline")
-        .expect("run task panicked")
+    let running = app.start().await.expect("startup failed");
+    // `start` resolves with the subscription open, so one poison message is enough.
+    let _ = publisher
+        .publish(OutgoingMessage::new(topic, &payload))
+        .await;
+    tokio::time::timeout(Duration::from_secs(5), running.stopping())
+        .await
+        .expect("service did not tear down within the deadline");
+    running.shutdown().await
 }
 
-/// Republishes `payload` to `topic` until `counter` advances once, proving the subscription is live
-/// and the handler ran.
+/// Publishes `payload` to `topic` once (`start` resolves with subscriptions open) and waits until
+/// `counter` advances, proving the handler ran.
 async fn drive_until_seen(
     publisher: &impl Publisher,
     topic: &str,
     payload: &[u8],
     counter: &AtomicUsize,
 ) {
-    tokio::time::timeout(Duration::from_secs(5), async {
-        let start = counter.load(Ordering::SeqCst);
-        while counter.load(Ordering::SeqCst) == start {
-            let _ = publisher
-                .publish(OutgoingMessage::new(topic, payload))
-                .await;
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("subscription never went live");
-}
-
-async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
-    let result = tokio::time::timeout(timeout, async {
-        while !cond() {
-            tokio::task::yield_now().await;
-        }
-    })
+    let start = counter.load(Ordering::SeqCst);
+    let _ = publisher
+        .publish(OutgoingMessage::new(topic, payload))
+        .await;
+    wait_for(
+        || counter.load(Ordering::SeqCst) > start,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -171,9 +153,7 @@ async fn panic_drop_keeps_the_subscriber_consuming() {
         b.include(dropping);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     drive_until_seen(&publisher, "dropping", &order_bytes(7), &DROP_DONE).await;
     let before = DROP_DONE.load(Ordering::SeqCst);
@@ -194,11 +174,9 @@ async fn panic_drop_keeps_the_subscriber_consuming() {
     )
     .await;
 
-    shutdown.notify_one();
-    let result = tokio::time::timeout(Duration::from_secs(5), run)
+    let result = tokio::time::timeout(Duration::from_secs(5), running.shutdown())
         .await
-        .expect("run did not stop")
-        .expect("run task panicked");
+        .expect("shutdown did not finish");
     assert!(
         result.is_ok(),
         "a dropped panic must not error the run: {result:?}"
@@ -228,9 +206,7 @@ async fn decode_skip_acks_past_bad_input_and_continues() {
         b.include(skipping);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     drive_until_seen(&publisher, "skipping", &order_bytes(1), &SKIP_DONE).await;
     let before = SKIP_DONE.load(Ordering::SeqCst);
@@ -251,11 +227,9 @@ async fn decode_skip_acks_past_bad_input_and_continues() {
     )
     .await;
 
-    shutdown.notify_one();
-    let result = tokio::time::timeout(Duration::from_secs(5), run)
+    let result = tokio::time::timeout(Duration::from_secs(5), running.shutdown())
         .await
-        .expect("run did not stop")
-        .expect("run task panicked");
+        .expect("shutdown did not finish");
     assert!(
         result.is_ok(),
         "a skipped decode failure must not error the run: {result:?}"
@@ -271,9 +245,7 @@ async fn publishing_decode_failure_is_dropped_and_continues() {
     let app = RustStream::new(AppInfo::new("rpcd", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     drive_until_seen(&publisher, "rpcd", &order_bytes(1), &RPC_DONE).await;
     let before = RPC_DONE.load(Ordering::SeqCst);
@@ -291,11 +263,9 @@ async fn publishing_decode_failure_is_dropped_and_continues() {
     )
     .await;
 
-    shutdown.notify_one();
-    let result = tokio::time::timeout(Duration::from_secs(5), run)
+    let result = tokio::time::timeout(Duration::from_secs(5), running.shutdown())
         .await
-        .expect("run did not stop")
-        .expect("run task panicked");
+        .expect("shutdown did not finish");
     assert!(
         result.is_ok(),
         "a dropped decode failure must not error the run: {result:?}"
@@ -310,9 +280,7 @@ async fn batch_decode_failure_drops_the_bad_element() {
         b.include_batch(bd);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     drive_until_seen(&publisher, "bd", &order_bytes(1), &BATCH_DONE).await;
     let before = BATCH_DONE.load(Ordering::SeqCst);
@@ -330,11 +298,9 @@ async fn batch_decode_failure_drops_the_bad_element() {
     )
     .await;
 
-    shutdown.notify_one();
-    let result = tokio::time::timeout(Duration::from_secs(5), run)
+    let result = tokio::time::timeout(Duration::from_secs(5), running.shutdown())
         .await
-        .expect("run did not stop")
-        .expect("run task panicked");
+        .expect("shutdown did not finish");
     assert!(
         result.is_ok(),
         "a dropped batch element must not error the run: {result:?}"
@@ -350,9 +316,7 @@ async fn batch_publishing_decode_failure_is_dropped() {
     let app = RustStream::new(AppInfo::new("bpd", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     drive_until_seen(&publisher, "bpd", &order_bytes(1), &BATCH_REPLY_DONE).await;
     let before = BATCH_REPLY_DONE.load(Ordering::SeqCst);
@@ -370,11 +334,9 @@ async fn batch_publishing_decode_failure_is_dropped() {
     )
     .await;
 
-    shutdown.notify_one();
-    let result = tokio::time::timeout(Duration::from_secs(5), run)
+    let result = tokio::time::timeout(Duration::from_secs(5), running.shutdown())
         .await
-        .expect("run did not stop")
-        .expect("run task panicked");
+        .expect("shutdown did not finish");
     assert!(
         result.is_ok(),
         "a dropped batch reply element must not error the run: {result:?}"

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -1,17 +1,18 @@
 //! Integration test for the `#[subscriber]` attribute macro.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so each
+//! distinct message is published exactly once - no republish loops.
 #![cfg(feature = "macros")]
 
 mod common;
 
-use std::{
-    sync::{
-        LazyLock,
-        atomic::{AtomicU32, Ordering},
-    },
-    time::Duration,
-};
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemorySubscriber};
 use ruststream::runtime::{
@@ -20,10 +21,6 @@ use ruststream::runtime::{
 };
 use ruststream::{Message, OutgoingMessage, Publisher, SubscriptionSource, subscriber};
 use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
 use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,7 +30,7 @@ struct Order {
 }
 
 static HANDLED: AtomicU32 = AtomicU32::new(0);
-static HANDLED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static HANDLED_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("orders")]
 async fn handle(order: &Order) -> HandlerResult {
@@ -76,7 +73,7 @@ impl SubscriptionSource<MemoryBroker> for StreamSource {
 }
 
 static HANDLED_ON_STREAM: AtomicU32 = AtomicU32::new(0);
-static HANDLED_ON_STREAM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static HANDLED_ON_STREAM_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("ignored-on-the-include_on-path")]
 async fn on_stream(order: &Order) -> HandlerResult {
@@ -99,32 +96,24 @@ async fn macro_def_mounts_on_arbitrary_source() {
         );
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
+    // The source subscribed to "events.stream", not the macro's name.
     let payload = serde_json::to_vec(&Order { id: 4, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            // The source subscribed to "events.stream", not the macro's name.
-            let _ = publisher
-                .publish(OutgoingMessage::new("events.stream", &payload))
-                .await;
-            handler_signal(&HANDLED_ON_STREAM_NOTIFY).await;
-            if HANDLED_ON_STREAM.load(Ordering::SeqCst) >= 4 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "include_on handler did not run");
+    publisher
+        .publish(OutgoingMessage::new("events.stream", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), HANDLED_ON_STREAM_NOTIFY.notified())
+        .await
+        .expect("include_on handler did not run");
+    assert_eq!(HANDLED_ON_STREAM.load(Ordering::SeqCst), 4);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static HANDLED_CTOR: AtomicU32 = AtomicU32::new(0);
-static HANDLED_CTOR_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static HANDLED_CTOR_NOTIFY: Notify = Notify::const_new();
 
 // The descriptor lives in the decorator: the macro pulls the `StreamSource` type out of the
 // constructor path and `include` mounts on `def.source()`, with the broker checked at compile time.
@@ -144,34 +133,23 @@ async fn macro_descriptor_in_decorator() {
     let app =
         RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(on_ctor));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Order { id: 6, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("ctor.stream", &payload))
-                .await;
-            handler_signal(&HANDLED_CTOR_NOTIFY).await;
-            if HANDLED_CTOR.load(Ordering::SeqCst) >= 6 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "descriptor-in-decorator handler did not run"
-    );
+    publisher
+        .publish(OutgoingMessage::new("ctor.stream", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), HANDLED_CTOR_NOTIFY.notified())
+        .await
+        .expect("descriptor-in-decorator handler did not run");
+    assert_eq!(HANDLED_CTOR.load(Ordering::SeqCst), 6);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static HANDLED_CHAIN: AtomicU32 = AtomicU32::new(0);
-static HANDLED_CHAIN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static HANDLED_CHAIN_NOTIFY: Notify = Notify::const_new();
 
 // A builder chain in the decorator: the macro follows the receivers down to `StreamSource::new`
 // for the type, and emits the whole chain as the source constructor.
@@ -190,31 +168,20 @@ async fn macro_builder_chain_in_decorator() {
     let app =
         RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(on_chain));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
+    // The `at(..)` option won: the subscription binds to "chain.stream".
     let payload = serde_json::to_vec(&Order { id: 7, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            // The `at(..)` option won: the subscription binds to "chain.stream".
-            let _ = publisher
-                .publish(OutgoingMessage::new("chain.stream", &payload))
-                .await;
-            handler_signal(&HANDLED_CHAIN_NOTIFY).await;
-            if HANDLED_CHAIN.load(Ordering::SeqCst) >= 7 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "builder-chain-in-decorator handler did not run"
-    );
+    publisher
+        .publish(OutgoingMessage::new("chain.stream", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), HANDLED_CHAIN_NOTIFY.notified())
+        .await
+        .expect("builder-chain-in-decorator handler did not run");
+    assert_eq!(HANDLED_CHAIN.load(Ordering::SeqCst), 7);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// An order placed by a customer.
@@ -241,32 +208,23 @@ async fn macro_subscriber_dispatches() {
     let app =
         RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(handle));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Order { id: 5, total: 1.0 }).unwrap();
-    // include subscribes inside run() (after connect); retry until the subscription is live.
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("orders", &payload))
-                .await;
-            handler_signal(&HANDLED_NOTIFY).await;
-            if HANDLED.load(Ordering::SeqCst) >= 5 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "macro handler did not run");
+    publisher
+        .publish(OutgoingMessage::new("orders", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), HANDLED_NOTIFY.notified())
+        .await
+        .expect("macro handler did not run");
+    assert_eq!(HANDLED.load(Ordering::SeqCst), 5);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static HANDLED_DEFAULT: AtomicU32 = AtomicU32::new(0);
-static HANDLED_DEFAULT_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static HANDLED_DEFAULT_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("orders-default")]
 async fn handle_default(order: &Order) -> HandlerResult {
@@ -285,27 +243,19 @@ async fn scope_default_codec_drops_per_call_codec() {
         RustStream::new(AppInfo::new("svc", "0.1.0"))
             .with_broker_codec(broker, JsonCodec, |b| b.include(handle_default));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Order { id: 9, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("orders-default", &payload))
-                .await;
-            handler_signal(&HANDLED_DEFAULT_NOTIFY).await;
-            if HANDLED_DEFAULT.load(Ordering::SeqCst) >= 9 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "scope-default-codec handler did not run");
+    publisher
+        .publish(OutgoingMessage::new("orders-default", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), HANDLED_DEFAULT_NOTIFY.notified())
+        .await
+        .expect("scope-default-codec handler did not run");
+    assert_eq!(HANDLED_DEFAULT.load(Ordering::SeqCst), 9);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// A static (zero-cost) publish transform baked onto the `TypedPublisher`.
@@ -323,7 +273,7 @@ struct Ping {
 }
 
 static STATIC_SEEN: AtomicU32 = AtomicU32::new(0);
-static STATIC_SEEN_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static STATIC_SEEN_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("ping-in", publish("ping-out"))]
 async fn relay(p: &Ping) -> Ping {
@@ -354,30 +304,23 @@ async fn static_publish_layer_transforms_reply() {
         })
         .with_broker(egress, |b| b.include(check));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Ping { n: 7 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress_pub
-                .publish(OutgoingMessage::new("ping-in", &payload))
-                .await;
-            handler_signal(&STATIC_SEEN_NOTIFY).await;
-            if STATIC_SEEN.load(Ordering::SeqCst) == 7 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
+    ingress_pub
+        .publish(OutgoingMessage::new("ping-in", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), STATIC_SEEN_NOTIFY.notified())
+        .await
+        .expect("the reply never reached the consumer");
+    assert_eq!(
+        STATIC_SEEN.load(Ordering::SeqCst),
+        7,
         "static publish layer header did not reach the consumer",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 #[derive(Serialize, Deserialize)]
@@ -391,7 +334,7 @@ struct Response {
 }
 
 static REPLY_DOUBLED: AtomicU32 = AtomicU32::new(0);
-static REPLY_DOUBLED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static REPLY_DOUBLED_NOTIFY: Notify = Notify::const_new();
 static REPLY_TAGGED: AtomicU32 = AtomicU32::new(0);
 
 /// A publish middleware that tags every outgoing reply with a header (envelope-style).
@@ -444,32 +387,24 @@ async fn macro_publisher_replies_cross_broker() {
         })
         .with_broker(egress, |b| b.include(capture));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Request { n: 21 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress_pub
-                .publish(OutgoingMessage::new("requests", &payload))
-                .await;
-            handler_signal(&REPLY_DOUBLED_NOTIFY).await;
-            if REPLY_DOUBLED.load(Ordering::SeqCst) == 42 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "reply was not published to egress");
+    ingress_pub
+        .publish(OutgoingMessage::new("requests", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), REPLY_DOUBLED_NOTIFY.notified())
+        .await
+        .expect("reply was not published to egress");
+    assert_eq!(REPLY_DOUBLED.load(Ordering::SeqCst), 42);
     assert_eq!(
         REPLY_TAGGED.load(Ordering::SeqCst),
         1,
         "publish middleware header did not reach the consumer",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 #[derive(Serialize, Deserialize)]
@@ -479,9 +414,9 @@ struct Confirmation {
 }
 
 static CONFIRM_REJECTED: AtomicU32 = AtomicU32::new(0);
-static CONFIRM_REJECTED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static CONFIRM_REJECTED_NOTIFY: Notify = Notify::const_new();
 static CONFIRM_ACCEPTED: AtomicU32 = AtomicU32::new(0);
-static CONFIRM_ACCEPTED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static CONFIRM_ACCEPTED_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("confirm-in", publish("confirm-out"))]
 async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
@@ -516,28 +451,18 @@ async fn publishing_result_form_controls_ack_and_publish() {
         b.include(confirm_sink);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     // Err(HandlerResult) skips the publish entirely.
     let rejected = serde_json::to_vec(&Order { id: 0, total: 0.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress
-                .publish(OutgoingMessage::new("confirm-in", &rejected))
-                .await;
-            handler_signal(&CONFIRM_REJECTED_NOTIFY).await;
-            if CONFIRM_REJECTED.load(Ordering::SeqCst) >= 3 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "Err branch of the publishing handler did not run",
-    );
+    ingress
+        .publish(OutgoingMessage::new("confirm-in", &rejected))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), CONFIRM_REJECTED_NOTIFY.notified())
+        .await
+        .expect("Err branch of the publishing handler did not run");
+    assert_eq!(CONFIRM_REJECTED.load(Ordering::SeqCst), 1);
     assert_eq!(
         CONFIRM_ACCEPTED.load(Ordering::SeqCst),
         0,
@@ -546,22 +471,16 @@ async fn publishing_result_form_controls_ack_and_publish() {
 
     // Ok(reply) publishes and acks.
     let accepted = serde_json::to_vec(&Order { id: 6, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress
-                .publish(OutgoingMessage::new("confirm-in", &accepted))
-                .await;
-            handler_signal(&CONFIRM_ACCEPTED_NOTIFY).await;
-            if CONFIRM_ACCEPTED.load(Ordering::SeqCst) == 6 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "Ok branch did not publish the reply");
+    ingress
+        .publish(OutgoingMessage::new("confirm-in", &accepted))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), CONFIRM_ACCEPTED_NOTIFY.notified())
+        .await
+        .expect("Ok branch did not publish the reply");
+    assert_eq!(CONFIRM_ACCEPTED.load(Ordering::SeqCst), 6);
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// App state read from the publishing handler's optional `&mut Context` parameter.
@@ -569,7 +488,7 @@ async fn publishing_result_form_controls_ack_and_publish() {
 struct Bump(u32);
 
 static CTX_REPLY: AtomicU32 = AtomicU32::new(0);
-static CTX_REPLY_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+static CTX_REPLY_NOTIFY: Notify = Notify::const_new();
 
 #[subscriber("ctx-in", publish("ctx-out"))]
 async fn ctx_reply(req: &Request, ctx: &mut Context<'_, (), Bump>) -> Response {
@@ -599,41 +518,32 @@ async fn publishing_handler_reads_context_state() {
             b.include(ctx_sink);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Request { n: 1 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = ingress
-                .publish(OutgoingMessage::new("ctx-in", &payload))
-                .await;
-            handler_signal(&CTX_REPLY_NOTIFY).await;
-            if CTX_REPLY.load(Ordering::SeqCst) == 101 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(
-        result.is_ok(),
+    ingress
+        .publish(OutgoingMessage::new("ctx-in", &payload))
+        .await
+        .expect("publish failed");
+    tokio::time::timeout(Duration::from_secs(5), CTX_REPLY_NOTIFY.notified())
+        .await
+        .expect("the reply never reached the sink");
+    assert_eq!(
+        CTX_REPLY.load(Ordering::SeqCst),
+        101,
         "publishing handler did not read app state from the context",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static ATTEMPTS: AtomicU32 = AtomicU32::new(0);
-static ATTEMPTS_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Asks for a delayed redelivery on first sight, then acks: the not-ready-yet pattern.
 #[subscriber("deferred")]
 async fn eventually(order: &Order) -> HandlerResult {
     let _ = order;
     let prev = ATTEMPTS.fetch_add(1, Ordering::SeqCst);
-    ATTEMPTS_NOTIFY.notify_one();
     if prev == 0 {
         return HandlerResult::retry_after(Duration::from_millis(10));
     }
@@ -648,31 +558,19 @@ async fn retry_after_redelivers_through_the_dispatcher() {
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
         .with_broker(broker, |b| b.include(eventually));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     // One publish is enough: the second attempt must come from the delayed redelivery.
     let payload = serde_json::to_vec(&Order { id: 5, total: 1.0 }).unwrap();
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if ATTEMPTS.load(Ordering::SeqCst) == 0 {
-                let _ = publisher
-                    .publish(OutgoingMessage::new("deferred", &payload))
-                    .await;
-            }
-            handler_signal(&ATTEMPTS_NOTIFY).await;
-            if ATTEMPTS.load(Ordering::SeqCst) >= 2 {
-                break;
-            }
-        }
-    })
+    publisher
+        .publish(OutgoingMessage::new("deferred", &payload))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || ATTEMPTS.load(Ordering::SeqCst) >= 2,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        result.is_ok(),
-        "the delayed nack never came back through the dispatcher",
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,14 +1,20 @@
 //! Integration test for the Prometheus metrics layer (consume + publish paths).
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so each test
+//! publishes exactly once; the metric itself is recorded when the reaction settles, moments after
+//! the handler returns, so the exported text is polled without sleeping.
 #![cfg(all(feature = "metrics", feature = "memory", feature = "json"))]
 
-use std::sync::Arc;
+mod common;
+
+use common::wait_for;
+
 use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
 use ruststream::metrics::Metrics;
 use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, Router, RustStream};
 use ruststream::{Name, OutgoingMessage, Publisher};
-use tokio::sync::Notify;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn consume_metrics_are_recorded() {
@@ -26,34 +32,27 @@ async fn consume_metrics_are_recorded() {
             );
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
-
-    let recorded = tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pings", b"{}"))
-                .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            if metrics
+    let running = app.start().await.expect("startup failed");
+    publisher
+        .publish(OutgoingMessage::new("pings", b"{}"))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || {
+            metrics
                 .export()
                 .unwrap()
                 .contains("ruststream_messages_consumed_total")
-            {
-                break;
-            }
-        }
-    })
+        },
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(recorded.is_ok(), "consume metric was never recorded");
 
     let text = metrics.export().unwrap();
     assert!(text.contains(r#"ruststream_messages_consumed_total{name="pings",status="ack"}"#));
     assert!(text.contains("ruststream_consume_duration_seconds"));
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -73,41 +72,31 @@ async fn consume_metrics_are_recorded_through_a_router() {
         ));
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
-
-    let recorded = tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pings", b"{}"))
-                .await;
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            if metrics
+    let running = app.start().await.expect("startup failed");
+    publisher
+        .publish(OutgoingMessage::new("pings", b"{}"))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || {
+            metrics
                 .export()
                 .unwrap()
                 .contains("ruststream_messages_consumed_total")
-            {
-                break;
-            }
-        }
-    })
+        },
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        recorded.is_ok(),
-        "consume metric was never recorded for a router handler"
-    );
 
     let text = metrics.export().unwrap();
     assert!(text.contains(r#"ruststream_messages_consumed_total{name="pings",status="ack"}"#));
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.unwrap();
 }
 
 #[cfg(feature = "macros")]
 mod publish {
-    use super::{Arc, Duration, Notify};
+    use super::{Duration, wait_for};
     use ruststream::memory::MemoryBroker;
     use ruststream::metrics::Metrics;
     use ruststream::runtime::{AppInfo, RustStream, TypedPublisher};
@@ -143,35 +132,28 @@ mod publish {
                 b.include_publishing(reply, egress_pub);
             });
 
-        let shutdown = Arc::new(Notify::new());
-        let signal = Arc::clone(&shutdown);
-        let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
-
+        let running = app.start().await.expect("startup failed");
         let payload = serde_json::to_vec(&Req { n: 7 }).unwrap();
-        let recorded = tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                let _ = ingress_pub
-                    .publish(OutgoingMessage::new("requests", &payload))
-                    .await;
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                if metrics
+        ingress_pub
+            .publish(OutgoingMessage::new("requests", &payload))
+            .await
+            .expect("publish failed");
+        wait_for(
+            || {
+                metrics
                     .export()
                     .unwrap()
                     .contains("ruststream_messages_published_total")
-                {
-                    break;
-                }
-            }
-        })
+            },
+            Duration::from_secs(5),
+        )
         .await;
-        assert!(recorded.is_ok(), "publish metric was never recorded");
 
         let text = metrics.export().unwrap();
         assert!(
             text.contains(r#"ruststream_messages_published_total{name="responses",status="ok"}"#)
         );
 
-        shutdown.notify_one();
-        run.await.unwrap().unwrap();
+        running.shutdown().await.unwrap();
     }
 }

--- a/tests/opentelemetry.rs
+++ b/tests/opentelemetry.rs
@@ -7,7 +7,7 @@
     feature = "json"
 ))]
 
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
@@ -45,8 +45,8 @@ async fn capture(_resp: &Resp, ctx: &mut Context<'_>) {
 /// must not run concurrently (cargo runs a file's tests in parallel by default).
 static SERIAL: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
 
-/// Drives the app until the reply lands, re-publishing to defeat the startup race, and returns the
-/// captured reply `traceparent`.
+/// Drives one request through the app (`start()` resolves with subscriptions already open, so a
+/// single publish lands) and returns the captured reply `traceparent`.
 async fn run_and_capture(incoming: Option<&'static str>) -> TraceContext {
     let _serial = SERIAL.lock().await;
     *CAPTURED.lock().expect("poisoned") = None;
@@ -66,34 +66,22 @@ async fn run_and_capture(incoming: Option<&'static str>) -> TraceContext {
         });
     // --8<-- [end:wiring]
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Req { n: 1 }).expect("encode");
-    let captured = tokio::time::timeout(Duration::from_secs(2), async {
-        let notified = GOT.notified();
-        tokio::pin!(notified);
-        loop {
-            let mut headers = Headers::new();
-            if let Some(tp) = incoming {
-                headers.insert("traceparent", tp);
-            }
-            ingress
-                .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
-                .await
-                .expect("publish");
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(captured.is_ok(), "reply never captured");
+    let mut headers = Headers::new();
+    if let Some(tp) = incoming {
+        headers.insert("traceparent", tp);
+    }
+    ingress
+        .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), GOT.notified())
+        .await
+        .expect("reply never captured");
 
-    shutdown.notify_one();
-    run.await.expect("join").expect("run");
+    running.shutdown().await.expect("graceful shutdown failed");
 
     let header = CAPTURED
         .lock()

--- a/tests/post_settle_hooks.rs
+++ b/tests/post_settle_hooks.rs
@@ -3,6 +3,9 @@
 //! `#[subscriber]` macro over `MemoryBroker`.
 #![cfg(all(feature = "macros", feature = "memory", feature = "json"))]
 
+mod common;
+
+use common::wait_for;
 use std::{
     sync::{
         Arc,
@@ -24,16 +27,6 @@ struct Order {
 
 fn order_bytes(id: u32) -> Vec<u8> {
     serde_json::to_vec(&Order { id }).unwrap()
-}
-
-async fn wait_for(mut cond: impl FnMut() -> bool, timeout: Duration) {
-    let result = tokio::time::timeout(timeout, async {
-        while !cond() {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "condition not met within {timeout:?}");
 }
 
 // Shared counters keyed by a static so the macro handler (a free fn) can reach them.

--- a/tests/publish_context.rs
+++ b/tests/publish_context.rs
@@ -97,31 +97,18 @@ async fn delivery_context_propagates_to_the_reply() {
             b.include(capture);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Req { n: 7 }).expect("encode");
-    // Re-publish until the reaction lands: the first sends can race subscription startup, and the
-    // in-memory broker drops a message with no subscriber yet (see the metrics publish test).
-    let captured = tokio::time::timeout(Duration::from_secs(2), async {
-        let notified = GOT.notified();
-        tokio::pin!(notified);
-        loop {
-            let mut headers = Headers::new();
-            headers.insert("correlation-id", "trace-abc");
-            ingress_pub
-                .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
-                .await
-                .expect("publish");
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(captured.is_ok(), "reply never captured");
+    let mut headers = Headers::new();
+    headers.insert("correlation-id", "trace-abc");
+    ingress_pub
+        .publish(OutgoingMessage::new("in", &payload).with_headers(headers))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), GOT.notified())
+        .await
+        .expect("reply never captured");
 
     assert_eq!(
         CAPTURED.lock().expect("poisoned").as_deref(),
@@ -129,8 +116,7 @@ async fn delivery_context_propagates_to_the_reply() {
         "the reply should carry the delivery's correlation id, stamped by the publish layer"
     );
 
-    shutdown.notify_one();
-    run.await.expect("join").expect("run");
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// A batch-only transform: marks every batched reply, never a single-message one.
@@ -169,27 +155,16 @@ async fn batch_layer_runs_only_on_batched_replies() {
         b.include(batch_capture);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Req { n: 1 }).expect("encode");
-    let captured = tokio::time::timeout(Duration::from_secs(2), async {
-        let notified = BATCH_GOT.notified();
-        tokio::pin!(notified);
-        loop {
-            ingress_pub
-                .publish(OutgoingMessage::new("batch-in", &payload))
-                .await
-                .expect("publish");
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(captured.is_ok(), "batched reply never captured");
+    ingress_pub
+        .publish(OutgoingMessage::new("batch-in", &payload))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), BATCH_GOT.notified())
+        .await
+        .expect("batched reply never captured");
 
     assert_eq!(
         *BATCHED.lock().expect("poisoned"),
@@ -197,8 +172,7 @@ async fn batch_layer_runs_only_on_batched_replies() {
         "the batch layer should stamp every batched reply"
     );
 
-    shutdown.notify_one();
-    run.await.expect("join").expect("run");
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// A dynamic, runtime-built publish middleware: stamps a header, then continues.
@@ -248,27 +222,16 @@ async fn dyn_stack_runs_a_runtime_built_middleware() {
             b.include(dyn_capture);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Req { n: 3 }).expect("encode");
-    let captured = tokio::time::timeout(Duration::from_secs(2), async {
-        let notified = DYN_GOT.notified();
-        tokio::pin!(notified);
-        loop {
-            ingress_pub
-                .publish(OutgoingMessage::new("dyn-in", &payload))
-                .await
-                .expect("publish");
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(captured.is_ok(), "reply never captured");
+    ingress_pub
+        .publish(OutgoingMessage::new("dyn-in", &payload))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), DYN_GOT.notified())
+        .await
+        .expect("reply never captured");
 
     assert_eq!(
         *DYN_SEEN.lock().expect("poisoned"),
@@ -276,8 +239,7 @@ async fn dyn_stack_runs_a_runtime_built_middleware() {
         "the dynamic stack middleware should run and stamp the reply"
     );
 
-    shutdown.notify_one();
-    run.await.expect("join").expect("run");
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 // Two app-wide publish middleware, each appending its letter to an "order" header, pin the
@@ -350,27 +312,16 @@ async fn publish_layer_last_added_runs_outermost() {
             b.include(ord_capture);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Req { n: 1 }).expect("encode");
-    let got = tokio::time::timeout(Duration::from_secs(2), async {
-        let notified = ORDER_GOT.notified();
-        tokio::pin!(notified);
-        loop {
-            ingress_pub
-                .publish(OutgoingMessage::new("ord-in", &payload))
-                .await
-                .expect("publish");
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(got.is_ok(), "reply never captured");
+    ingress_pub
+        .publish(OutgoingMessage::new("ord-in", &payload))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), ORDER_GOT.notified())
+        .await
+        .expect("reply never captured");
 
     // B was added last, so it wraps A and appends first: "BA".
     assert_eq!(
@@ -379,6 +330,5 @@ async fn publish_layer_last_added_runs_outermost() {
         "the last publish_layer added must run outermost"
     );
 
-    shutdown.notify_one();
-    run.await.expect("join").expect("run");
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/retry_semantics.rs
+++ b/tests/retry_semantics.rs
@@ -1,19 +1,21 @@
 //! Integration tests for retry semantics at the dispatcher level: the `retry_after` delay is
 //! honored (not merely "redelivery happens"), retries complete inside worker pools and keyed
 //! lanes, and batch pools genuinely overlap batches.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so every
+//! message is published exactly once; any further delivery is a genuine redelivery.
 #![cfg(feature = "macros")]
 
 mod common;
 
 use std::{
     sync::{
-        Arc, LazyLock, Mutex,
+        LazyLock, Mutex,
         atomic::{AtomicU32, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use common::handler_signal;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
 use ruststream::{OutgoingMessage, Publisher, subscriber};
@@ -64,24 +66,17 @@ async fn retry_after_delay_is_honored_by_the_dispatcher() {
     let app = RustStream::new(AppInfo::new("delayed", "0.1.0"))
         .with_broker(broker, |b| b.include(deferred));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let payload = order_bytes(1);
+    // One publish is enough: the second attempt must come from the delayed redelivery.
+    publisher
+        .publish(OutgoingMessage::new("delayed", &order_bytes(1)))
+        .await
+        .expect("publish");
+
     let result = tokio::time::timeout(Duration::from_secs(60), async {
-        loop {
-            // One delivery is enough once the subscription is live: the second attempt must
-            // come from the delayed redelivery, never from this loop.
-            if DELAY_ATTEMPTS.lock().unwrap().is_empty() {
-                let _ = publisher
-                    .publish(OutgoingMessage::new("delayed", &payload))
-                    .await;
-            }
-            handler_signal(&DELAY_NOTIFY).await;
-            if DELAY_ATTEMPTS.lock().unwrap().len() >= 2 {
-                break;
-            }
+        while DELAY_ATTEMPTS.lock().unwrap().len() < 2 {
+            DELAY_NOTIFY.notified().await;
         }
     })
     .await;
@@ -96,8 +91,7 @@ async fn retry_after_delay_is_honored_by_the_dispatcher() {
         "redelivery arrived after {between:?}, before the requested {RETRY_DELAY:?}",
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static POOL_ACKED: AtomicU32 = AtomicU32::new(0);
@@ -137,35 +131,18 @@ async fn retry_completes_inside_a_worker_pool() {
     let app = RustStream::new(AppInfo::new("pool-retry", "0.1.0"))
         .with_broker(broker, |b| b.include(pool_retry));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
-
-    // Warm up with id 0 until the subscription is live, then submit ids 1-4 exactly once.
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pool-retry", &order_bytes(0)))
-                .await;
-            handler_signal(&POOL_NOTIFY).await;
-            if POOL_RETRIED.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
+    let running = app.start().await.expect("startup failed");
 
     for id in 1..=4u32 {
         publisher
             .publish(OutgoingMessage::new("pool-retry", &order_bytes(id)))
             .await
-            .unwrap();
+            .expect("publish");
     }
 
-    // 5 distinct ids (warmup included), each retried once then acked.
+    // 4 distinct ids, each retried once then acked.
     let result = tokio::time::timeout(Duration::from_secs(5), async {
-        while POOL_ACKED.load(Ordering::SeqCst) < 5 {
+        while POOL_ACKED.load(Ordering::SeqCst) < 4 {
             POOL_NOTIFY.notified().await;
         }
     })
@@ -177,8 +154,7 @@ async fn retry_completes_inside_a_worker_pool() {
         POOL_RETRIED.load(Ordering::SeqCst),
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static LANE_ACKED: AtomicU32 = AtomicU32::new(0);
@@ -216,9 +192,7 @@ async fn retry_completes_inside_keyed_lanes() {
     let app = RustStream::new(AppInfo::new("lane-retry", "0.1.0"))
         .with_broker(broker, |b| b.include(lane_retry));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let keyed_publish = |key: &'static str, id: u32| {
         let publisher = publisher.clone();
@@ -231,25 +205,12 @@ async fn retry_completes_inside_keyed_lanes() {
         }
     };
 
-    // Warm up with id 0 until the subscription is live (its retry also completes), then two
-    // keyed messages, each retried once.
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = keyed_publish("warmup", 0).await;
-            handler_signal(&LANE_NOTIFY).await;
-            if LANE_ACKED.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
-
-    keyed_publish("alpha", 1).await.unwrap();
-    keyed_publish("beta", 2).await.unwrap();
+    // Two keyed messages, each retried once then acked.
+    keyed_publish("alpha", 1).await.expect("publish");
+    keyed_publish("beta", 2).await.expect("publish");
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
-        while LANE_ACKED.load(Ordering::SeqCst) < 3 {
+        while LANE_ACKED.load(Ordering::SeqCst) < 2 {
             LANE_NOTIFY.notified().await;
         }
     })
@@ -260,25 +221,18 @@ async fn retry_completes_inside_keyed_lanes() {
         LANE_ACKED.load(Ordering::SeqCst),
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static BATCHES_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
-static OVERLAP_WARMED: AtomicUsize = AtomicUsize::new(0);
 static OVERLAP_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 /// Flipping this to `true` releases every held and future batch, so no handler task can outlive
 /// the test and hang the graceful drain (a barrier would strand a third, unpaired batch).
 static RELEASE: LazyLock<watch::Sender<bool>> = LazyLock::new(|| watch::Sender::new(false));
 
-/// Holds every non-warmup batch until the test observes two of them in flight at once.
+/// Holds every batch until the test observes two of them in flight at once.
 #[subscriber(batch("overlap"), workers(2))]
-async fn overlap(orders: &[Order]) -> HandlerResult {
-    if orders.iter().any(|o| o.id == 0) {
-        OVERLAP_WARMED.fetch_add(1, Ordering::SeqCst);
-        OVERLAP_NOTIFY.notify_one();
-        return HandlerResult::Ack;
-    }
+async fn overlap(_orders: &[Order]) -> HandlerResult {
     BATCHES_IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
     OVERLAP_NOTIFY.notify_one();
     let mut release = RELEASE.subscribe();
@@ -298,38 +252,30 @@ async fn batch_pool_overlaps_batches() {
     let app = RustStream::new(AppInfo::new("overlap", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(overlap));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Warm up until the subscription is live.
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("overlap", &order_bytes(0)))
-                .await;
-            handler_signal(&OVERLAP_NOTIFY).await;
-            if OVERLAP_WARMED.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
+    // Publish the second message only after the first batch is held on the latch, so the two
+    // messages arrive in distinct batches - which a sequential batch loop could never hold in
+    // flight simultaneously.
+    publisher
+        .publish(OutgoingMessage::new("overlap", &order_bytes(1)))
+        .await
+        .expect("publish");
+    let first_held = tokio::time::timeout(Duration::from_secs(5), async {
+        while BATCHES_IN_FLIGHT.load(Ordering::SeqCst) < 1 {
+            OVERLAP_NOTIFY.notified().await;
         }
     })
     .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
+    assert!(first_held.is_ok(), "the first batch never reached the pool");
 
-    // Keep publishing single messages; held batches accumulate on the latch until two are in
-    // flight simultaneously - which a sequential batch loop can never reach.
+    publisher
+        .publish(OutgoingMessage::new("overlap", &order_bytes(2)))
+        .await
+        .expect("publish");
     let result = tokio::time::timeout(Duration::from_secs(5), async {
-        let mut id = 1u32;
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("overlap", &order_bytes(id)))
-                .await;
-            id += 1;
-            handler_signal(&OVERLAP_NOTIFY).await;
-            if BATCHES_IN_FLIGHT.load(Ordering::SeqCst) >= 2 {
-                break;
-            }
+        while BATCHES_IN_FLIGHT.load(Ordering::SeqCst) < 2 {
+            OVERLAP_NOTIFY.notified().await;
         }
     })
     .await;
@@ -340,6 +286,5 @@ async fn batch_pool_overlaps_batches() {
 
     // Release every held (and any late) batch so the graceful drain can finish.
     RELEASE.send_replace(true);
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/router_include.rs
+++ b/tests/router_include.rs
@@ -5,21 +5,15 @@
 
 mod common;
 
-use std::{
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, layers::TracingLayer};
 use ruststream::{Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -30,63 +24,53 @@ fn order_bytes(id: u32) -> Vec<u8> {
     serde_json::to_vec(&Order { id }).unwrap()
 }
 
-/// Publishes `payload` to each topic until every counter is non-zero (subscriptions open inside
-/// `run()`, so early publishes are lost), bounded by a hang guard.
-async fn drive_until_all_seen(
+/// Publishes `payload` once to each topic (the app is already started, so the subscriptions are
+/// open and every publish lands), then waits until every counter is non-zero.
+async fn publish_and_await_all(
     publisher: &impl Publisher<Error = std::convert::Infallible>,
     topics: &[&str],
     counters: &[&AtomicUsize],
-    signal: &Notify,
 ) {
     let payload = order_bytes(1);
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for topic in topics {
-                let _ = publisher
-                    .publish(OutgoingMessage::new(topic, &payload))
-                    .await;
-            }
-            handler_signal(signal).await;
-            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
-                break;
-            }
-        }
-    })
+    for topic in topics {
+        publisher
+            .publish(OutgoingMessage::new(topic, &payload))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1),
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "not every include form dispatched");
 }
 
 static RI_PLAIN: AtomicUsize = AtomicUsize::new(0);
 static RI_ON: AtomicUsize = AtomicUsize::new(0);
 static RI_BATCH: AtomicUsize = AtomicUsize::new(0);
 static RI_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
-static RI_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("ri-plain")]
 async fn ri_plain(_o: &Order) -> HandlerResult {
     RI_PLAIN.fetch_add(1, Ordering::SeqCst);
-    RI_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("ri-ignored")]
 async fn ri_on(_o: &Order) -> HandlerResult {
     RI_ON.fetch_add(1, Ordering::SeqCst);
-    RI_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("ri-batch"))]
 async fn ri_batch(orders: &[Order]) -> HandlerResult {
     RI_BATCH.fetch_add(orders.len(), Ordering::SeqCst);
-    RI_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("ri-ignored"))]
 async fn ri_batch_on(orders: &[Order]) -> HandlerResult {
     RI_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
-    RI_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -106,53 +90,44 @@ async fn default_codec_router_includes_dispatch() {
     let app = RustStream::new(AppInfo::new("ri", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_all_seen(
+    publish_and_await_all(
         &publisher,
         &["ri-plain", "ri-on", "ri-batch", "ri-batch-on"],
         &[&RI_PLAIN, &RI_ON, &RI_BATCH, &RI_BATCH_ON],
-        &RI_NOTIFY,
     )
     .await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static RC_PLAIN: AtomicUsize = AtomicUsize::new(0);
 static RC_ON: AtomicUsize = AtomicUsize::new(0);
 static RC_BATCH: AtomicUsize = AtomicUsize::new(0);
 static RC_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
-static RC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("rc-plain")]
 async fn rc_plain(_o: &Order) -> HandlerResult {
     RC_PLAIN.fetch_add(1, Ordering::SeqCst);
-    RC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("rc-ignored")]
 async fn rc_on(_o: &Order) -> HandlerResult {
     RC_ON.fetch_add(1, Ordering::SeqCst);
-    RC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("rc-batch"))]
 async fn rc_batch(orders: &[Order]) -> HandlerResult {
     RC_BATCH.fetch_add(orders.len(), Ordering::SeqCst);
-    RC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("rc-ignored"))]
 async fn rc_batch_on(orders: &[Order]) -> HandlerResult {
     RC_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
-    RC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -172,37 +147,30 @@ async fn chain_codec_router_includes_dispatch() {
     let app = RustStream::new(AppInfo::new("rc", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_all_seen(
+    publish_and_await_all(
         &publisher,
         &["rc-plain", "rc-on", "rc-batch", "rc-batch-on"],
         &[&RC_PLAIN, &RC_ON, &RC_BATCH, &RC_BATCH_ON],
-        &RC_NOTIFY,
     )
     .await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static RM_A: AtomicUsize = AtomicUsize::new(0);
 static RM_B: AtomicUsize = AtomicUsize::new(0);
-static RM_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("rm-a")]
 async fn rm_a(_o: &Order) -> HandlerResult {
     RM_A.fetch_add(1, Ordering::SeqCst);
-    RM_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("rm-b")]
 async fn rm_b(_o: &Order) -> HandlerResult {
     RM_B.fetch_add(1, Ordering::SeqCst);
-    RM_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -225,12 +193,9 @@ async fn merged_router_dispatches_and_collects_metadata() {
     let app = RustStream::new(AppInfo::new("rm", "0.1.0"))
         .with_broker(broker, |b| b.include_router(merged));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_all_seen(&publisher, &["rm-a", "rm-b"], &[&RM_A, &RM_B], &RM_NOTIFY).await;
+    publish_and_await_all(&publisher, &["rm-a", "rm-b"], &[&RM_A, &RM_B]).await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/router_publishing.rs
+++ b/tests/router_publishing.rs
@@ -7,13 +7,13 @@ mod common;
 
 use std::{
     sync::{
-        Arc, LazyLock,
+        LazyLock,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemoryMessage};
 use ruststream::runtime::{
@@ -40,35 +40,30 @@ fn order_bytes(id: u32) -> Vec<u8> {
     serde_json::to_vec(&Order { id }).unwrap()
 }
 
-/// Publishes orders to each ingress topic until every reply counter is non-zero (subscriptions
-/// open inside `run()`, so early publishes are lost), bounded by a hang guard.
-async fn drive_until_replied(
+/// Publishes an order once to each ingress topic (the app is already started, so the
+/// subscriptions are open and every publish lands), then waits until every reply counter is
+/// non-zero.
+async fn publish_and_await_replies(
     publisher: &impl Publisher<Error = std::convert::Infallible>,
     topics: &[&str],
     counters: &[&AtomicUsize],
-    signal: &Notify,
 ) {
     let payload = order_bytes(1);
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for topic in topics {
-                let _ = publisher
-                    .publish(OutgoingMessage::new(topic, &payload))
-                    .await;
-            }
-            handler_signal(signal).await;
-            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
-                break;
-            }
-        }
-    })
+    for topic in topics {
+        publisher
+            .publish(OutgoingMessage::new(topic, &payload))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1),
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "not every publishing form replied");
 }
 
 static RP_OUT: AtomicUsize = AtomicUsize::new(0);
 static RP_OUT_ON: AtomicUsize = AtomicUsize::new(0);
-static RP_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("rp-in", publish("rp-out"))]
 async fn rp_relay(o: &Order) -> Receipt {
@@ -83,14 +78,12 @@ async fn rp_relay_on(o: &Order) -> Receipt {
 #[subscriber("rp-out")]
 async fn rp_check(_r: &Receipt) -> HandlerResult {
     RP_OUT.fetch_add(1, Ordering::SeqCst);
-    RP_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("rp-out-on")]
 async fn rp_check_on(_r: &Receipt) -> HandlerResult {
     RP_OUT_ON.fetch_add(1, Ordering::SeqCst);
-    RP_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -114,25 +107,15 @@ async fn default_codec_router_publishing_replies() {
         b.include(rp_check_on);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_replied(
-        &publisher,
-        &["rp-in", "rp-in-on"],
-        &[&RP_OUT, &RP_OUT_ON],
-        &RP_NOTIFY,
-    )
-    .await;
+    publish_and_await_replies(&publisher, &["rp-in", "rp-in-on"], &[&RP_OUT, &RP_OUT_ON]).await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static RPC_OUT: AtomicUsize = AtomicUsize::new(0);
 static RPC_OUT_ON: AtomicUsize = AtomicUsize::new(0);
-static RPC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("rpc-in", publish("rpc-out"))]
 async fn rpc_relay(o: &Order) -> Receipt {
@@ -147,14 +130,12 @@ async fn rpc_relay_on(o: &Order) -> Receipt {
 #[subscriber("rpc-out")]
 async fn rpc_check(_r: &Receipt) -> HandlerResult {
     RPC_OUT.fetch_add(1, Ordering::SeqCst);
-    RPC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("rpc-out-on")]
 async fn rpc_check_on(_r: &Receipt) -> HandlerResult {
     RPC_OUT_ON.fetch_add(1, Ordering::SeqCst);
-    RPC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -180,25 +161,20 @@ async fn chain_codec_router_publishing_replies() {
         b.include(rpc_check_on);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_replied(
+    publish_and_await_replies(
         &publisher,
         &["rpc-in", "rpc-in-on"],
         &[&RPC_OUT, &RPC_OUT_ON],
-        &RPC_NOTIFY,
     )
     .await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static BP_OUT: AtomicUsize = AtomicUsize::new(0);
 static BP_OUT_ON: AtomicUsize = AtomicUsize::new(0);
-static BP_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber(batch("bp-in"), publish("bp-out"))]
 async fn bp_relay(orders: &[Order]) -> Vec<Receipt> {
@@ -213,14 +189,12 @@ async fn bp_relay_on(orders: &[Order]) -> Vec<Receipt> {
 #[subscriber("bp-out")]
 async fn bp_check(_r: &Receipt) -> HandlerResult {
     BP_OUT.fetch_add(1, Ordering::SeqCst);
-    BP_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("bp-out-on")]
 async fn bp_check_on(_r: &Receipt) -> HandlerResult {
     BP_OUT_ON.fetch_add(1, Ordering::SeqCst);
-    BP_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -245,25 +219,15 @@ async fn default_codec_router_batch_publishing_replies() {
         b.include(bp_check_on);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_replied(
-        &publisher,
-        &["bp-in", "bp-in-on"],
-        &[&BP_OUT, &BP_OUT_ON],
-        &BP_NOTIFY,
-    )
-    .await;
+    publish_and_await_replies(&publisher, &["bp-in", "bp-in-on"], &[&BP_OUT, &BP_OUT_ON]).await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static BPC_OUT: AtomicUsize = AtomicUsize::new(0);
 static BPC_OUT_ON: AtomicUsize = AtomicUsize::new(0);
-static BPC_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber(batch("bpc-in"), publish("bpc-out"))]
 async fn bpc_relay(orders: &[Order]) -> Vec<Receipt> {
@@ -278,14 +242,12 @@ async fn bpc_relay_on(orders: &[Order]) -> Vec<Receipt> {
 #[subscriber("bpc-out")]
 async fn bpc_check(_r: &Receipt) -> HandlerResult {
     BPC_OUT.fetch_add(1, Ordering::SeqCst);
-    BPC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("bpc-out-on")]
 async fn bpc_check_on(_r: &Receipt) -> HandlerResult {
     BPC_OUT_ON.fetch_add(1, Ordering::SeqCst);
-    BPC_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -311,20 +273,16 @@ async fn chain_codec_router_batch_publishing_replies() {
         b.include(bpc_check_on);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    drive_until_replied(
+    publish_and_await_replies(
         &publisher,
         &["bpc-in", "bpc-in-on"],
         &[&BPC_OUT, &BPC_OUT_ON],
-        &BPC_NOTIFY,
     )
     .await;
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 // A static, app-wide publish middleware that stamps a header onto every reply. Used to prove the
@@ -377,27 +335,16 @@ async fn app_publish_layer_reaches_router_publishing_handlers() {
             b.include(rl_check);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Re-publish until the reply lands (subscriptions open inside run()).
     let payload = order_bytes(1);
-    let driven = tokio::time::timeout(Duration::from_secs(5), async {
-        let notified = RL_NOTIFY.notified();
-        tokio::pin!(notified);
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("rl-in", &payload))
-                .await;
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(driven.is_ok(), "router publishing handler never replied");
+    publisher
+        .publish(OutgoingMessage::new("rl-in", &payload))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), RL_NOTIFY.notified())
+        .await
+        .expect("router publishing handler never replied");
 
     assert_eq!(
         *RL_STAMPED.lock().unwrap(),
@@ -405,8 +352,7 @@ async fn app_publish_layer_reaches_router_publishing_handlers() {
         "the app-wide publish_layer must reach a router-mounted publishing handler"
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 // The same fix on the BATCH router-publishing path: the app's publish_layer must reach a
@@ -442,29 +388,16 @@ async fn app_publish_layer_reaches_router_batch_publishing_handlers() {
             b.include(bl_check);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = order_bytes(1);
-    let driven = tokio::time::timeout(Duration::from_secs(5), async {
-        let notified = BL_NOTIFY.notified();
-        tokio::pin!(notified);
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("bl-in", &payload))
-                .await;
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(
-        driven.is_ok(),
-        "router batch publishing handler never replied"
-    );
+    publisher
+        .publish(OutgoingMessage::new("bl-in", &payload))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), BL_NOTIFY.notified())
+        .await
+        .expect("router batch publishing handler never replied");
 
     assert_eq!(
         *BL_STAMPED.lock().unwrap(),
@@ -472,8 +405,7 @@ async fn app_publish_layer_reaches_router_batch_publishing_handlers() {
         "the app-wide publish_layer must reach a router-mounted batch publishing handler"
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 // A typed delivery context on a ROUTER-mounted publishing handler. The old SubscribeRoute-based
@@ -544,28 +476,18 @@ async fn router_publishing_threads_typed_delivery_context() {
         b.include(tc_check);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let payload = order_bytes(1);
-    let driven = tokio::time::timeout(Duration::from_secs(5), async {
-        let notified = TC_NOTIFY.notified();
-        tokio::pin!(notified);
-        loop {
-            let mut headers = Headers::new();
-            headers.insert("correlation-id", "trace-xyz");
-            let _ = publisher
-                .publish(OutgoingMessage::new("tc-in", &payload).with_headers(headers))
-                .await;
-            tokio::select! {
-                () = &mut notified => break,
-                () = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
-        }
-    })
-    .await;
-    assert!(driven.is_ok(), "typed-context router relay never replied");
+    let mut headers = Headers::new();
+    headers.insert("correlation-id", "trace-xyz");
+    publisher
+        .publish(OutgoingMessage::new("tc-in", &payload).with_headers(headers))
+        .await
+        .expect("publish");
+    tokio::time::timeout(Duration::from_secs(5), TC_NOTIFY.notified())
+        .await
+        .expect("typed-context router relay never replied");
 
     assert_eq!(
         TC_CORR.lock().unwrap().as_deref(),
@@ -573,6 +495,5 @@ async fn router_publishing_threads_typed_delivery_context() {
         "a router publishing handler must thread its typed delivery context to the publish layer"
     );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/scope_codec.rs
+++ b/tests/scope_codec.rs
@@ -9,21 +9,15 @@
 
 mod common;
 
-use std::{
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
 use ruststream::{Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Notify;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -42,26 +36,22 @@ static POUT: AtomicUsize = AtomicUsize::new(0);
 static POUT_ON: AtomicUsize = AtomicUsize::new(0);
 static BPOUT: AtomicUsize = AtomicUsize::new(0);
 static BPOUT_ON: AtomicUsize = AtomicUsize::new(0);
-static NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("sc-plain-on")]
 async fn plain_on(_o: &Order) -> HandlerResult {
     PLAIN_ON.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("sc-batch"))]
 async fn batch(orders: &[Order]) -> HandlerResult {
     BATCH.fetch_add(orders.len(), Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("sc-batch-ignored"))]
 async fn batch_on(orders: &[Order]) -> HandlerResult {
     BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -88,28 +78,24 @@ async fn batch_relay_on(orders: &[Order]) -> Vec<Receipt> {
 #[subscriber("sc-pout")]
 async fn pout_check(_r: &Receipt) -> HandlerResult {
     POUT.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("sc-pout-on")]
 async fn pout_on_check(_r: &Receipt) -> HandlerResult {
     POUT_ON.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("sc-bpout")]
 async fn bpout_check(_r: &Receipt) -> HandlerResult {
     BPOUT.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("sc-bpout-on")]
 async fn bpout_on_check(_r: &Receipt) -> HandlerResult {
     BPOUT_ON.fetch_add(1, Ordering::SeqCst);
-    NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -145,9 +131,8 @@ async fn scope_codec_include_family_dispatches() {
             b.include(bpout_on_check);
         });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    // `start` resolves only once subscriptions are open, so one publish per topic suffices.
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Order { id: 1 }).unwrap();
     let topics = [
@@ -163,44 +148,35 @@ async fn scope_codec_include_family_dispatches() {
         &PLAIN_ON, &BATCH, &BATCH_ON, &POUT, &POUT_ON, &BPOUT, &BPOUT_ON,
     ];
 
-    let outcome = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for topic in topics {
-                let _ = driver.publish(OutgoingMessage::new(topic, &payload)).await;
-            }
-            handler_signal(&NOTIFY).await;
-            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
-                break;
-            }
-        }
-    })
+    for topic in topics {
+        driver
+            .publish(OutgoingMessage::new(topic, &payload))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1),
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        outcome.is_ok(),
-        "a scope-codec include variant never dispatched"
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static D_PLAIN_ON: AtomicUsize = AtomicUsize::new(0);
 static D_BATCH_ON: AtomicUsize = AtomicUsize::new(0);
 static D_POUT_ON: AtomicUsize = AtomicUsize::new(0);
 static D_BPOUT_ON: AtomicUsize = AtomicUsize::new(0);
-static D_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 #[subscriber("d-plain-on")]
 async fn d_plain_on(_o: &Order) -> HandlerResult {
     D_PLAIN_ON.fetch_add(1, Ordering::SeqCst);
-    D_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber(batch("d-batch-ignored"))]
 async fn d_batch_on(orders: &[Order]) -> HandlerResult {
     D_BATCH_ON.fetch_add(orders.len(), Ordering::SeqCst);
-    D_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -217,14 +193,12 @@ async fn d_batch_relay_on(orders: &[Order]) -> Vec<Receipt> {
 #[subscriber("d-pout-on")]
 async fn d_pout_on_check(_r: &Receipt) -> HandlerResult {
     D_POUT_ON.fetch_add(1, Ordering::SeqCst);
-    D_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
 #[subscriber("d-bpout-on")]
 async fn d_bpout_on_check(_r: &Receipt) -> HandlerResult {
     D_BPOUT_ON.fetch_add(1, Ordering::SeqCst);
-    D_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -254,31 +228,24 @@ async fn default_codec_include_on_family_dispatches() {
         b.include(d_bpout_on_check);
     });
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    // `start` resolves only once subscriptions are open, so one publish per topic suffices.
+    let running = app.start().await.expect("startup failed");
 
     let payload = serde_json::to_vec(&Order { id: 1 }).unwrap();
     let topics = ["d-plain-on", "d-batch-on", "d-pin-on", "d-bpin-on"];
     let counters: [&AtomicUsize; 4] = [&D_PLAIN_ON, &D_BATCH_ON, &D_POUT_ON, &D_BPOUT_ON];
 
-    let outcome = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            for topic in topics {
-                let _ = driver.publish(OutgoingMessage::new(topic, &payload)).await;
-            }
-            handler_signal(&D_NOTIFY).await;
-            if counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1) {
-                break;
-            }
-        }
-    })
+    for topic in topics {
+        driver
+            .publish(OutgoingMessage::new(topic, &payload))
+            .await
+            .expect("publish");
+    }
+    wait_for(
+        || counters.iter().all(|c| c.load(Ordering::SeqCst) >= 1),
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        outcome.is_ok(),
-        "a default-codec include_on variant never dispatched"
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -1,5 +1,8 @@
 //! Integration tests for the workers(..) dispatch policies: concurrent pools, per-key lanes,
 //! and batch pools.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so every
+//! message is published exactly once - no warmup or republish loops.
 #![cfg(feature = "macros")]
 
 mod common;
@@ -12,7 +15,7 @@ use std::{
     time::Duration,
 };
 
-use common::handler_signal;
+use common::wait_for;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
@@ -20,7 +23,7 @@ use ruststream::runtime::{
 };
 use ruststream::{Headers, Name, OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Barrier, Notify};
+use tokio::sync::Barrier;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Order {
@@ -31,24 +34,15 @@ fn order_bytes(id: u32) -> Vec<u8> {
     serde_json::to_vec(&Order { id }).unwrap()
 }
 
-static WARMED: AtomicU32 = AtomicU32::new(0);
-static WARMED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static CRUNCHED: AtomicU32 = AtomicU32::new(0);
-static CRUNCHED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 static GATE: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(4));
 
 /// Four deliveries must be in flight at once to pass the barrier; a sequential loop would
 /// deadlock on the first one.
 #[subscriber("jobs", workers(4))]
-async fn crunch(job: &Order) -> HandlerResult {
-    if job.id == 0 {
-        WARMED.fetch_add(1, Ordering::SeqCst);
-        WARMED_NOTIFY.notify_one();
-        return HandlerResult::Ack;
-    }
+async fn crunch(_job: &Order) -> HandlerResult {
     GATE.wait().await;
     CRUNCHED.fetch_add(1, Ordering::SeqCst);
-    CRUNCHED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -60,49 +54,27 @@ async fn pool_processes_deliveries_concurrently() {
     let app =
         RustStream::new(AppInfo::new("jobs", "0.1.0")).with_broker(broker, |b| b.include(crunch));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    // Warm up until the subscription is live, then submit exactly the barrier's worth of jobs.
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("jobs", &order_bytes(0)))
-                .await;
-            handler_signal(&WARMED_NOTIFY).await;
-            if WARMED.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
-
+    // Exactly the barrier's worth of jobs: if they were dispatched sequentially, the first one
+    // would deadlock on the barrier and the wait below would time out.
     for id in 1..=4u32 {
         publisher
             .publish(OutgoingMessage::new("jobs", &order_bytes(id)))
             .await
-            .unwrap();
+            .expect("publish");
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        while CRUNCHED.load(Ordering::SeqCst) < 4 {
-            CRUNCHED_NOTIFY.notified().await;
-        }
-    })
+    wait_for(
+        || CRUNCHED.load(Ordering::SeqCst) >= 4,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        result.is_ok(),
-        "4 deliveries never ran concurrently (sequential dispatch would deadlock the barrier)",
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static KEYED_SEEN: Mutex<Vec<(String, u32)>> = Mutex::new(Vec::new());
-static KEYED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Records (key, id) pairs; per-key arrival order must match publish order.
 #[subscriber("keyed", workers(4, by_key))]
@@ -115,7 +87,6 @@ async fn keyed(order: &Order, ctx: &mut ruststream::runtime::Context<'_>) -> Han
     // Encourage interleaving between lanes; each lane itself stays sequential.
     tokio::task::yield_now().await;
     KEYED_SEEN.lock().unwrap().push((key, order.id));
-    KEYED_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -129,9 +100,7 @@ async fn by_key_lanes_preserve_per_key_order() {
     let app =
         RustStream::new(AppInfo::new("keyed", "0.1.0")).with_broker(broker, |b| b.include(keyed));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
     let keyed_publish = |key: &'static str, id: u32| {
         let publisher = publisher.clone();
@@ -144,40 +113,16 @@ async fn by_key_lanes_preserve_per_key_order() {
         }
     };
 
-    // Warm up until the subscription is live (warmup deliveries carry their own key).
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = keyed_publish("warmup", 0).await;
-            handler_signal(&KEYED_NOTIFY).await;
-            if !KEYED_SEEN.lock().unwrap().is_empty() {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
-
     for id in 1..=PER_KEY {
-        keyed_publish("alpha", id).await.unwrap();
-        keyed_publish("beta", id + 100).await.unwrap();
+        keyed_publish("alpha", id).await.expect("publish");
+        keyed_publish("beta", id + 100).await.expect("publish");
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            KEYED_NOTIFY.notified().await;
-            let counted = KEYED_SEEN
-                .lock()
-                .unwrap()
-                .iter()
-                .filter(|(key, _)| key == "alpha" || key == "beta")
-                .count();
-            if counted >= (PER_KEY as usize) * 2 {
-                break;
-            }
-        }
-    })
+    wait_for(
+        || KEYED_SEEN.lock().unwrap().len() >= (PER_KEY as usize) * 2,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(result.is_ok(), "keyed deliveries did not all arrive");
 
     let seen = KEYED_SEEN.lock().unwrap().clone();
     for key in ["alpha", "beta"] {
@@ -192,18 +137,15 @@ async fn by_key_lanes_preserve_per_key_order() {
         );
     }
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 static PAGES: AtomicUsize = AtomicUsize::new(0);
-static PAGES_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Batch form composing with a pool: up to two pages in flight.
 #[subscriber(batch("pages"), workers(2))]
 async fn settle(orders: &[Order]) -> HandlerResult {
     PAGES.fetch_add(orders.len(), Ordering::SeqCst);
-    PAGES_NOTIFY.notify_one();
     HandlerResult::Ack
 }
 
@@ -215,26 +157,17 @@ async fn batch_pool_dispatches_batches() {
     let app = RustStream::new(AppInfo::new("pages", "0.1.0"))
         .with_broker(broker, |b| b.include_batch(settle));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("pages", &order_bytes(1)))
-                .await;
-            handler_signal(&PAGES_NOTIFY).await;
-            if PAGES.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "no batch was dispatched through the pool");
+    publisher
+        .publish(OutgoingMessage::new("pages", &order_bytes(1)))
+        .await
+        .expect("publish");
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    // A batch carrying the message must be dispatched through the pool.
+    wait_for(|| PAGES.load(Ordering::SeqCst) >= 1, Duration::from_secs(5)).await;
+
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(3))`.
@@ -245,31 +178,18 @@ async fn closure_subscription_pool_runs_concurrently() {
     let broker = MemoryBroker::new();
     let publisher = broker.publisher();
 
-    let warmed = Arc::new(AtomicU32::new(0));
     let crunched = Arc::new(AtomicU32::new(0));
-    let signal = Arc::new(Notify::new());
     let gate = Arc::new(Barrier::new(3));
 
     let handler = {
-        let warmed = Arc::clone(&warmed);
         let crunched = Arc::clone(&crunched);
-        let signal = Arc::clone(&signal);
         let gate = Arc::clone(&gate);
-        typed(JsonCodec, move |order: &Order, _ctx: &mut Context| {
-            let warmed = Arc::clone(&warmed);
+        typed(JsonCodec, move |_order: &Order, _ctx: &mut Context| {
             let crunched = Arc::clone(&crunched);
-            let signal = Arc::clone(&signal);
             let gate = Arc::clone(&gate);
-            let id = order.id;
             async move {
-                if id == 0 {
-                    warmed.fetch_add(1, Ordering::SeqCst);
-                    signal.notify_one();
-                    return HandlerResult::Ack;
-                }
                 gate.wait().await;
                 crunched.fetch_add(1, Ordering::SeqCst);
-                signal.notify_one();
                 HandlerResult::Ack
             }
         })
@@ -286,44 +206,24 @@ async fn closure_subscription_pool_runs_concurrently() {
     let app = RustStream::new(AppInfo::new("fn-jobs", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let warmup = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("fn-jobs", &order_bytes(0)))
-                .await;
-            handler_signal(&signal).await;
-            if warmed.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(warmup.is_ok(), "subscription did not come up");
-
+    // Exactly the barrier's worth of jobs: sequential dispatch would deadlock on the first one
+    // and the wait below would time out.
     for id in 1..=3u32 {
         publisher
             .publish(OutgoingMessage::new("fn-jobs", &order_bytes(id)))
             .await
-            .unwrap();
+            .expect("publish");
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        while crunched.load(Ordering::SeqCst) < 3 {
-            signal.notified().await;
-        }
-    })
+    wait_for(
+        || crunched.load(Ordering::SeqCst) >= 3,
+        Duration::from_secs(5),
+    )
     .await;
-    assert!(
-        result.is_ok(),
-        "3 deliveries never ran concurrently (sequential dispatch would deadlock the barrier)",
-    );
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    running.shutdown().await.expect("graceful shutdown failed");
 }
 
 /// The functional batch path: a `Router::subscribe_batch` slice closure receives whole decoded
@@ -334,18 +234,14 @@ async fn closure_batch_subscription_receives_batches() {
     let publisher = broker.publisher();
 
     let seen = Arc::new(AtomicUsize::new(0));
-    let signal = Arc::new(Notify::new());
 
     let handler = {
         let seen = Arc::clone(&seen);
-        let signal = Arc::clone(&signal);
         move |orders: &[Order], _ctx: &mut Context| {
             let count = orders.len();
             let seen = Arc::clone(&seen);
-            let signal = Arc::clone(&signal);
             async move {
                 seen.fetch_add(count, Ordering::SeqCst);
-                signal.notify_one();
                 HandlerResult::Ack
             }
         }
@@ -362,24 +258,15 @@ async fn closure_batch_subscription_receives_batches() {
     let app = RustStream::new(AppInfo::new("fn-pages", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
 
-    let shutdown = Arc::new(Notify::new());
-    let shutdown_signal = Arc::clone(&shutdown);
-    let run = tokio::spawn(app.run_until(async move { shutdown_signal.notified().await }));
+    let running = app.start().await.expect("startup failed");
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let _ = publisher
-                .publish(OutgoingMessage::new("fn-pages", &order_bytes(1)))
-                .await;
-            handler_signal(&signal).await;
-            if seen.load(Ordering::SeqCst) >= 1 {
-                break;
-            }
-        }
-    })
-    .await;
-    assert!(result.is_ok(), "no batch reached the slice closure");
+    publisher
+        .publish(OutgoingMessage::new("fn-pages", &order_bytes(1)))
+        .await
+        .expect("publish");
 
-    shutdown.notify_one();
-    run.await.unwrap().unwrap();
+    // The message must reach the slice closure as a decoded batch.
+    wait_for(|| seen.load(Ordering::SeqCst) >= 1, Duration::from_secs(5)).await;
+
+    running.shutdown().await.expect("graceful shutdown failed");
 }


### PR DESCRIPTION
# Description

Running a RustStream service beside another foreground server (an HTTP framework, typically axum) required `tokio::spawn(app.run_until(pending()))`, which swallows startup failures, gives no readiness point, and cannot coordinate a graceful shutdown.

`RustStream::start` (also on the sealed `App` trait) performs the same startup sequence as `run` - state producer, broker connects, subscription opens, `after_startup` hooks - and resolves once the service is running, so a startup failure surfaces before the host accepts traffic. It returns a `RunningApp` handle:

- `stopping()` - an owned `'static` future that resolves when the service tears itself down on a fail-fast failure; plugs directly into a host's graceful shutdown (`with_graceful_shutdown`).
- `shutdown(self)` - the explicit async graceful teardown (`on_shutdown` hooks, drain of in-flight handlers and post-settle continuations bounded by the shutdown timeout, broker shutdown, `after_shutdown` hooks), surfacing a fail-fast reason as `Err(Dispatch)`.

`run_until` is reimplemented as `start` + select + `shutdown`, so there is a single startup/teardown code path; `run` and signal ownership are unchanged. `start` installs no signal handlers - the host decides what stops the service. The handle is non-generic (shutdown hooks capture the state at start time), so it fits in struct fields without naming the app's type parameters.

The impl block bound gains `St: 'static`. This is not observable: the `on_startup` producer returns the state from a `'static` boxed future, so every constructible app already satisfies it.

Fixes #147

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable

The HTTP frameworks guide and its `http_outbox` example (PR #144) move to this API; the site docs update rides there.