### PR TITLE
docs: broker-author contract catch-up, bump to 0.5.3

### DIFF
--- a/.cursor/rules/broker-authors.mdc
+++ b/.cursor/rules/broker-authors.mdc
@@ -5,19 +5,36 @@ alwaysApply: false
 ---
 
 - A broker is its own crate that depends on `ruststream` (broker clients never go into core).
-  Implement `Broker`: associated `Error`, async `connect`, async `shutdown`.
+  Implement `Broker`: associated `Error`, async `connect`, async `shutdown`. Pre-1.0 the broker
+  crate's version tracks the core minor line (core 0.5.x -> broker 0.5.x); breaking broker changes
+  ship as a patch within the line.
 - Lazy-startup contract (so the broker works with `#[ruststream::app]`): a synchronous, I/O-free
   `new(addrs)` that only records config; all network work happens in `connect`, which is idempotent
   and runs once at startup. Keep the connection behind interior mutability so publishers handed out
   before `connect` resolve on first use.
 - Implement `Subscribe` for the by-name `#[subscriber("topic")]` form, and ship a
-  `SubscriptionSource<YourBroker>` descriptor for broker-specific options. Implement capability traits
-  (`RequestReply`, `BatchSubscriber`, `TransactionalPublisher`, `Partitioned`, `DescribeServer`) only
-  for what the broker natively supports.
-- `ack` consumes `self`; for transports without acks return `AckError::Unsupported`.
-- Ship a `TestClient` (handler-stub, Core routing only) under a `testing` feature. Verify with the
-  conformance harness; run `lifecycle` against a real server (env-gated). No simulation of
-  broker-specific semantics (durable cursors, offsets, DLX) - those are tested only against a server.
+  `SubscriptionSource<YourBroker>` descriptor for broker-specific options (even a parameter-less
+  broker ships one). Implement capability traits (`RequestReply`, `BatchSubscriber`,
+  `TransactionalPublisher`, `Partitioned`, `DescribeServer`) only for what the broker natively
+  supports - never emulate.
+- Expose the per-delivery context as a `#[non_exhaustive]` typed struct plus `ContextField` key
+  types (unit structs with an associated `Context` and owned `Value`), so handlers can take
+  `Ctx<Partition>`-style parameters. No type-map, no heap on the delivery path.
+- `ack` consumes `self`; for transports without acks return `AckError::Unsupported`. Errors and
+  logs are self-explanatory: name the subscription and the type involved, not just the raw error.
+- Integrations that need async I/O around encode/decode (schema registries, wire-format envelopes)
+  are middleware on the async edges: transcode on the subscription's delivery path for consuming,
+  and a core `PublishLayer` (`RustStream::publish_layer`) for publishing. Never a custom sync
+  `Codec` and never hooks threaded through the publisher - handlers stay on the default codec.
+- Raw librdkafka-style client options go through a passthrough builder (`config(key, value)`), not
+  one wrapper method per option. Auth (TLS, SASL) rides that passthrough; surface only the cargo
+  features that build hermetically everywhere, and let users enable exotic client features by
+  depending on the client crate directly (cargo features are additive).
+- Testing: implement `TestableBroker` for the broker's in-process transport and register it with
+  `register_testable_broker!` (under a `testing` feature), so `TestApp` and `run_suite` can drive
+  it. Verify with the conformance harness; run `lifecycle` against a real server (env-gated). No
+  simulation of broker-specific semantics (durable cursors, offsets, DLX) - those are tested only
+  against a server.
 
 ## Lazy broker
 
@@ -115,17 +132,50 @@ impl SubscriptionSource<MyBroker> for MySubscribeOptions {
 }
 ```
 
+## Typed context and `Ctx` keys
+
+The broker names its context type on the subscriber; `ContextField` keys make individual fields
+injectable as handler parameters.
+
+```rust
+use ruststream::ContextField;
+
+/// Per-delivery context of this broker.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct MyContext {
+    pub partition: i32,
+}
+
+/// `Ctx<Partition>` in a handler binds the delivery's partition.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Partition;
+
+impl ContextField for Partition {
+    type Context = MyContext;
+    type Value = i32;
+    fn read(self, src: &MyContext) -> i32 {
+        src.partition
+    }
+}
+```
+
 ## Conformance
 
-Run both, the lifecycle against a real server behind an env gate.
+Routing runs against the broker's in-process transport (a `TestableBroker` with a synchronous
+factory); the full lazy lifecycle runs against a real server behind an env gate.
 
 ```rust
 use ruststream::conformance::harness;
 
-// routing, via your TestClient (testing feature)
-harness::run_suite(|| async { MyTestClient::start().await }).await;
+// routing contract: ordering, ack/nack, headers, ... (testing feature)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn routing_conformance() {
+    harness::run_suite(MyTestBroker::new).await; // sync Fn() -> B, B: TestableBroker + Subscribe
+}
 
-// full lazy lifecycle against a real broker
+// full lazy lifecycle: sync new -> connect -> subscribe via SubscriptionSource -> publish ->
+// receive -> ack -> shutdown, against a real broker
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn lazy_lifecycle_conformance() {
     let Ok(url) = std::env::var("MY_BROKER_TEST_URL") else { return };
@@ -137,3 +187,6 @@ async fn lazy_lifecycle_conformance() {
     .await;
 }
 ```
+
+When changing anything on the broker contract, run the conformance suite against the real broker
+before releasing - an in-process pass is not enough.

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -5,17 +5,23 @@ alwaysApply: false
 ---
 
 - A handler is an `async fn` annotated with `#[subscriber("subject")]`. Its first parameter is the
-  decoded payload by reference (`&T`, where `T: serde::Deserialize`); an optional second parameter is
-  `ctx: &mut ruststream::runtime::Context`.
+  decoded payload by reference (`&T`, where `T: serde::Deserialize`). Further parameters are
+  extractors: `State<T>` injects a component of the application state, `Ctx<K>` injects one broker
+  context field (partition, offset, ...). An explicit `ctx: &mut Context` parameter is optional and
+  last; omit it unless you use it.
 - The return type drives acknowledgement: `HandlerResult`, `()` (always acks), or `Result<_, E>` (an
   `Err` nacks). For a reply handler, add a `publish("subject")` clause and return the reply value,
   or `Result<Reply, HandlerResult>` for explicit ack control.
-- Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream`. Do not write
-  your own `main` or `#[tokio::main]`.
+- Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream` (or
+  `impl App` when layers/state change the type). Do not write your own `main` or `#[tokio::main]`.
+- Application state is built once in `on_startup` (async closures: `async move |()| ...`) and
+  injected with `State<T>` via `#[derive(FromRef)]` on the state struct. There is no runtime
+  type-map; everything is typed and zero-cost.
 - Construct brokers synchronously (`MemoryBroker::new()`, `NatsBroker::new(url)`); the runtime
   connects them at startup. Never connect inside the builder.
 - The codec defaults to `codec::DefaultCodec` (`json` > `cbor` > `msgpack`), so `include` needs no
-  codec argument. Log with `tracing`, never `println!`. In tests use `MemoryBroker` or a `TestClient`.
+  codec argument. Log with `tracing`, never `println!`. In tests use `MemoryBroker` driven by the
+  `TestApp` harness (`testing` feature).
 
 ## Subscriber and app
 
@@ -95,15 +101,72 @@ Return `Result<Reply, HandlerResult>` to control acknowledgement: `Ok(reply)` pu
 `Result` out in the signature (a type alias is treated as a plain reply type). A failed reply
 publish nacks the incoming message with `requeue = true`.
 
+Note the `publish(..)` clause takes a string literal; runtime-computed destinations are not
+supported there.
+
+## State injection (dependency injection)
+
+Build the state once in `on_startup`; `#[derive(FromRef)]` makes every field injectable with
+`State<FieldType>` - no extractor impls, no type-map.
+
 ```rust
-#[subscriber("orders", publish("confirmations"))]
-async fn confirm(order: &Order) -> Result<Confirmation, HandlerResult> {
-    if order.id == 0 {
-        return Err(HandlerResult::drop());
-    }
-    Ok(Confirmation { id: order.id, accepted: true })
+use std::convert::Infallible;
+
+use ruststream::FromRef;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream, State};
+use ruststream::subscriber;
+
+#[derive(Clone)]
+struct Database; // connection pool, etc.
+
+#[derive(FromRef)]
+struct AppState {
+    db: Database,
+}
+
+#[subscriber("orders")]
+async fn handle(order: &Order, State(db): State<Database>) -> HandlerResult {
+    // db.store(order).await;
+    let _ = db;
+    HandlerResult::Ack
+}
+
+#[ruststream::app]
+fn app() -> impl ruststream::runtime::App {
+    RustStream::new(AppInfo::new("orders", "0.1.0"))
+        .on_startup(async move |()| Ok::<_, Infallible>(AppState { db: Database }))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle))
 }
 ```
+
+## Broker context fields (`Ctx<K>`)
+
+`Ctx<K>` injects one field of the broker's per-delivery context, the way `State<T>` injects a
+state component. The key `K` is a broker-provided `ContextField` type; a handler using only `Ctx`
+extractors needs no `&mut Context` parameter at all.
+
+```rust
+use ruststream::runtime::Ctx;
+// Keys come from the broker crate, e.g. ruststream_rdkafka::context::{Partition, Offset}.
+
+#[subscriber("orders")]
+async fn handle(order: &Order, Ctx(partition): Ctx<Partition>) -> HandlerResult {
+    tracing::info!(partition, "delivery");
+    HandlerResult::Ack
+}
+```
+
+## Context (optional explicit parameter)
+
+When you need the raw delivery objects, take `ctx: &mut Context<'_, C, S>` as the last parameter
+(`C` = broker context type, `S` = application state):
+
+- `ctx.name()` - the subject/channel the message arrived on.
+- `ctx.headers()` / `ctx.headers_mut()` - the working copy of the message headers.
+- `ctx.state()` - the shared application state built by `on_startup`.
+
+There is no `ctx.get::<T>()` and no named-publisher registry; state is typed (`State<T>` /
+`ctx.state()`), and publishing goes through `publish(..)` replies or a `TypedPublisher` in state.
 
 ## Choosing a codec
 
@@ -128,7 +191,8 @@ Collect handlers in their own module, then mount the group. A `Router` is a cons
 (each call returns a new type), so the calls chain and the function returns `impl RouterDef<B>`.
 The app's global `.layer(..)` reaches router handlers, so cross-cutting middleware (logging,
 metrics) goes on the app and applies everywhere; that global layer must be a `BlanketLayer`
-(every bundled layer is).
+(every bundled layer is). Publish-side middleware (tracing propagation, broker envelopes such as
+Kafka's Schema Registry framing) is added app-wide with `.publish_layer(..)` before `with_broker`.
 
 ```rust
 use ruststream::runtime::{Router, RouterDef};
@@ -147,9 +211,9 @@ fn orders(broker: &MemoryBroker) -> impl RouterDef<MemoryBroker> + use<> {
 
 ## Broker-specific subscriptions
 
-For options the by-name form can't express (NATS JetStream, consumer groups), override the source
-with `include_on`. The codec resolves the same way as for `include` (the default, or the scope /
-chain codec).
+For options the by-name form can't express (NATS JetStream, Kafka consumer groups / start offsets),
+pass the broker's descriptor directly in the attribute, or override the source with `include_on`.
+The codec resolves the same way as for `include`.
 
 ```rust
 use ruststream_nats::SubscribeOptions;
@@ -158,45 +222,6 @@ b.include_on(
     SubscribeOptions::new("orders.*").jetstream("ORDERS").durable("worker"),
     handle,
 );
-```
-
-## Context (optional handler argument)
-
-`ctx: &mut Context` is an **optional** second handler parameter. Omit it when you do not use it - do
-not add it just in case. When present it exposes the delivery's runtime objects:
-
-- `ctx.name()` - the subject/channel the message arrived on.
-- `ctx.headers()` / `ctx.headers_mut()` - the working copy of the message headers.
-- `ctx.get::<T>()` - shared application state registered with `RustStream::insert_state`.
-- `ctx.publisher(name)` - a named publisher (registered with `RustStream::publisher`) for a manual
-  publish through the same middleware pipeline as a macro reply.
-
-```rust
-use ruststream::runtime::{Context, HandlerResult, Outgoing};
-
-struct Database; // connection pool, etc.
-
-#[subscriber("orders")]
-async fn handle(order: &Order, ctx: &mut Context) -> HandlerResult {
-    let subject = ctx.name();                  // "orders"
-    if let Some(db) = ctx.get::<Database>() {   // application state
-        // db.store(order).await;
-        let _ = db;
-    }
-    if let Some(audit) = ctx.publisher("audit") {
-        let _ = audit.publish(Outgoing::new("audit", b"stored".to_vec())).await;
-    }
-    HandlerResult::Ack
-}
-```
-
-Register state and named publishers on the app builder:
-
-```rust
-RustStream::new(AppInfo::new("orders", "0.1.0"))
-    .insert_state(Database)
-    .publisher("audit", broker.publisher())
-    .with_broker(broker, |b| b.include(handle))
 ```
 
 ## AsyncAPI metadata
@@ -224,17 +249,31 @@ struct Order {
 
 ## Testing
 
-Use the in-memory broker (or a broker's `TestClient` under the `testing` feature); no real server.
+Use the `TestApp` harness (`testing` feature): it drives the built application with no network and
+no server, injects input through the broker bus, and exposes per-broker assertions. `MemoryBroker`
+is a real broker here, driven through the same dispatch path as production.
 
 ```rust
-use std::time::Duration;
 use ruststream::memory::MemoryBroker;
-use ruststream::testing::TestClient;
+use ruststream::testing::TestApp;
 
-let client = MemoryBroker::start().await?;
-client.publish("orders", br#"{"id":1}"#).await?;
-let published = client
-    .expect_published("confirmations", 1, Duration::from_secs(1))
+let tb = TestApp::start(service()).await?;
+
+tb.broker::<MemoryBroker>()
+    .publish("orders", &Order { id: 42 })
     .await?;
-client.shutdown().await?;
+
+tb.broker::<MemoryBroker>()
+    .subscriber("orders")
+    .assert_called_once()
+    .with(&Order { id: 42 })
+    .settled(HandlerResult::Ack);
+
+tb.broker::<MemoryBroker>()
+    .published::<Receipt>("receipts")
+    .assert_called_once()
+    .with(&Receipt { order_id: 42 });
 ```
+
+Broker crates ship their own in-process test broker under their `testing` feature; `TestApp` drives
+those the same way.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/ruststream-macros"]
 exclude = ["templates"]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -21,7 +21,7 @@ default = []
 testing = ["ruststream/conformance"]
 
 [dependencies]
-ruststream = { version = "0.4", default-features = false }
+ruststream = { version = "0.5", default-features = false }
 async-nats = "0.46"
 bytes = "1"
 futures = "0.3"

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -6,7 +6,7 @@ any other broker:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.4", default-features = false }
+ruststream = { version = "0.5", default-features = false }
 ```
 
 This page is the contract. Implement the required traits, expose your own `Config`, add capability
@@ -31,6 +31,14 @@ pub trait Broker: Send + Sync {
 ```
 
 `shutdown` must never block or panic; do all fallible teardown here and return a `Result`.
+
+Construction is **synchronous and I/O-free**: `new(addrs)` only records configuration, all network
+work happens in `connect` (idempotent, called once at startup by the runtime). Keep the live
+connection behind interior mutability (for example `Arc<tokio::sync::OnceCell<_>>`) so a publisher
+handed out before `connect` resolves the connection on first use; operations that need it earlier
+return a clear "not connected" error. This lazy-startup contract is what lets a service compose
+with the synchronous `#[ruststream::app]` builder; the
+[conformance harness](conformance.md) proves it end to end.
 
 ### `Subscribe`
 
@@ -134,6 +142,47 @@ Implement only the capabilities your broker supports; none are part of the manda
 | `RequestReply` | native request-reply (NATS yes, Kafka no) |
 | `Partitioned` | a partition key on outgoing messages |
 | `DescribeServer` | reporting a `ServerSpec` for AsyncAPI |
+
+## Per-delivery context and `Ctx` keys
+
+A broker with native delivery metadata (a partition, an offset, a stream sequence) exposes it as a
+typed per-delivery context: a `#[non_exhaustive]` struct the subscriber names, plus `ContextField`
+key types so handlers can bind single fields as parameters with the
+[`Ctx<K>` extractor](../guides/context.md#per-delivery-context). Keys are unit structs; values are
+owned. No type-map and no heap on the delivery path.
+
+<!-- inline-rust: sketch; the real trait lives in src/field.rs -->
+```rust
+/// Per-delivery context of this broker.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct MyContext {
+    pub partition: i32,
+}
+
+/// `Ctx<Partition>` in a handler binds the delivery's partition.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Partition;
+
+impl ContextField for Partition {
+    type Context = MyContext;
+    type Value = i32;
+    fn read(self, src: &MyContext) -> i32 {
+        src.partition
+    }
+}
+```
+
+A broker with no per-delivery fields uses `()` and skips all of this.
+
+## Middleware on the async edges
+
+Integrations that need async I/O around encode and decode (a schema registry, a wire-format
+envelope) do not belong in a `Codec`: the core codec is synchronous and handlers should stay on the
+default one. Put them on the async edges instead - transcode incoming payloads on the
+subscription's delivery path (before the codec sees them), and frame outgoing ones with a core
+`PublishLayer` added app-wide via `RustStream::publish_layer`. The publish layer is async and
+fallible, and `Outgoing::payload_mut` exists exactly for envelope wrapping.
 
 ## Config and defaults
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -43,7 +43,7 @@ Codec features are mutually compatible; enable as many as you need (see
 
 ```toml
 [dependencies]
-ruststream = { version = "0.4", default-features = false }
+ruststream = { version = "0.5", default-features = false }
 ```
 
 ## The CLI


### PR DESCRIPTION
# Description

Ports the uncommitted broker-author docs work that was sitting in the working tree (the docs half of the 0.5.2 / Ctx rollout) onto the restructured site.

- The dependency pins on the contract pages and in installation still said `0.4`; they now say `0.5`.
- The broker-author contract page gains the pieces 0.5 added but the docs never described: the lazy-startup prose right under the `Broker` trait (synchronous `new`, idempotent `connect`, connection behind interior mutability), how a broker exposes its per-delivery context as a `#[non_exhaustive]` typed struct plus `ContextField` keys for the `Ctx<K>` extractor (sketch checked against the real trait: `Default` supertrait, owned `Value`, `read`), and where async encode/decode integrations belong - the subscription's delivery path and an app-wide `PublishLayer`, never a custom sync `Codec`.
- The Cursor rules are synced to the same contract; they still described the `TestClient` removed in 0.5 and now name `TestableBroker` / `register_testable_broker!`, the broker versioning policy, `ContextField` keys, the async-edges rule, passthrough client config, and self-explanatory diagnostics.

`properdocs build --strict` and the fence lint pass; no Rust surface is touched.

**Version bump to 0.5.3.** Everything since the published 0.5.2 is additive - security schemes on AsyncAPI servers (#141) and the background start handle `app.start() -> RunningApp` (#148) - so the workspace moves to 0.5.3 (patch = additive, per the pre-1.0 policy; both crates ride the lockstep workspace version).

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)