### PR TITLE
fix: pin the macros crate to the exact lockstep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
-ruststream-macros = { version = "0.5", path = "crates/ruststream-macros", optional = true }
+# Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
+# release for release (a loose range let a partial `cargo update` pair a new core with an old
+# macros crate and fail to compile). Bumped by the same edit as [workspace.package].version.
+ruststream-macros = { version = "=0.5.3", path = "crates/ruststream-macros", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }


### PR DESCRIPTION
# Description

The `ruststream-macros` dependency was declared as a loose `0.5` range. The two crates release in lockstep, so any resolution pairing them across releases is unsupported - and a downstream running a partial `cargo update -p ruststream` gets exactly that: ruststream-fred moving to core 0.5.3 kept macros locked at 0.5.0 (pre-`FromRef`) and the published core failed to compile with `unresolved import ruststream_macros::FromRef`.

The requirement is now the exact `=0.5.3` and moves with the same edit as `[workspace.package].version` (comment added at the declaration). The published 0.5.3 itself is fine for fresh resolutions (cargo picks the latest macros); this manifest fix rides the next release and prevents the stale-lock pairing from then on.

The multi-package publish dry-run (`cargo publish --dry-run -p ruststream-macros -p ruststream`) passes with the exact pin resolved through the in-workspace overlay.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)