### PR TITLE
docs: move the metrics example off the spawned run_until wiring

### DIFF
--- a/docs/hooks/snippet_titles.py
+++ b/docs/hooks/snippet_titles.py
@@ -1,0 +1,45 @@
+"""Filename headers on embedded snippets.
+
+Every code fence that embeds a compiled snippet (a ``--8<--`` include) gets a Material
+``title="<path>"`` header naming the source file, and the rendered header links to the file on
+GitHub - so a reader can jump from any excerpt to the full compiled example. Fences that already
+carry an explicit ``title=`` (for example the scaffold walkthrough titling a block
+``src/main.rs``) are left alone.
+
+The title is injected in the markdown phase, before pymdownx.snippets resolves the include; the
+link is wrapped in the HTML phase, because Material renders the title as a plain
+``<span class="filename">``.
+"""
+
+import re
+
+REPO_BLOB = "https://github.com/powersemmi/ruststream/blob/main/"
+
+FENCE = re.compile(r"^```(?P<info>[^\n`]*)\n(?P<body>.*?)^```$", re.M | re.S)
+INCLUDE = re.compile(r'--8<--\s+"(?P<path>[^":]+)(?::[^"]*)?"')
+
+# Paths whose filename headers get linkified in the HTML phase. Collected across pages; the
+# build is single-process, so a plain module-level set is enough.
+_linked_paths: set[str] = set()
+
+
+def on_page_markdown(markdown, **_kwargs):
+    def add_title(match):
+        info, body = match.group("info"), match.group("body")
+        include = INCLUDE.search(body)
+        if include is None or "title=" in info:
+            return match.group(0)
+        path = include.group("path")
+        _linked_paths.add(path)
+        return f'```{info} title="{path}"\n{body}```'
+
+    return FENCE.sub(add_title, markdown)
+
+
+def on_page_content(html, **_kwargs):
+    for path in _linked_paths:
+        html = html.replace(
+            f'<span class="filename">{path}</span>',
+            f'<span class="filename"><a href="{REPO_BLOB}{path}">{path}</a></span>',
+        )
+    return html

--- a/examples/metrics_http.rs
+++ b/examples/metrics_http.rs
@@ -14,7 +14,6 @@
 //! Each published order is consumed (incrementing the consume counter) and replied to on
 //! `confirmations` through the metrics publish layer (incrementing the publish counter).
 
-use std::future::pending;
 use std::sync::Arc;
 
 use axum::Router;
@@ -81,10 +80,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     // --8<-- [end:wiring]
 
-    // Run the service in the background; it shares the metric collectors with the HTTP state.
-    tokio::spawn(async move {
-        let _ = app.run_until(pending::<()>()).await;
-    });
+    // The messaging side starts in the background and shares the metric collectors with the
+    // HTTP state; a startup failure surfaces here, before HTTP accepts traffic.
+    let running = app.start().await?;
 
     let state = Arc::new(AppState { metrics, ingest });
     let router = Router::new()
@@ -94,6 +92,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:8080").await?;
     println!("metrics on http://127.0.0.1:8080/metrics");
-    axum::serve(listener, router).await?;
+    // The host owns the signals. HTTP stops on Ctrl+C, or when the messaging side tears itself
+    // down (fail-fast); either way the messaging side then drains gracefully.
+    let stopping = running.stopping();
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                () = stopping => {}
+            }
+        })
+        .await?;
+    running.shutdown().await?;
     Ok(())
 }

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -61,6 +61,9 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 
+hooks:
+  - docs/hooks/snippet_titles.py
+
 plugins:
   - search
   # Versioned docs are published with `mike` (see the Docs workflow and the version switcher).


### PR DESCRIPTION
# Description

`examples/metrics_http.rs` predates `start()` and still brought the app up with `tokio::spawn(app.run_until(pending()))` - the exact pattern the HTTP frameworks guide now warns against: it swallows startup failures and offers no graceful shutdown. The example now mirrors the canonical `http_outbox` wiring: `start()` resolves before the HTTP server accepts traffic, axum stops on Ctrl+C or a fail-fast teardown of the messaging side, and `shutdown()` drains in-flight handlers. The metrics guide embeds this file, so the rendered site follows along; it was the last remaining use of the spawned form outside the pages that document `run_until` itself.

Verified end to end: publish via curl increments the consume and publish counters, SIGINT exits gracefully.

**Snippet source headers.** A build hook (`docs/hooks/snippet_titles.py`) stamps every code fence that embeds a `--8<--` snippet with a Material filename header naming the source path, linked to the file on GitHub - a reader can jump from any excerpt to the full compiled example. Fences with an explicit `title=` (the scaffold walkthrough titling a block `src/main.rs`) are left alone. 69 snippet blocks across the site pick this up; no new dependency, the hook is a dozen lines on the standard hooks mechanism.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in `examples/` where applicable