### PR TITLE
docs: add the Trendshift badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/84257" target="_blank"><img src="https://trendshift.io/api/badge/repositories/84257" alt="powersemmi%2Fruststream | Trendshift" width="250" height="55"/></a>
+</p>
+
+<p align="center">
   <b><a href="https://powersemmi.github.io/ruststream/">Documentation</a></b>
 </p>
 


### PR DESCRIPTION
# Description

Adds the Trendshift badge to the README header, linking to the project's Trendshift page. The badge sits in its own centered row above the documentation link, since it is a large-format banner rather than a shields.io-style badge.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)