### PR TITLE
ci: make the Coveralls upload advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,13 +195,16 @@ jobs:
 
       # Feeds the README coverage badge. Coveralls accepts the default GITHUB_TOKEN for public
       # repositories, so no extra secret is required; uploaded even when the gate fails so the
-      # badge reflects reality rather than the last green run.
+      # badge reflects reality rather than the last green run. The upload is advisory: a
+      # Coveralls outage must not fail the pipeline (the enforced coverage gate is the
+      # fail-under step above).
       - name: Upload to Coveralls
         if: always()
         uses: coverallsapp/github-action@v2
         with:
           file: lcov.info
           format: lcov
+          fail-on-error: false
 
   package:
     name: Package (publish dry-run)


### PR DESCRIPTION
# Description

The Coveralls upload feeds the README badge and nothing else; a Coveralls-side outage must not fail the pipeline. PR #148's coverage job just failed exactly this way: the gate passed, then the upload step got an HTTP 500 from the Coveralls API ("Internal server error. Please contact Coveralls team.") and took the job down with it. The upload step now carries `fail-on-error: false`; the enforced coverage gate remains the `--fail-under-lines` step.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] I have performed a self-review of my own code