### PR TITLE
feat: add a transaction scope guard on the Transactional wrapper

### DIFF
--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -94,7 +94,7 @@ without the capability simply do not call it. Each suite takes the same factory 
 |---|---|---|
 | `capabilities::request_reply` | `RequestReply` | the request reaches a responder with a usable `reply-to` header, the correlated reply resolves the request, an unanswered request fails after its timeout |
 | `capabilities::batches` | `BatchSubscriber` | every published message arrives in publish order, distributed over non-empty batches |
-| `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it |
+| `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it; misuse errors - `commit` / `abort` with no open transaction, a second `begin_transaction` while one is open (which must leave it untouched) |
 
 <!-- inline-rust: worked request-reply capability check against the external ruststream-nats crate; its real gated suite lives in that repo, so it has no compiled home here -->
 ```rust

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -43,7 +43,10 @@ in-process semantics, not a simulation of another broker's:
   batches ship immediately, so no deadline timer is involved.
 - **Transactions.** `MemoryPublisher` implements `TransactionalPublisher`: publishes between
   `begin_transaction` and `commit` are buffered and fan out together in publish order; `abort`
-  discards them. Clones of a publisher handle do not share its transaction.
+  discards them. Misuse errors with `MemoryError` per the trait contract: a second
+  `begin_transaction` returns `TransactionBusy` (the open transaction is untouched), and
+  `commit` / `abort` without one return `NoTransaction`. Clones of a publisher handle do not
+  share its transaction.
 - **Partition keys.** `MemoryMessage` implements `Partitioned`, reading the key from the
   well-known `partition-key` header (`memory::PARTITION_KEY_HEADER`).
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -150,6 +150,22 @@ brokers without transactions the compiler rejects it. The single-message `includ
 forms keep taking a plain `TypedPublisher`: a one-message transaction adds broker round-trips
 for no atomicity gain.
 
+## Manual transactions
+
+Outside the batch-reply path, drive a transaction by hand: `begin()` on the transactional wiring
+opens a `TransactionScope` that owns the transaction. Publishes go through the scope, and
+`commit()` / `abort()` consume it - so a commit without a begin, a second commit, or a publish
+after settling are compile errors, not runtime surprises:
+
+```rust
+--8<-- "examples/publishing.rs:manual_transaction"
+```
+
+The scope encodes values with the publisher's codec and sends them directly: per-publisher
+transforms and the app-wide `publish_layer` middleware belong to the dispatch path (they read the
+originating delivery) and do not run here. Dropping an unsettled scope logs a warning and leaves
+the broker transaction open on that handle - always settle explicitly.
+
 ## Batch publishing
 
 There is no direct batch-publish API on `Publisher`. For most brokers (NATS, Kafka) the client

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -6,7 +6,9 @@
 //! cargo run --example publishing --features macros,memory,json -- run
 //! ```
 
+use std::error::Error;
 use std::future::Future;
+use std::io;
 use std::pin::Pin;
 
 use ruststream::codec::{Codec, JsonCodec};
@@ -15,7 +17,7 @@ use ruststream::runtime::{
     App, AppInfo, HandlerResult, Outgoing, PublishLayer, PublishNext, PublishTransform, RustStream,
     TypedPublisher,
 };
-use ruststream::{OutgoingMessage, Publisher, subscriber};
+use ruststream::{OutgoingMessage, Publisher, TransactionalPublisher, subscriber};
 use serde::{Deserialize, Serialize};
 
 // A publisher shared with handlers as a typed field of the application state.
@@ -95,9 +97,7 @@ impl PublishLayer for AuditPublish {
         &'a self,
         out: &'a mut Outgoing<'a>,
         next: PublishNext<'a, N>,
-    ) -> Pin<
-        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
-    > {
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + Send + Sync>>> + Send + 'a>> {
         Box::pin(async move {
             println!("publishing to {}", out.name());
             next.run(out).await
@@ -117,18 +117,39 @@ async fn confirm(orders: &[Event]) -> Result<Vec<Event>, HandlerResult> {
 }
 // --8<-- [end:batch_publishing]
 
+// --8<-- [start:manual_transaction]
+/// Seeds the reference events inside one broker transaction: both records become visible
+/// together on commit, or not at all. The scope owns the transaction, so a commit without a
+/// begin, a second commit, or a publish after settling do not compile.
+async fn seed_events<P>(publisher: P) -> Result<(), Box<dyn Error + Send + Sync>>
+where
+    P: TransactionalPublisher,
+{
+    let seeder = TypedPublisher::new(publisher).transactional();
+    let mut scope = seeder.begin().await?;
+    scope.publish("events", &Event { id: 1 }).await?;
+    scope.publish("events", &Event { id: 2 }).await?;
+    scope.commit().await?;
+    Ok(())
+}
+// --8<-- [end:manual_transaction]
+
 // `impl App` hides the composed pipeline type: the app-wide `publish_layer` would otherwise surface
 // in the return type as `RustStream<_, AppState, PublishStack<AuditPublish, PublishIdentity>>`.
 #[ruststream::app]
 fn app() -> impl App {
     let broker = MemoryBroker::new();
     let egress = broker.publisher();
+    let seed = broker.publisher();
     // --8<-- [start:pipeline]
     RustStream::new(AppInfo::new("publishing", "0.1.0"))
         // app-wide layer: wraps every published reply
         .publish_layer(AuditPublish)
         // a publisher shared with handlers as typed state, reached via `ctx.state().egress`
-        .on_startup(move |()| async move { Ok::<_, std::convert::Infallible>(AppState { egress }) })
+        .on_startup(async move |()| {
+            seed_events(seed).await.map_err(io::Error::other)?;
+            Ok::<_, io::Error>(AppState { egress })
+        })
         .with_broker(broker, |b| {
             // static, per-publisher: composed onto this TypedPublisher at compile time
             let replies = TypedPublisher::new(b.broker().publisher()).transform(EnvelopeTransform);

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -92,12 +92,16 @@ impl<C> PublishTransform<C> for EnvelopeTransform {
 #[derive(Clone)]
 struct AuditPublish;
 
+// The boxed future every publish layer returns; named once so the impl signature stays readable.
+type PublishFut<'a> =
+    Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + Send + Sync>>> + Send + 'a>>;
+
 impl PublishLayer for AuditPublish {
     fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
         &'a self,
         out: &'a mut Outgoing<'a>,
         next: PublishNext<'a, N>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn Error + Send + Sync>>> + Send + 'a>> {
+    ) -> PublishFut<'a> {
         Box::pin(async move {
             println!("publishing to {}", out.name());
             next.run(out).await

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -37,8 +37,15 @@ pub trait BatchSubscriber: Subscriber {
 /// Implementations must guarantee that messages published between [`begin_transaction`] and
 /// [`commit`] either all become visible to subscribers or none of them do.
 ///
+/// Misuse is an error, never a silent no-op: a [`commit`] or [`abort`] with no open transaction,
+/// and a [`begin_transaction`] while one is open, must return `Self::Error`. A caller can
+/// therefore trust that `Ok` from `commit` means "an open transaction committed", not "there was
+/// nothing to commit". The [`conformance`](crate::conformance) transactional suite checks these
+/// paths.
+///
 /// [`begin_transaction`]: Self::begin_transaction
 /// [`commit`]: Self::commit
+/// [`abort`]: Self::abort
 pub trait TransactionalPublisher: Publisher {
     /// Begins a new transaction on this publisher.
     ///
@@ -47,8 +54,9 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker refuses to start a transaction, for example
-    /// because transactions are already in progress or the broker is misconfigured.
+    /// Returns `Self::Error` when a transaction is already open on this handle (a second begin
+    /// must not silently join or restart it), or when the broker refuses to start one. A
+    /// rejected begin must leave an already-open transaction untouched.
     ///
     /// [`commit`]: Self::commit
     /// [`abort`]: Self::abort
@@ -58,15 +66,21 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker rejects the commit. The transaction state after
-    /// a failed commit is implementation-defined; implementors must document it.
+    /// Returns `Self::Error` when no transaction is open on this handle, or when the broker
+    /// rejects the commit. After a failed commit the transaction is closed: the implementation
+    /// discards or aborts the broker-side transaction rather than leaving it open, and a
+    /// subsequent [`begin_transaction`](Self::begin_transaction) either starts a fresh
+    /// transaction or returns an error - the handle must never wedge permanently. Messages of a
+    /// failed transaction are lost to this handle; redelivery of the inputs, not resubmission of
+    /// the buffer, is the recovery path.
     fn commit(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Aborts the active transaction, discarding all buffered messages.
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker rejects the abort.
+    /// Returns `Self::Error` when no transaction is open on this handle, or when the broker
+    /// fails to abort.
     fn abort(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 

--- a/src/conformance/capabilities.rs
+++ b/src/conformance/capabilities.rs
@@ -227,7 +227,10 @@ pub async fn batches<B, MkBroker, Src, MkSrc, Pub, MkPub>(
 /// Verifies the [`TransactionalPublisher`] contract.
 ///
 /// Nothing published inside a transaction is visible before `commit`, a commit makes every
-/// buffered message visible in publish order, and an abort discards the buffer.
+/// buffered message visible in publish order, and an abort discards the buffer. Misuse must
+/// error rather than silently succeed: `commit` / `abort` with no open transaction, and a
+/// second `begin_transaction` while one is open (which must also leave the open transaction
+/// untouched).
 ///
 /// # Examples
 ///
@@ -316,6 +319,43 @@ pub async fn transactions<B, MkBroker, Src, MkSrc, Pub, MkPub>(
         .expect("publish inside transaction failed");
     publisher.abort().await.expect("abort failed");
     expect_no_more(&mut stream, "transactions: after abort").await;
+
+    // Misuse must surface as errors, never as silent success.
+    assert!(
+        publisher.commit().await.is_err(),
+        "commit with no open transaction must error",
+    );
+    assert!(
+        publisher.abort().await.is_err(),
+        "abort with no open transaction must error",
+    );
+    publisher
+        .begin_transaction()
+        .await
+        .expect("begin_transaction failed");
+    assert!(
+        publisher.begin_transaction().await.is_err(),
+        "begin_transaction while a transaction is open must error",
+    );
+    // The rejected second begin must not have disturbed the open transaction.
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"third".as_slice()))
+        .await
+        .expect("publish inside transaction failed");
+    publisher
+        .commit()
+        .await
+        .expect("commit after a rejected double begin failed");
+    let third = expect_next(&mut stream, "transactions: after rejected double begin").await;
+    assert_eq!(
+        third.payload(),
+        b"third",
+        "a rejected double begin must leave the open transaction intact",
+    );
+    match third.ack().await {
+        Ok(()) | Err(AckError::Unsupported) => {}
+        Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+    }
 
     Broker::shutdown(&broker)
         .await

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -7,7 +7,6 @@
 //! them.
 
 use std::{
-    convert::Infallible,
     sync::{Arc, atomic::Ordering},
     task::Poll,
     time::Duration,
@@ -18,7 +17,9 @@ use futures::Stream;
 use thiserror::Error;
 use tokio::{sync::mpsc, time::timeout};
 
-use super::{MemoryDelivery, MemoryMessage, MemoryPublisher, MemoryState, MemorySubscriber};
+use super::{
+    MemoryDelivery, MemoryError, MemoryMessage, MemoryPublisher, MemoryState, MemorySubscriber,
+};
 use crate::{
     BatchSubscriber, IncomingMessage, OutgoingMessage, Partitioned, Publisher, RequestReply,
     Subscriber, TransactionalPublisher,
@@ -205,37 +206,41 @@ impl BatchSubscriber for MemorySubscriber {
 /// switches this handle to buffering, [`commit`](TransactionalPublisher::commit) fans out the
 /// buffer in publish order, [`abort`](TransactionalPublisher::abort) discards it.
 ///
-/// Every operation is total, matching the infallible publisher: `begin_transaction` inside an
-/// active transaction continues that transaction, and `commit` / `abort` without one are no-ops.
-/// Clones of the handle do not share the transaction (see [`MemoryPublisher`]).
+/// Misuse errors per the trait contract: a second `begin_transaction` returns
+/// [`MemoryError::TransactionBusy`] (leaving the open transaction untouched), and `commit` /
+/// `abort` without an open transaction return [`MemoryError::NoTransaction`]. Clones of the
+/// handle do not share the transaction (see [`MemoryPublisher`]).
 impl TransactionalPublisher for MemoryPublisher {
-    async fn begin_transaction(&self) -> Result<(), Infallible> {
+    async fn begin_transaction(&self) -> Result<(), MemoryError> {
         let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
-        if txn.is_none() {
-            *txn = Some(Vec::new());
+        if txn.is_some() {
+            return Err(MemoryError::TransactionBusy);
         }
+        *txn = Some(Vec::new());
         drop(txn);
         Ok(())
     }
 
-    async fn commit(&self) -> Result<(), Infallible> {
+    async fn commit(&self) -> Result<(), MemoryError> {
         let buffered = self
             .txn
             .lock()
             .expect("memory broker mutex poisoned")
-            .take();
-        for delivery in buffered.into_iter().flatten() {
+            .take()
+            .ok_or(MemoryError::NoTransaction)?;
+        for delivery in buffered {
             self.state.fanout(&delivery);
         }
         Ok(())
     }
 
-    async fn abort(&self) -> Result<(), Infallible> {
+    async fn abort(&self) -> Result<(), MemoryError> {
         self.txn
             .lock()
             .expect("memory broker mutex poisoned")
-            .take();
-        Ok(())
+            .take()
+            .map(|_| ())
+            .ok_or(MemoryError::NoTransaction)
     }
 }
 
@@ -381,6 +386,24 @@ mod tests {
         let second = stream.next().await.unwrap().unwrap();
         assert_eq!(second.payload(), b"buffered");
         second.ack().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn transactional_misuse_errors() {
+        let broker = MemoryBroker::new();
+        let publisher = broker.publisher();
+
+        assert_eq!(publisher.commit().await, Err(MemoryError::NoTransaction));
+        assert_eq!(publisher.abort().await, Err(MemoryError::NoTransaction));
+
+        publisher.begin_transaction().await.unwrap();
+        assert_eq!(
+            publisher.begin_transaction().await,
+            Err(MemoryError::TransactionBusy),
+        );
+        // The rejected second begin left the transaction open; an abort settles it.
+        publisher.abort().await.unwrap();
+        assert_eq!(publisher.abort().await, Err(MemoryError::NoTransaction));
     }
 
     #[tokio::test]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::Stream;
+use thiserror::Error;
 use tokio::sync::{Notify, mpsc};
 
 type Sender = mpsc::UnboundedSender<MemoryDelivery>;
@@ -369,8 +370,24 @@ impl std::fmt::Debug for MemoryPublisher {
     }
 }
 
+/// Error returned by [`MemoryPublisher`].
+///
+/// Publishing itself cannot fail (the bus is in-process); the variants cover transactional
+/// misuse, which the [`TransactionalPublisher`](crate::TransactionalPublisher) contract requires
+/// to surface as errors rather than silent no-ops.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MemoryError {
+    /// `begin_transaction` was called while a transaction is already open on this handle.
+    #[error("a transaction is already open on this publisher handle")]
+    TransactionBusy,
+    /// `commit` or `abort` was called with no open transaction on this handle.
+    #[error("no transaction is open on this publisher handle")]
+    NoTransaction,
+}
+
 impl Publisher for MemoryPublisher {
-    type Error = Infallible;
+    type Error = MemoryError;
 
     async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
         let delivery = MemoryDelivery {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -41,8 +41,8 @@ pub use publish::{
     BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, ForBatch, Outgoing,
     PublishContext, PublishDynLayer, PublishDynNext, PublishDynStack, PublishIdentity,
     PublishLayer, PublishNext, PublishPipeline, PublishStack, PublishTransform,
-    PublishTransformIdentity, PublishTransformStack, ReplyPublisher, Transactional, TypedPublisher,
-    for_batch,
+    PublishTransformIdentity, PublishTransformStack, ReplyPublisher, TransactionPublishError,
+    TransactionScope, Transactional, TypedPublisher, for_batch,
 };
 pub use publisher_registry::ErasedPublisher;
 pub use publishing::{PublishingCall, PublishingDef, PublishingHandler};

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -10,17 +10,18 @@ use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
 
 use bytes::BytesMut;
 use serde::Serialize;
+use thiserror::Error;
 use tracing::warn;
 
 use super::lifecycle::BoxError;
 use super::publisher_registry::ErasedPublisher;
-use crate::codec::Codec;
+use crate::codec::{Codec, CodecError};
 // `DefaultCodec` only exists when a codec feature is on; the impl that names it is gated the same
 // way, so an ungated import would break `--no-default-features`.
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::codec::DefaultCodec;
 use crate::runtime::publish::sealed::Sealed;
-use crate::{Headers, Publisher, TransactionalPublisher};
+use crate::{Headers, OutgoingMessage, Publisher, TransactionalPublisher};
 
 type PublishFut<'a> = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'a>>;
 
@@ -802,6 +803,167 @@ async fn abort_quietly<P: TransactionalPublisher>(publisher: &P) {
     if let Err(err) = publisher.abort().await {
         warn!(target: "ruststream::dispatch", error = %err, "transaction abort failed");
     }
+}
+
+impl<P, C, PL, BL> Transactional<P, C, PL, BL>
+where
+    P: TransactionalPublisher,
+    C: Sync,
+    PL: Sync,
+    BL: Sync,
+{
+    /// Opens a broker transaction and returns the [`TransactionScope`] that owns it.
+    ///
+    /// The scope is the only handle on the transaction: publishes go through it, and it is
+    /// consumed by [`commit`](TransactionScope::commit) or [`abort`](TransactionScope::abort).
+    /// A second `begin` on this wrapper, a commit without a begin, or a publish after the commit
+    /// are not expressible - the methods do not exist on the types those states leave behind.
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "memory", feature = "json"))]
+    /// # {
+    /// use ruststream::memory::MemoryBroker;
+    /// use ruststream::runtime::TypedPublisher;
+    ///
+    /// # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let broker = MemoryBroker::new();
+    /// let publisher = TypedPublisher::new(broker.publisher()).transactional();
+    ///
+    /// let mut scope = publisher.begin().await?;
+    /// scope.publish("orders.settled", &42_u32).await?;
+    /// scope.commit().await?;
+    /// # Ok(())
+    /// # }
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the publisher's error when the broker refuses to start a transaction.
+    pub async fn begin(&self) -> Result<TransactionScope<'_, P, C>, P::Error> {
+        self.inner.publisher.begin_transaction().await?;
+        Ok(TransactionScope {
+            publisher: &self.inner.publisher,
+            codec: &self.inner.codec,
+            open: true,
+        })
+    }
+}
+
+/// A live broker transaction, opened by [`Transactional::begin`].
+///
+/// Publishes issued through the scope become visible together on [`commit`](Self::commit), or
+/// not at all after [`abort`](Self::abort); both consume the scope, so a double commit or a
+/// publish after settling is a compile error. This is the manual counterpart of the per-batch
+/// transaction the runtime drives for `include_batch_publishing` mounts.
+///
+/// The scope encodes values with the wrapper's codec and sends them directly: the reply
+/// [`PublishTransform`] stack and the app-wide [`publish_layer`](super::RustStream::publish_layer)
+/// middleware do not run here - both belong to the dispatch path, where a delivery context
+/// exists.
+///
+/// Dropping an unsettled scope logs a warning and leaves the broker transaction open (destructors
+/// cannot run async work); always settle explicitly.
+#[must_use = "a transaction scope must be settled with commit() or abort()"]
+pub struct TransactionScope<'a, P, C> {
+    publisher: &'a P,
+    codec: &'a C,
+    open: bool,
+}
+
+impl<P, C> TransactionScope<'_, P, C>
+where
+    P: TransactionalPublisher,
+    C: Codec,
+{
+    /// Encodes `value` with the wrapper's codec and publishes it to `name` inside the
+    /// transaction.
+    ///
+    /// A failed publish does not settle the scope: the caller decides between retrying and
+    /// [`abort`](Self::abort). Aborting is the safe default - after an error the broker-side
+    /// transaction state is implementation-defined.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionPublishError::Encode`] when the codec rejects the value, and
+    /// [`TransactionPublishError::Publish`] when the broker rejects the message.
+    ///
+    /// # Cancel safety
+    ///
+    /// As with [`Publisher::publish`], cancel safety is broker-defined: dropping the future
+    /// mid-flight may leave the message in an indeterminate state inside the transaction.
+    pub async fn publish<T: Serialize + Sync>(
+        &mut self,
+        name: &str,
+        value: &T,
+    ) -> Result<(), TransactionPublishError<P::Error>> {
+        let payload = self
+            .codec
+            .encode(value)
+            .map_err(TransactionPublishError::Encode)?;
+        self.publisher
+            .publish(OutgoingMessage::new(name, &payload))
+            .await
+            .map_err(TransactionPublishError::Publish)
+    }
+
+    /// Commits the transaction: every publish issued through the scope becomes visible at once.
+    ///
+    /// # Errors
+    ///
+    /// Returns the publisher's error when the broker rejects the commit. The scope aborts the
+    /// transaction on a best-effort basis first (an abort failure is logged, not propagated), so
+    /// the handle does not stay wedged on a transaction that can no longer complete.
+    pub async fn commit(mut self) -> Result<(), P::Error> {
+        self.open = false;
+        if let Err(err) = self.publisher.commit().await {
+            abort_quietly(self.publisher).await;
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    /// Aborts the transaction: nothing published through the scope becomes visible.
+    ///
+    /// # Errors
+    ///
+    /// Returns the publisher's error when the broker fails to abort.
+    pub async fn abort(mut self) -> Result<(), P::Error> {
+        self.open = false;
+        self.publisher.abort().await
+    }
+}
+
+impl<P, C> Drop for TransactionScope<'_, P, C> {
+    fn drop(&mut self) {
+        if self.open {
+            warn!(
+                target: "ruststream::dispatch",
+                "transaction scope dropped without commit or abort; the broker transaction stays \
+                 open on this publisher handle until it is settled or the handle is dropped"
+            );
+        }
+    }
+}
+
+impl<P, C> std::fmt::Debug for TransactionScope<'_, P, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransactionScope")
+            .field("open", &self.open)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Error returned by [`TransactionScope::publish`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TransactionPublishError<E> {
+    /// The codec rejected the value.
+    #[error("failed to encode the value for a transactional publish")]
+    Encode(#[source] CodecError),
+    /// The broker rejected the message.
+    #[error("failed to publish inside the transaction")]
+    Publish(#[source] E),
 }
 
 #[cfg(test)]

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -789,11 +789,12 @@ where
                 return Err(err);
             }
         }
-        if let Err(err) = publisher.commit().await {
-            abort_quietly(publisher).await;
-            return Err(Box::new(err) as BoxError);
-        }
-        Ok(())
+        // Per the TransactionalPublisher contract a failed commit closes the transaction, so
+        // there is nothing left to abort here; the error alone settles the batch as failed.
+        publisher
+            .commit()
+            .await
+            .map_err(|err| Box::new(err) as BoxError)
     }
 }
 
@@ -911,16 +912,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns the publisher's error when the broker rejects the commit. The scope aborts the
-    /// transaction on a best-effort basis first (an abort failure is logged, not propagated), so
-    /// the handle does not stay wedged on a transaction that can no longer complete.
+    /// Returns the publisher's error when the broker rejects the commit. Per the
+    /// [`TransactionalPublisher`] contract a failed commit closes the transaction, so the spent
+    /// scope leaves the handle free for a fresh [`begin`](Transactional::begin).
     pub async fn commit(mut self) -> Result<(), P::Error> {
         self.open = false;
-        if let Err(err) = self.publisher.commit().await {
-            abort_quietly(self.publisher).await;
-            return Err(err);
-        }
-        Ok(())
+        self.publisher.commit().await
     }
 
     /// Aborts the transaction: nothing published through the scope becomes visible.

--- a/tests/router_include.rs
+++ b/tests/router_include.rs
@@ -27,7 +27,7 @@ fn order_bytes(id: u32) -> Vec<u8> {
 /// Publishes `payload` once to each topic (the app is already started, so the subscriptions are
 /// open and every publish lands), then waits until every counter is non-zero.
 async fn publish_and_await_all(
-    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    publisher: &impl Publisher,
     topics: &[&str],
     counters: &[&AtomicUsize],
 ) {

--- a/tests/router_publishing.rs
+++ b/tests/router_publishing.rs
@@ -44,7 +44,7 @@ fn order_bytes(id: u32) -> Vec<u8> {
 /// subscriptions are open and every publish lands), then waits until every reply counter is
 /// non-zero.
 async fn publish_and_await_replies(
-    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    publisher: &impl Publisher,
     topics: &[&str],
     counters: &[&AtomicUsize],
 ) {

--- a/tests/transaction_scope.rs
+++ b/tests/transaction_scope.rs
@@ -1,0 +1,96 @@
+//! Integration tests for the manual transaction scope: publishes issued through a
+//! [`TransactionScope`] become visible together on commit, never after an abort, and the
+//! wrapper is reusable once a scope settles.
+//!
+//! [`TransactionScope`]: ruststream::runtime::TransactionScope
+#![cfg(all(feature = "memory", feature = "json"))]
+
+use std::pin::pin;
+
+use futures::{FutureExt, StreamExt};
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::TypedPublisher;
+use ruststream::{IncomingMessage, Subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Order {
+    id: u32,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_makes_scope_publishes_visible_atomically() {
+    let broker = MemoryBroker::new();
+    let mut subscriber = broker.subscribe("orders.settled");
+    let publisher = TypedPublisher::new(broker.publisher()).transactional();
+
+    let mut scope = publisher.begin().await.expect("begin failed");
+    scope
+        .publish("orders.settled", &Order { id: 1 })
+        .await
+        .expect("publish failed");
+    scope
+        .publish("orders.settled", &Order { id: 2 })
+        .await
+        .expect("publish failed");
+
+    // The memory broker fans out synchronously, so an uncommitted publish that leaked would
+    // already be in the queue here.
+    let mut stream = pin!(subscriber.stream());
+    assert!(
+        stream.next().now_or_never().flatten().is_none(),
+        "scope publishes became visible before commit"
+    );
+
+    scope.commit().await.expect("commit failed");
+
+    for expected in [1, 2] {
+        let msg = stream
+            .next()
+            .now_or_never()
+            .flatten()
+            .expect("committed publish did not arrive")
+            .expect("memory subscriber never errors");
+        let order: Order = serde_json::from_slice(msg.payload()).expect("decode failed");
+        assert_eq!(order.id, expected);
+        msg.ack().await.expect("ack failed");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abort_discards_scope_publishes_and_frees_the_wrapper() {
+    let broker = MemoryBroker::new();
+    let mut subscriber = broker.subscribe("orders.settled");
+    let publisher = TypedPublisher::new(broker.publisher()).transactional();
+
+    let mut scope = publisher.begin().await.expect("begin failed");
+    scope
+        .publish("orders.settled", &Order { id: 1 })
+        .await
+        .expect("publish failed");
+    scope.abort().await.expect("abort failed");
+
+    let mut stream = pin!(subscriber.stream());
+    assert!(
+        stream.next().now_or_never().flatten().is_none(),
+        "aborted publish became visible"
+    );
+
+    // The wrapper is free again: a fresh scope on the same handle commits normally.
+    let mut scope = publisher.begin().await.expect("second begin failed");
+    scope
+        .publish("orders.settled", &Order { id: 3 })
+        .await
+        .expect("publish failed");
+    scope.commit().await.expect("commit failed");
+
+    let msg = stream
+        .next()
+        .now_or_never()
+        .flatten()
+        .expect("committed publish did not arrive")
+        .expect("memory subscriber never errors");
+    let order: Order = serde_json::from_slice(msg.payload()).expect("decode failed");
+    assert_eq!(order.id, 3);
+    msg.ack().await.expect("ack failed");
+}


### PR DESCRIPTION
# Description

Adds a manual transaction API on the `Transactional` publisher wrapper: `begin()` opens a `TransactionScope` that owns the broker transaction. Publishes go through the scope, and `commit()` / `abort()` consume it, so a commit without a begin, a double commit, or a publish after settling are compile errors instead of the silent runtime no-ops the broker implementations currently exhibit.

The scope encodes values with the wrapper's codec and sends them directly; reply transforms and the app-wide publish middleware remain dispatch-path features (documented). A failed commit aborts on a best-effort basis so the handle is not left wedged; dropping an unsettled scope logs a warning, since destructors cannot run async work (a deviation from the issue sketch, which suggested best-effort abort on drop). Additive only: the `TransactionalPublisher` SPI is unchanged.

Fixes #161

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable