### PR TITLE
chore: replace broker-specific crate keywords with concept keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ repository.workspace = true
 authors.workspace = true
 description = "Async messaging framework for Rust: broker-agnostic traits, router, codecs, and a conformance harness for broker authors."
 readme = "README.md"
-keywords = ["messaging", "async", "broker", "faststream", "nats"]
+keywords = ["messaging", "async", "broker", "pubsub", "event-driven"]
 categories = ["asynchronous", "network-programming"]
 
 [features]


### PR DESCRIPTION
# Description

Reworks the `keywords` list in the core crate metadata. The previous list named faststream and nats, which misrepresents the scope: the core is broker-agnostic and is not tied to any single broker. The list now describes the domain instead: `messaging`, `async`, `broker`, `pubsub`, `event-driven`.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)