### PR TITLE
feat: enforce app builder call order with a phase type parameter

### DIFF
--- a/docs/guides/lifespan.md
+++ b/docs/guides/lifespan.md
@@ -32,7 +32,10 @@ after_shutdown(Arc<S>)           # final teardown
 - **`on_startup`** receives the previous state **by value** (`()` on the first call) and returns the
   new state, so its future can own resources across awaits - connect a pool, build the state struct,
   return it. The returned type becomes the app's state type. A failing `on_startup` aborts startup.
-  The later hooks receive the state as a shared `Arc<S>`.
+  The later hooks receive the state as a shared `Arc<S>`. `on_startup` only exists before the first
+  `with_broker`: handlers are registered against the state type it produces, so the reverse order
+  does not compile. Register the other lifecycle hooks after it (an earlier hook would close over
+  the wrong state type; `on_startup` panics if one exists).
 - **`after_startup`** runs once subscriptions are open and handlers are live. Use it to publish an
   initial message or signal readiness (the [testing guide](testing.md) uses it as the "handlers are
   live" gate). A failure here also aborts startup.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -11,7 +11,10 @@ it.
 
 **Application scope.** Add a layer to the whole application with `RustStream::layer`, before
 `with_broker`. Every handler registered after it is wrapped - both handlers registered directly on
-a broker scope and handlers a router brings in via `include_router`:
+a broker scope and handlers a router brings in via `include_router`. The order is enforced at
+compile time: the first `with_broker` moves the builder to a phase where `layer` (and
+`publish_layer`, and `on_startup`) no longer exist, so a layer that could not wrap the
+already-registered handlers is a compile error, not a silent no-op:
 
 ```rust
 --8<-- "examples/middleware_app_scope.rs:app_scope"

--- a/src/runtime/app/app_trait.rs
+++ b/src/runtime/app/app_trait.rs
@@ -11,7 +11,7 @@ use super::{AppInfo, RunningApp, RustStream, RustStreamError};
 
 mod sealed {
     pub trait Sealed {}
-    impl<L, St, PP> Sealed for super::RustStream<L, St, PP> {}
+    impl<L, St, PP, Phase> Sealed for super::RustStream<L, St, PP, Phase> {}
 }
 
 /// The functional surface of a built [`RustStream`] service: run it, and read the metadata the
@@ -88,7 +88,7 @@ pub trait App: sealed::Sealed + Sized {
 // `St: 'static` mirrors the inherent impl in run.rs: every constructible app already satisfies
 // it, and `start` needs it to bind the state into the shutdown hooks.
 #[allow(clippy::use_self)]
-impl<L: Send, St: Send + Sync + 'static, PP: Send> App for RustStream<L, St, PP> {
+impl<L: Send, St: Send + Sync + 'static, PP: Send, Phase> App for RustStream<L, St, PP, Phase> {
     fn run(self) -> impl Future<Output = Result<(), RustStreamError>> + Send {
         RustStream::run(self)
     }

--- a/src/runtime/app/app_trait.rs
+++ b/src/runtime/app/app_trait.rs
@@ -1,5 +1,5 @@
 //! The sealed [`App`] trait: the functional surface a built service exposes, so a builder can
-//! return `impl App` instead of spelling the full `RustStream<L, St, PP>` type.
+//! return `impl App` instead of spelling the full `RustStream<Layers, State, Pipeline>` type.
 
 use std::collections::BTreeMap;
 use std::future::Future;
@@ -11,7 +11,7 @@ use super::{AppInfo, RunningApp, RustStream, RustStreamError};
 
 mod sealed {
     pub trait Sealed {}
-    impl<L, St, PP, Phase> Sealed for super::RustStream<L, St, PP, Phase> {}
+    impl<Layers, State, Pipeline, Phase> Sealed for super::RustStream<Layers, State, Pipeline, Phase> {}
 }
 
 /// The functional surface of a built [`RustStream`] service: run it, and read the metadata the
@@ -19,7 +19,7 @@ mod sealed {
 ///
 /// Implemented only by [`RustStream`] (the trait is sealed), so a builder function can hide the
 /// composed middleware / state / publish-pipeline type parameters behind `impl App` instead of
-/// naming `RustStream<Stack<..>, St, PublishStack<..>>` in full:
+/// naming `RustStream<Stack<..>, State, PublishStack<..>>` in full:
 ///
 /// ```no_run
 /// # #[cfg(feature = "memory")]
@@ -78,17 +78,19 @@ pub trait App: sealed::Sealed + Sized {
     fn handlers(&self) -> &[HandlerMetadata];
 }
 
-// `PP: Send` is what makes the run futures `Send`: `run` consumes `self`, which holds the publish
+// `Pipeline: Send` is what makes the run futures `Send`: `run` consumes `self`, which holds the publish
 // pipeline. Every real pipeline is `Send` (the `PublishLayer` trait requires `Send + Sync`), so the
 // bound never gets in the way; it just lets the type system see what is already true.
 //
 // Each method names `RustStream` explicitly rather than `Self`: the inherent methods share these
 // names with the trait, so spelling the type makes clear the call delegates to the inherent method
 // (which wins by priority) and does not recurse into the trait method.
-// `St: 'static` mirrors the inherent impl in run.rs: every constructible app already satisfies
+// `State: 'static` mirrors the inherent impl in run.rs: every constructible app already satisfies
 // it, and `start` needs it to bind the state into the shutdown hooks.
 #[allow(clippy::use_self)]
-impl<L: Send, St: Send + Sync + 'static, PP: Send, Phase> App for RustStream<L, St, PP, Phase> {
+impl<Layers: Send, State: Send + Sync + 'static, Pipeline: Send, Phase> App
+    for RustStream<Layers, State, Pipeline, Phase>
+{
     fn run(self) -> impl Future<Output = Result<(), RustStreamError>> + Send {
         RustStream::run(self)
     }

--- a/src/runtime/app/include.rs
+++ b/src/runtime/app/include.rs
@@ -18,7 +18,7 @@ use crate::runtime::typed::Typed;
 
 use super::scope::BrokerScope;
 
-impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
+impl<B: Broker + 'static, Layers, State, Pipeline> BrokerScope<B, Layers, (), State, Pipeline> {
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
     /// [`DefaultCodec`](crate::codec::DefaultCodec) and wrapping the handler with the global stack.
     ///
@@ -45,8 +45,8 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
             > + Send
             + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<
+        State: Send + Sync + 'static,
+        Layers: Layer<
             Typed<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Input,
@@ -54,10 +54,10 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
                 D::Handler,
             >,
         >,
-        L::Handler: Handler<
+        Layers::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
-                St,
+                State,
             > + 'static,
     {
         let source = def.source();
@@ -80,8 +80,8 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<
+        State: Send + Sync + 'static,
+        Layers: Layer<
             Typed<
                 <S::Subscriber as Subscriber>::Message,
                 D::Input,
@@ -89,7 +89,8 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
                 D::Handler,
             >,
         >,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         self.mount_subscriber(source, def, crate::codec::DefaultCodec::default());
     }
@@ -111,8 +112,8 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: crate::runtime::SliceHandler<D::Input, St> + 'static,
-        St: Send + Sync + 'static,
+        D::Handler: crate::runtime::SliceHandler<D::Input, State> + 'static,
+        State: Send + Sync + 'static,
     {
         let source = def.source();
         self.mount_batch(source, def, crate::codec::DefaultCodec::default());
@@ -128,8 +129,8 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         S::Subscriber: BatchSubscriber + Send + 'static,
         D: BatchDef,
         D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: crate::runtime::SliceHandler<D::Input, St> + 'static,
-        St: Send + Sync + 'static,
+        D::Handler: crate::runtime::SliceHandler<D::Input, State> + 'static,
+        State: Send + Sync + 'static,
     {
         self.mount_batch(source, def, crate::codec::DefaultCodec::default());
     }
@@ -144,15 +145,15 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
     /// every reply, commits, then acks the batch; any failure aborts and the batch is retried.
     pub fn include_batch_publishing<D, RP>(&mut self, def: D, publisher: RP)
     where
-        D: BatchPublishingCall<St> + 'static,
+        D: BatchPublishingCall<State> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
-        PP: PublishPipeline + Clone + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
         RP::Codec: Clone + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = publisher.reply_codec().clone();
         let source = def.source();
@@ -165,13 +166,13 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingCall<St> + 'static,
+        D: BatchPublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
-        PP: PublishPipeline + Clone + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
         RP::Codec: Clone + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = publisher.reply_codec().clone();
         self.mount_batch_publishing(source, def, codec, publisher);
@@ -184,7 +185,7 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
     /// default with [`with_broker_codec`](crate::runtime::RustStream::with_broker_codec).
     pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
     where
-        D: PublishingCall<St> + 'static,
+        D: PublishingCall<State> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
@@ -198,13 +199,13 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishTransform<D::Context> + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<PublishingHandler<D, PC, P, PC, PL, PP>>,
-        L::Handler: Handler<
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<PublishingHandler<D, PC, P, PC, PL, Pipeline>>,
+        Layers::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
-                St,
+                State,
             > + 'static,
     {
         let codec = publisher.codec().clone();
@@ -223,7 +224,7 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingCall<St> + 'static,
+        D: PublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         D::Context:
@@ -231,17 +232,20 @@ impl<B: Broker + 'static, L, St, PP> BrokerScope<B, L, (), St, PP> {
         P: Publisher + 'static,
         PC: Codec + Clone + 'static,
         PL: PublishTransform<D::Context> + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<PublishingHandler<D, PC, P, PC, PL, PP>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<PublishingHandler<D, PC, P, PC, PL, Pipeline>>,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         let codec = publisher.codec().clone();
         self.mount_publishing(source, def, codec, publisher);
     }
 }
 
-impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, L, C, St, PP> {
+impl<B: Broker + 'static, Layers, C: Codec + Clone + 'static, State, Pipeline>
+    BrokerScope<B, Layers, C, State, Pipeline>
+{
     /// Mounts a `#[subscriber]`-generated definition on its own source, decoding its input with the
     /// scope's default codec (set by
     /// [`with_broker_codec`](crate::runtime::RustStream::with_broker_codec)).
@@ -257,8 +261,8 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
             > + Send
             + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<
+        State: Send + Sync + 'static,
+        Layers: Layer<
             Typed<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Input,
@@ -266,10 +270,10 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
                 D::Handler,
             >,
         >,
-        L::Handler: Handler<
+        Layers::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
-                St,
+                State,
             > + 'static,
     {
         let codec = self.codec.clone();
@@ -288,9 +292,10 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Handler: 'static,
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         let codec = self.codec.clone();
         self.mount_subscriber(source, def, codec);
@@ -305,8 +310,8 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: crate::runtime::SliceHandler<D::Input, St> + 'static,
-        St: Send + Sync + 'static,
+        D::Handler: crate::runtime::SliceHandler<D::Input, State> + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         let source = def.source();
@@ -321,8 +326,8 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         S::Subscriber: BatchSubscriber + Send + 'static,
         D: BatchDef,
         D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: crate::runtime::SliceHandler<D::Input, St> + 'static,
-        St: Send + Sync + 'static,
+        D::Handler: crate::runtime::SliceHandler<D::Input, State> + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         self.mount_batch(source, def, codec);
@@ -333,14 +338,14 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
     /// through `publisher`.
     pub fn include_batch_publishing<D, RP>(&mut self, def: D, publisher: RP)
     where
-        D: BatchPublishingCall<St> + 'static,
+        D: BatchPublishingCall<State> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: BatchSubscriber + Send + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         let source = def.source();
@@ -353,12 +358,12 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingCall<St> + 'static,
+        D: BatchPublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         RP: ReplyPublisher + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
     {
         let codec = self.codec.clone();
         self.mount_batch_publishing(source, def, codec, publisher);
@@ -368,7 +373,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
     /// input with the scope's default codec and sending the reply through `publisher`.
     pub fn include_publishing<D, P, PC, PL>(&mut self, def: D, publisher: TypedPublisher<P, PC, PL>)
     where
-        D: PublishingCall<St> + 'static,
+        D: PublishingCall<State> + 'static,
         D::Source: SubscriptionSource<B> + Send + 'static,
         <D::Source as SubscriptionSource<B>>::Subscriber: Send + 'static,
         <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message: 'static,
@@ -382,13 +387,13 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishTransform<D::Context> + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<PublishingHandler<D, C, P, PC, PL, PP>>,
-        L::Handler: Handler<
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<PublishingHandler<D, C, P, PC, PL, Pipeline>>,
+        Layers::Handler: Handler<
                 <<D::Source as SubscriptionSource<B>>::Subscriber as Subscriber>::Message,
                 D::Context,
-                St,
+                State,
             > + 'static,
     {
         let codec = self.codec.clone();
@@ -407,7 +412,7 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingCall<St> + 'static,
+        D: PublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         D::Context:
@@ -415,10 +420,11 @@ impl<B: Broker + 'static, L, C: Codec + Clone + 'static, St, PP> BrokerScope<B, 
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishTransform<D::Context> + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<PublishingHandler<D, C, P, PC, PL, PP>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<PublishingHandler<D, C, P, PC, PL, Pipeline>>,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         let codec = self.codec.clone();
         self.mount_publishing(source, def, codec, publisher);

--- a/src/runtime/app/mod.rs
+++ b/src/runtime/app/mod.rs
@@ -10,9 +10,9 @@ mod service;
 pub use app_trait::App;
 pub use run::RunningApp;
 pub use scope::BrokerScope;
-pub use service::RustStream;
 #[cfg(feature = "testing")]
 pub(crate) use service::{RegisteredBroker, TestParts};
+pub use service::{RustStream, Setup, Wired};
 
 use std::sync::Arc;
 

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -21,9 +21,9 @@ use super::{LifecycleHook, RustStream, RustStreamError};
 type BoundHook = Box<dyn FnOnce() -> BoxFuture<'static, Result<(), BoxError>> + Send>;
 
 /// Binds the shared state into each hook, erasing the state type from the hook list.
-fn bind_hooks<St: Send + Sync + 'static>(
-    hooks: Vec<LifecycleHook<St>>,
-    state: &Arc<St>,
+fn bind_hooks<State: Send + Sync + 'static>(
+    hooks: Vec<LifecycleHook<State>>,
+    state: &Arc<State>,
 ) -> Vec<BoundHook> {
     hooks
         .into_iter()
@@ -35,12 +35,14 @@ fn bind_hooks<St: Send + Sync + 'static>(
 }
 
 // `run`/`run_until` are routinely driven from a multi-thread runtime (`tokio::spawn`, the CLI's
-// `block_on`), so their futures must be `Send`: the shared state is held as `Arc<St>` across the
-// startup awaits (needs `St: Sync`) and the global stack `L` is carried in `self` (needs `L: Send`).
-// `St: 'static` is what every constructible app already satisfies (the `on_startup` producer
+// `block_on`), so their futures must be `Send`: the shared state is held as `Arc<State>` across the
+// startup awaits (needs `State: Sync`) and the global stack `Layers` is carried in `self` (needs `Layers: Send`).
+// `State: 'static` is what every constructible app already satisfies (the `on_startup` producer
 // returns the state from a `'static` boxed future); naming it here lets `start` box the shutdown
 // hooks with the state bound in.
-impl<L: Send, St: Send + Sync + 'static, PP, Phase> RustStream<L, St, PP, Phase> {
+impl<Layers: Send, State: Send + Sync + 'static, Pipeline, Phase>
+    RustStream<Layers, State, Pipeline, Phase>
+{
     /// Runs the service until an interrupt (`SIGINT` / `SIGTERM`) is received, then shuts down
     /// gracefully.
     ///

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -40,7 +40,7 @@ fn bind_hooks<St: Send + Sync + 'static>(
 // `St: 'static` is what every constructible app already satisfies (the `on_startup` producer
 // returns the state from a `'static` boxed future); naming it here lets `start` box the shutdown
 // hooks with the state bound in.
-impl<L: Send, St: Send + Sync + 'static, PP> RustStream<L, St, PP> {
+impl<L: Send, St: Send + Sync + 'static, PP, Phase> RustStream<L, St, PP, Phase> {
     /// Runs the service until an interrupt (`SIGINT` / `SIGTERM`) is received, then shuts down
     /// gracefully.
     ///

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -29,19 +29,19 @@ use crate::runtime::typed::{Typed, typed};
 ///
 /// Handed to the [`RustStream::with_broker`](crate::runtime::RustStream::with_broker) closure. It
 /// is a [`Router`](crate::runtime::Router) plus the broker it is bound to and the global middleware
-/// stack `L`; registrations are collected and started later, in
+/// stack `Layers`; registrations are collected and started later, in
 /// [`RustStream::run`](crate::runtime::RustStream::run). Each handler registered here is wrapped
-/// with `L` before it is stored.
-pub struct BrokerScope<B, L = Identity, C = (), St = (), PP = PublishIdentity> {
+/// with `Layers` before it is stored.
+pub struct BrokerScope<B, Layers = Identity, C = (), State = (), Pipeline = PublishIdentity> {
     pub(super) broker: Arc<B>,
-    pub(super) sink: RouterSink<B, St>,
-    pub(super) pipeline: PP,
+    pub(super) sink: RouterSink<B, State>,
+    pub(super) pipeline: Pipeline,
     pub(super) retry_publisher: Option<Arc<dyn ErasedPublisher>>,
-    pub(super) global: L,
+    pub(super) global: Layers,
     pub(super) codec: C,
 }
 
-impl<B: Broker + 'static, L, C, St, PP> BrokerScope<B, L, C, St, PP> {
+impl<B: Broker + 'static, Layers, C, State, Pipeline> BrokerScope<B, Layers, C, State, Pipeline> {
     /// Returns the broker, for creating subscribers or publishers with its own API.
     #[must_use]
     pub fn broker(&self) -> &B {
@@ -95,11 +95,11 @@ impl<B: Broker + 'static, L, C, St, PP> BrokerScope<B, L, C, St, PP> {
     pub fn handle<S, H, Cx>(&mut self, subscriber: S, handler: H, meta: HandlerMetadata)
     where
         S: Subscriber + Send + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
         Cx: crate::BuildContext<S::Message> + Send + 'static,
-        H: Handler<S::Message, Cx, St> + 'static,
-        L: Layer<H>,
-        L::Handler: Handler<S::Message, Cx, St> + 'static,
+        H: Handler<S::Message, Cx, State> + 'static,
+        Layers: Layer<H>,
+        Layers::Handler: Handler<S::Message, Cx, State> + 'static,
     {
         let handler = self.global.layer(handler);
         self.sink
@@ -113,11 +113,11 @@ impl<B: Broker + 'static, L, C, St, PP> BrokerScope<B, L, C, St, PP> {
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
         Cx: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
-        H: Handler<<S::Subscriber as Subscriber>::Message, Cx, St> + 'static,
-        L: Layer<H>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, Cx, St> + 'static,
+        H: Handler<<S::Subscriber as Subscriber>::Message, Cx, State> + 'static,
+        Layers: Layer<H>,
+        Layers::Handler: Handler<<S::Subscriber as Subscriber>::Message, Cx, State> + 'static,
     {
         let handler = self.global.layer(handler);
         self.sink
@@ -133,16 +133,16 @@ impl<B: Broker + 'static, L, C, St, PP> BrokerScope<B, L, C, St, PP> {
     /// bundled layer and any [`Stack`](crate::runtime::Stack) of them satisfies.
     pub fn include_router<R>(&mut self, router: R)
     where
-        R: RouterDef<B, St>,
-        St: Send + Sync + 'static,
-        L: BlanketLayer,
-        PP: PublishPipeline + Clone + 'static,
+        R: RouterDef<B, State>,
+        State: Send + Sync + 'static,
+        Layers: BlanketLayer,
+        Pipeline: PublishPipeline + Clone + 'static,
     {
         router.mount(&self.global, &self.pipeline, &mut self.sink);
     }
 }
 
-impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
+impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC, State, Pipeline> {
     /// Mounts a definition on `source`, decoding with `codec`. The shared tail of the
     /// `include` / `include_on` forms.
     pub(super) fn mount_subscriber<S, D, C>(&mut self, source: S, def: D, codec: C)
@@ -155,9 +155,10 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
         D::Context: crate::BuildContext<<S::Subscriber as Subscriber>::Message> + Send + 'static,
         D::Handler: 'static,
         C: Codec + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<Typed<<S::Subscriber as Subscriber>::Message, D::Input, C, D::Handler>>,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         let meta = subscriber_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -178,9 +179,9 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
         S::Subscriber: BatchSubscriber + Send + 'static,
         D: BatchDef,
         D::Input: DeserializeOwned + Send + Sync + 'static,
-        D::Handler: crate::runtime::SliceHandler<D::Input, St> + 'static,
+        D::Handler: crate::runtime::SliceHandler<D::Input, State> + 'static,
         C: Codec + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -202,13 +203,13 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
     ) where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
-        D: BatchPublishingCall<St> + 'static,
+        D: BatchPublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         C: Codec + 'static,
         RP: ReplyPublisher + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
     {
         let meta = batch_publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -236,7 +237,7 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         <S::Subscriber as Subscriber>::Message: 'static,
-        D: PublishingCall<St> + 'static,
+        D: PublishingCall<State> + 'static,
         D::Input: DeserializeOwned + Send + Sync + 'static,
         D::Reply: Serialize + Send + Sync + 'static,
         D::Context:
@@ -245,10 +246,11 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
         P: Publisher + 'static,
         PC: Codec + 'static,
         PL: PublishTransform<D::Context> + 'static,
-        PP: PublishPipeline + Clone + 'static,
-        St: Send + Sync + 'static,
-        L: Layer<PublishingHandler<D, C, P, PC, PL, PP>>,
-        L::Handler: Handler<<S::Subscriber as Subscriber>::Message, D::Context, St> + 'static,
+        Pipeline: PublishPipeline + Clone + 'static,
+        State: Send + Sync + 'static,
+        Layers: Layer<PublishingHandler<D, C, P, PC, PL, Pipeline>>,
+        Layers::Handler:
+            Handler<<S::Subscriber as Subscriber>::Message, D::Context, State> + 'static,
     {
         let meta = publishing_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
@@ -265,7 +267,7 @@ impl<B: Broker + 'static, L, SC, St, PP> BrokerScope<B, L, SC, St, PP> {
     }
 }
 
-impl<B, L, C, St, PP> std::fmt::Debug for BrokerScope<B, L, C, St, PP> {
+impl<B, Layers, C, State, Pipeline> std::fmt::Debug for BrokerScope<B, Layers, C, State, Pipeline> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BrokerScope")
             .field("sink", &self.sink)

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -1,7 +1,8 @@
 //! The [`RustStream`] builder: construction, configuration and handler registration.
 
 use std::{
-    collections::BTreeMap, error::Error as StdError, future::Future, sync::Arc, time::Duration,
+    collections::BTreeMap, error::Error as StdError, future::Future, marker::PhantomData,
+    sync::Arc, time::Duration,
 };
 
 use crate::codec::Codec;
@@ -34,8 +35,18 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 /// registered after it (and not to handlers brought in via
 /// [`include_router`](BrokerScope::include_router)).
 ///
+/// The type parameter `Phase` tracks the builder phase at compile time: [`new`](Self::new)
+/// starts in [`Setup`], where the state ([`on_startup`]), the middleware stack ([`layer`]) and
+/// the publish pipeline ([`publish_layer`](Self::publish_layer)) are still configurable; the
+/// first [`with_broker`] moves it to [`Wired`], where those methods no longer exist - so a
+/// configuration call that would silently not apply to already-registered handlers does not
+/// compile. `Phase` defaults to [`Wired`] because a signature that names `RustStream` almost
+/// always means the built service; the `Setup` state lives inside a builder chain and is rarely
+/// written out.
+///
 /// [`with_broker`]: Self::with_broker
 /// [`layer`]: Self::layer
+/// [`on_startup`]: Self::on_startup
 /// [`run`]: Self::run
 ///
 /// # Examples
@@ -60,7 +71,7 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 /// app.run().await
 /// # }
 /// ```
-pub struct RustStream<L = Identity, St = (), PP = PublishIdentity> {
+pub struct RustStream<L = Identity, St = (), PP = PublishIdentity, Phase = Wired> {
     pub(super) info: AppInfo,
     pub(super) brokers: Vec<RegisteredBroker>,
     pub(super) starters: Vec<Starter<St>>,
@@ -82,7 +93,20 @@ pub struct RustStream<L = Identity, St = (), PP = PublishIdentity> {
     #[cfg(feature = "testing")]
     pub(super) test_hooks: Arc<TestHooks>,
     pub(super) global: L,
+    // `fn() -> Phase` keeps the marker out of auto-trait and variance considerations, matching
+    // the router builder's broker marker.
+    pub(super) phase: PhantomData<fn() -> Phase>,
 }
+
+/// [`RustStream`] phase marker: the builder is still being configured - the state type, the
+/// middleware stack, and the publish pipeline may change, and no broker is registered yet.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Setup;
+
+/// [`RustStream`] phase marker: at least one broker (with its handlers) is registered, so the
+/// state type, the middleware stack, and the publish pipeline are fixed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Wired;
 
 /// A broker held by the app for lifecycle management, paired with its optional label.
 ///
@@ -108,7 +132,7 @@ pub(crate) struct TestParts<St> {
     pub(crate) test_hooks: Arc<TestHooks>,
 }
 
-impl<L, St, PP> std::fmt::Debug for RustStream<L, St, PP> {
+impl<L, St, PP, Phase> std::fmt::Debug for RustStream<L, St, PP, Phase> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RustStream")
             .field("info", &self.info)
@@ -118,7 +142,7 @@ impl<L, St, PP> std::fmt::Debug for RustStream<L, St, PP> {
     }
 }
 
-impl RustStream<Identity, (), PublishIdentity> {
+impl RustStream<Identity, (), PublishIdentity, Setup> {
     /// Creates an empty service with the given metadata, no global middleware, and the unit
     /// application state `()`. Produce a typed state with [`on_startup`](Self::on_startup).
     #[must_use]
@@ -139,16 +163,19 @@ impl RustStream<Identity, (), PublishIdentity> {
             #[cfg(feature = "testing")]
             test_hooks: Arc::new(TestHooks::detached()),
             global: Identity,
+            phase: PhantomData,
         }
     }
 }
 
-impl<L, St, PP> RustStream<L, St, PP> {
-    /// Adds a global middleware layer, applied to every handler registered after it.
+impl<L, St, PP> RustStream<L, St, PP, Setup> {
+    /// Adds a global middleware layer, applied to every handler registered later.
     ///
-    /// The first layer added runs outermost. Call before [`with_broker`](Self::with_broker).
+    /// The first layer added runs outermost. Only available before the first
+    /// [`with_broker`](Self::with_broker): a layer added later could not wrap the handlers
+    /// already registered, so that ordering does not compile.
     #[must_use]
-    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, L>, St, PP> {
+    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, L>, St, PP, Setup> {
         RustStream {
             info: self.info,
             brokers: self.brokers,
@@ -165,6 +192,7 @@ impl<L, St, PP> RustStream<L, St, PP> {
             #[cfg(feature = "testing")]
             test_hooks: self.test_hooks,
             global: Stack::new(layer, self.global),
+            phase: PhantomData,
         }
     }
 
@@ -177,10 +205,18 @@ impl<L, St, PP> RustStream<L, St, PP> {
     /// failing hook aborts startup. The initial state is `()` (from [`new`](Self::new)), so the
     /// first call's hook receives `()`.
     ///
-    /// Call this BEFORE registering handlers or read-only hooks: it fixes the app's state type, and
-    /// registrations made earlier (which saw a different state type) are not carried across.
+    /// Only available before the first [`with_broker`](Self::with_broker): the call fixes the
+    /// app's state type, and handlers registered against a different state type could not be
+    /// carried across - so that ordering does not compile.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lifecycle hook ([`after_startup`](Self::after_startup),
+    /// [`on_shutdown`](Self::on_shutdown), [`after_shutdown`](Self::after_shutdown)) was
+    /// registered first: hooks close over the state type and cannot be carried across the state
+    /// change. Register hooks after `on_startup`.
     #[must_use]
-    pub fn on_startup<F, Fut, St2, E>(self, hook: F) -> RustStream<L, St2, PP>
+    pub fn on_startup<F, Fut, St2, E>(self, hook: F) -> RustStream<L, St2, PP, Setup>
     where
         F: FnOnce(St) -> Fut + Send + 'static,
         Fut: Future<Output = Result<St2, E>> + Send,
@@ -188,10 +224,18 @@ impl<L, St, PP> RustStream<L, St, PP> {
         St2: Send + Sync + 'static,
         E: StdError + Send + Sync + 'static,
     {
+        assert!(
+            self.after_startup.is_empty()
+                && self.on_shutdown.is_empty()
+                && self.after_shutdown.is_empty(),
+            "on_startup must be called before lifecycle hooks are registered: hooks close over \
+             the state type and cannot be carried across the state change"
+        );
         let prev = self.state_init;
         RustStream {
             info: self.info,
             brokers: self.brokers,
+            // Provably empty: with_broker (the only way to add starters) leaves Setup.
             starters: Vec::new(),
             handlers: self.handlers,
             servers: self.servers,
@@ -210,6 +254,65 @@ impl<L, St, PP> RustStream<L, St, PP> {
             #[cfg(feature = "testing")]
             test_hooks: self.test_hooks,
             global: self.global,
+            phase: PhantomData,
+        }
+    }
+
+    /// Adds an outgoing publish middleware, run on every published reply before it reaches the
+    /// broker (a Confluent / Avro envelope, publish metrics, dead-letter). It composes into the
+    /// pipeline type parameter, so the *last* one added wraps the rest and runs outermost (unlike the
+    /// consume-side [`layer`](Self::layer), where the first added is outermost); the middleware must
+    /// be [`Clone`] (the pipeline is cloned into each publishing handler). Only available before
+    /// the first [`with_broker`](Self::with_broker): a middleware added later could not wrap the
+    /// publishers already handed out, so that ordering does not compile.
+    #[must_use]
+    pub fn publish_layer<M>(self, middleware: M) -> RustStream<L, St, PublishStack<M, PP>, Setup>
+    where
+        M: PublishLayer + Clone + 'static,
+    {
+        // Prepend `middleware` as the new outermost wrapper: the publish pipeline stays a statically
+        // composed type (no `dyn` dispatch), and the last one added runs outermost.
+        RustStream {
+            info: self.info,
+            brokers: self.brokers,
+            starters: self.starters,
+            handlers: self.handlers,
+            servers: self.servers,
+            publish_pipeline: PublishStack::new(middleware, self.publish_pipeline),
+            state_init: self.state_init,
+            after_startup: self.after_startup,
+            on_shutdown: self.on_shutdown,
+            after_shutdown: self.after_shutdown,
+            shutdown_timeout: self.shutdown_timeout,
+            continuations: self.continuations,
+            #[cfg(feature = "testing")]
+            test_hooks: self.test_hooks,
+            global: self.global,
+            phase: PhantomData,
+        }
+    }
+}
+
+impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
+    /// Rebuilds the app under a different phase marker; the fields move as they are.
+    fn into_phase<Q>(self) -> RustStream<L, St, PP, Q> {
+        RustStream {
+            info: self.info,
+            brokers: self.brokers,
+            starters: self.starters,
+            handlers: self.handlers,
+            servers: self.servers,
+            publish_pipeline: self.publish_pipeline,
+            state_init: self.state_init,
+            after_startup: self.after_startup,
+            on_shutdown: self.on_shutdown,
+            after_shutdown: self.after_shutdown,
+            shutdown_timeout: self.shutdown_timeout,
+            continuations: self.continuations,
+            #[cfg(feature = "testing")]
+            test_hooks: self.test_hooks,
+            global: self.global,
+            phase: PhantomData,
         }
     }
 
@@ -280,38 +383,6 @@ impl<L, St, PP> RustStream<L, St, PP> {
         self
     }
 
-    /// Adds an outgoing publish middleware, run on every published reply before it reaches the
-    /// broker (a Confluent / Avro envelope, publish metrics, dead-letter). It composes into the
-    /// pipeline type parameter, so the *last* one added wraps the rest and runs outermost (unlike the
-    /// consume-side [`layer`](Self::layer), where the first added is outermost); the middleware must
-    /// be [`Clone`] (the pipeline is cloned into each publishing handler). Call before
-    /// [`with_broker`](Self::with_broker).
-    #[must_use]
-    pub fn publish_layer<M>(self, middleware: M) -> RustStream<L, St, PublishStack<M, PP>>
-    where
-        M: PublishLayer + Clone + 'static,
-    {
-        // Prepend `middleware` as the new outermost wrapper: the publish pipeline stays a statically
-        // composed type (no `dyn` dispatch), and the last one added runs outermost.
-        RustStream {
-            info: self.info,
-            brokers: self.brokers,
-            starters: self.starters,
-            handlers: self.handlers,
-            servers: self.servers,
-            publish_pipeline: PublishStack::new(middleware, self.publish_pipeline),
-            state_init: self.state_init,
-            after_startup: self.after_startup,
-            on_shutdown: self.on_shutdown,
-            after_shutdown: self.after_shutdown,
-            shutdown_timeout: self.shutdown_timeout,
-            continuations: self.continuations,
-            #[cfg(feature = "testing")]
-            test_hooks: self.test_hooks,
-            global: self.global,
-        }
-    }
-
     /// Registers a broker for lifecycle management only (connect / shutdown), without attaching
     /// subscribers. Use for publish-only brokers.
     #[must_use]
@@ -350,8 +421,12 @@ impl<L, St, PP> RustStream<L, St, PP> {
     /// The scope has no default codec, so macro handlers are mounted with an explicit one
     /// (`b.include(handle, JsonCodec)`). To set a scope default and drop the per-call codec, use
     /// [`with_broker_codec`](Self::with_broker_codec).
+    ///
+    /// The first call moves the builder to the [`Wired`] phase: the state, the middleware stack,
+    /// and the publish pipeline are fixed from here on, so a configuration call that could not
+    /// apply to this broker's handlers does not compile.
     #[must_use]
-    pub fn with_broker<B, F>(mut self, broker: B, build: F) -> Self
+    pub fn with_broker<B, F>(self, broker: B, build: F) -> RustStream<L, St, PP, Wired>
     where
         B: Broker + 'static,
         L: Clone,
@@ -359,11 +434,12 @@ impl<L, St, PP> RustStream<L, St, PP> {
         St: Send + Sync + 'static,
         F: FnOnce(&mut BrokerScope<B, L, (), St, PP>),
     {
+        let mut this = self.into_phase::<Wired>();
         let broker = Arc::new(broker);
-        let mut scope = self.new_scope(&broker, ());
+        let mut scope = this.new_scope(&broker, ());
         build(&mut scope);
-        self.collect_scope(&broker, scope, None);
-        self
+        this.collect_scope(&broker, scope, None);
+        this
     }
 
     /// Registers a broker with a default `codec`, so its macro handlers are mounted without
@@ -373,7 +449,12 @@ impl<L, St, PP> RustStream<L, St, PP> {
     /// [`include_publishing`](BrokerScope::include_publishing) take just the definition and decode
     /// it with `codec`.
     #[must_use]
-    pub fn with_broker_codec<B, C, F>(mut self, broker: B, codec: C, build: F) -> Self
+    pub fn with_broker_codec<B, C, F>(
+        self,
+        broker: B,
+        codec: C,
+        build: F,
+    ) -> RustStream<L, St, PP, Wired>
     where
         B: Broker + 'static,
         C: Codec + Clone + 'static,
@@ -382,11 +463,12 @@ impl<L, St, PP> RustStream<L, St, PP> {
         St: Send + Sync + 'static,
         F: FnOnce(&mut BrokerScope<B, L, C, St, PP>),
     {
+        let mut this = self.into_phase::<Wired>();
         let broker = Arc::new(broker);
-        let mut scope = self.new_scope(&broker, codec);
+        let mut scope = this.new_scope(&broker, codec);
         build(&mut scope);
-        self.collect_scope(&broker, scope, None);
-        self
+        this.collect_scope(&broker, scope, None);
+        this
     }
 
     /// Registers a self-describing broker under `label`, along with the handlers attached to it.
@@ -426,11 +508,11 @@ impl<L, St, PP> RustStream<L, St, PP> {
     /// ```
     #[must_use]
     pub fn with_broker_labeled<B, F>(
-        mut self,
+        self,
         label: impl Into<String>,
         broker: B,
         build: F,
-    ) -> Self
+    ) -> RustStream<L, St, PP, Wired>
     where
         B: DescribeServer + 'static,
         L: Clone,
@@ -438,12 +520,13 @@ impl<L, St, PP> RustStream<L, St, PP> {
         St: Send + Sync + 'static,
         F: FnOnce(&mut BrokerScope<B, L, (), St, PP>),
     {
-        let label = self.record_server(label, &broker);
+        let mut this = self.into_phase::<Wired>();
+        let label = this.record_server(label, &broker);
         let broker = Arc::new(broker);
-        let mut scope = self.new_scope(&broker, ());
+        let mut scope = this.new_scope(&broker, ());
         build(&mut scope);
-        self.collect_scope(&broker, scope, Some(label));
-        self
+        this.collect_scope(&broker, scope, Some(label));
+        this
     }
 
     /// Registers a self-describing broker under `label` with a default `codec`.
@@ -454,12 +537,12 @@ impl<L, St, PP> RustStream<L, St, PP> {
     /// codec).
     #[must_use]
     pub fn with_broker_labeled_codec<B, C, F>(
-        mut self,
+        self,
         label: impl Into<String>,
         broker: B,
         codec: C,
         build: F,
-    ) -> Self
+    ) -> RustStream<L, St, PP, Wired>
     where
         B: DescribeServer + 'static,
         C: Codec + Clone + 'static,
@@ -468,12 +551,13 @@ impl<L, St, PP> RustStream<L, St, PP> {
         St: Send + Sync + 'static,
         F: FnOnce(&mut BrokerScope<B, L, C, St, PP>),
     {
-        let label = self.record_server(label, &broker);
+        let mut this = self.into_phase::<Wired>();
+        let label = this.record_server(label, &broker);
         let broker = Arc::new(broker);
-        let mut scope = self.new_scope(&broker, codec);
+        let mut scope = this.new_scope(&broker, codec);
         build(&mut scope);
-        self.collect_scope(&broker, scope, Some(label));
-        self
+        this.collect_scope(&broker, scope, Some(label));
+        this
     }
 
     /// Records `broker`'s server coordinates under `label` (keeping an explicit

--- a/src/runtime/app/service.rs
+++ b/src/runtime/app/service.rs
@@ -29,7 +29,7 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 /// hands a scope bound to that broker; nothing connects or subscribes until [`run`]. Brokers are
 /// held type-erased (only their lifecycle), so a single service can mix broker types.
 ///
-/// The type parameter `L` is the global middleware stack applied to every handler registered
+/// The type parameter `Layers` is the global middleware stack applied to every handler registered
 /// directly on a broker scope; it defaults to the no-op [`Identity`] and grows as [`layer`] is
 /// called. Add all layers before [`with_broker`], since a layer only applies to handlers
 /// registered after it (and not to handlers brought in via
@@ -71,17 +71,17 @@ use super::{AppInfo, LifecycleHook, LifecyclePhase, Starter, StateInit};
 /// app.run().await
 /// # }
 /// ```
-pub struct RustStream<L = Identity, St = (), PP = PublishIdentity, Phase = Wired> {
+pub struct RustStream<Layers = Identity, State = (), Pipeline = PublishIdentity, Phase = Wired> {
     pub(super) info: AppInfo,
     pub(super) brokers: Vec<RegisteredBroker>,
-    pub(super) starters: Vec<Starter<St>>,
+    pub(super) starters: Vec<Starter<State>>,
     pub(super) handlers: Vec<HandlerMetadata>,
     pub(super) servers: BTreeMap<String, ServerSpec>,
-    pub(super) publish_pipeline: PP,
-    pub(super) state_init: StateInit<St>,
-    pub(super) after_startup: Vec<LifecycleHook<St>>,
-    pub(super) on_shutdown: Vec<LifecycleHook<St>>,
-    pub(super) after_shutdown: Vec<LifecycleHook<St>>,
+    pub(super) publish_pipeline: Pipeline,
+    pub(super) state_init: StateInit<State>,
+    pub(super) after_startup: Vec<LifecycleHook<State>>,
+    pub(super) on_shutdown: Vec<LifecycleHook<State>>,
+    pub(super) after_shutdown: Vec<LifecycleHook<State>>,
     pub(super) shutdown_timeout: Option<Duration>,
     /// Tracks post-settle `and_after` continuations spawned during dispatch, so a graceful
     /// shutdown drains them after the dispatch loops stop. Shared (cloned) into every
@@ -92,7 +92,7 @@ pub struct RustStream<L = Identity, St = (), PP = PublishIdentity, Phase = Wired
     /// non-harness run with the `testing` feature enabled stays inert.
     #[cfg(feature = "testing")]
     pub(super) test_hooks: Arc<TestHooks>,
-    pub(super) global: L,
+    pub(super) global: Layers,
     // `fn() -> Phase` keeps the marker out of auto-trait and variance considerations, matching
     // the router builder's broker marker.
     pub(super) phase: PhantomData<fn() -> Phase>,
@@ -122,17 +122,19 @@ pub(crate) struct RegisteredBroker {
 /// connecting: the brokers (to recover and instrument), the deferred starters, the lifecycle hooks,
 /// and the shared test hooks slot. Produced by [`RustStream::into_test_parts`].
 #[cfg(feature = "testing")]
-pub(crate) struct TestParts<St> {
+pub(crate) struct TestParts<State> {
     pub(crate) brokers: Vec<RegisteredBroker>,
-    pub(crate) starters: Vec<Starter<St>>,
-    pub(crate) state_init: StateInit<St>,
-    pub(crate) after_startup: Vec<LifecycleHook<St>>,
+    pub(crate) starters: Vec<Starter<State>>,
+    pub(crate) state_init: StateInit<State>,
+    pub(crate) after_startup: Vec<LifecycleHook<State>>,
     pub(crate) shutdown_timeout: Option<Duration>,
     pub(crate) continuations: TaskTracker,
     pub(crate) test_hooks: Arc<TestHooks>,
 }
 
-impl<L, St, PP, Phase> std::fmt::Debug for RustStream<L, St, PP, Phase> {
+impl<Layers, State, Pipeline, Phase> std::fmt::Debug
+    for RustStream<Layers, State, Pipeline, Phase>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RustStream")
             .field("info", &self.info)
@@ -168,14 +170,14 @@ impl RustStream<Identity, (), PublishIdentity, Setup> {
     }
 }
 
-impl<L, St, PP> RustStream<L, St, PP, Setup> {
+impl<Layers, State, Pipeline> RustStream<Layers, State, Pipeline, Setup> {
     /// Adds a global middleware layer, applied to every handler registered later.
     ///
     /// The first layer added runs outermost. Only available before the first
     /// [`with_broker`](Self::with_broker): a layer added later could not wrap the handlers
     /// already registered, so that ordering does not compile.
     #[must_use]
-    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, L>, St, PP, Setup> {
+    pub fn layer<N>(self, layer: N) -> RustStream<Stack<N, Layers>, State, Pipeline, Setup> {
         RustStream {
             info: self.info,
             brokers: self.brokers,
@@ -197,10 +199,10 @@ impl<L, St, PP> RustStream<L, St, PP, Setup> {
     }
 
     /// Produces the typed application state at startup, transitioning the app's state type from the
-    /// previous `St` to `St2`.
+    /// previous `State` to `State2`.
     ///
     /// The hook runs once before brokers connect; its future can `await` (open a database pool,
-    /// connect a client), and the produced `St2` is shared with every handler (read via
+    /// connect a client), and the produced `State2` is shared with every handler (read via
     /// [`Context::state`](crate::runtime::Context::state)) and the read-only lifecycle hooks. A
     /// failing hook aborts startup. The initial state is `()` (from [`new`](Self::new)), so the
     /// first call's hook receives `()`.
@@ -216,12 +218,15 @@ impl<L, St, PP> RustStream<L, St, PP, Setup> {
     /// registered first: hooks close over the state type and cannot be carried across the state
     /// change. Register hooks after `on_startup`.
     #[must_use]
-    pub fn on_startup<F, Fut, St2, E>(self, hook: F) -> RustStream<L, St2, PP, Setup>
+    pub fn on_startup<F, Fut, State2, E>(
+        self,
+        hook: F,
+    ) -> RustStream<Layers, State2, Pipeline, Setup>
     where
-        F: FnOnce(St) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<St2, E>> + Send,
-        St: Send + 'static,
-        St2: Send + Sync + 'static,
+        F: FnOnce(State) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<State2, E>> + Send,
+        State: Send + 'static,
+        State2: Send + Sync + 'static,
         E: StdError + Send + Sync + 'static,
     {
         assert!(
@@ -266,7 +271,10 @@ impl<L, St, PP> RustStream<L, St, PP, Setup> {
     /// the first [`with_broker`](Self::with_broker): a middleware added later could not wrap the
     /// publishers already handed out, so that ordering does not compile.
     #[must_use]
-    pub fn publish_layer<M>(self, middleware: M) -> RustStream<L, St, PublishStack<M, PP>, Setup>
+    pub fn publish_layer<M>(
+        self,
+        middleware: M,
+    ) -> RustStream<Layers, State, PublishStack<M, Pipeline>, Setup>
     where
         M: PublishLayer + Clone + 'static,
     {
@@ -293,9 +301,9 @@ impl<L, St, PP> RustStream<L, St, PP, Setup> {
     }
 }
 
-impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
+impl<Layers, State, Pipeline, Phase> RustStream<Layers, State, Pipeline, Phase> {
     /// Rebuilds the app under a different phase marker; the fields move as they are.
-    fn into_phase<Q>(self) -> RustStream<L, St, PP, Q> {
+    fn into_phase<Q>(self) -> RustStream<Layers, State, Pipeline, Q> {
         RustStream {
             info: self.info,
             brokers: self.brokers,
@@ -321,8 +329,8 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     #[must_use]
     pub fn after_startup<F, Fut, E>(self, hook: F) -> Self
     where
-        St: Send + Sync + 'static,
-        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
+        State: Send + Sync + 'static,
+        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -333,8 +341,8 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     #[must_use]
     pub fn on_shutdown<F, Fut, E>(self, hook: F) -> Self
     where
-        St: Send + Sync + 'static,
-        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
+        State: Send + Sync + 'static,
+        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -346,8 +354,8 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     #[must_use]
     pub fn after_shutdown<F, Fut, E>(self, hook: F) -> Self
     where
-        St: Send + Sync + 'static,
-        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
+        State: Send + Sync + 'static,
+        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
@@ -356,12 +364,12 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
 
     fn push_lifecycle_hook<F, Fut, E>(mut self, phase: LifecyclePhase, hook: F) -> Self
     where
-        St: Send + Sync + 'static,
-        F: FnOnce(Arc<St>) -> Fut + Send + 'static,
+        State: Send + Sync + 'static,
+        F: FnOnce(Arc<State>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), E>> + Send,
         E: StdError + Send + Sync + 'static,
     {
-        let boxed: LifecycleHook<St> = Box::new(move |state| {
+        let boxed: LifecycleHook<State> = Box::new(move |state| {
             Box::pin(async move { hook(state).await.map_err(|e| Box::new(e) as BoxError) })
         });
         match phase {
@@ -426,13 +434,17 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     /// and the publish pipeline are fixed from here on, so a configuration call that could not
     /// apply to this broker's handlers does not compile.
     #[must_use]
-    pub fn with_broker<B, F>(self, broker: B, build: F) -> RustStream<L, St, PP, Wired>
+    pub fn with_broker<B, F>(
+        self,
+        broker: B,
+        build: F,
+    ) -> RustStream<Layers, State, Pipeline, Wired>
     where
         B: Broker + 'static,
-        L: Clone,
-        PP: Clone,
-        St: Send + Sync + 'static,
-        F: FnOnce(&mut BrokerScope<B, L, (), St, PP>),
+        Layers: Clone,
+        Pipeline: Clone,
+        State: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, Layers, (), State, Pipeline>),
     {
         let mut this = self.into_phase::<Wired>();
         let broker = Arc::new(broker);
@@ -454,14 +466,14 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
         broker: B,
         codec: C,
         build: F,
-    ) -> RustStream<L, St, PP, Wired>
+    ) -> RustStream<Layers, State, Pipeline, Wired>
     where
         B: Broker + 'static,
         C: Codec + Clone + 'static,
-        L: Clone,
-        PP: Clone,
-        St: Send + Sync + 'static,
-        F: FnOnce(&mut BrokerScope<B, L, C, St, PP>),
+        Layers: Clone,
+        Pipeline: Clone,
+        State: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, Layers, C, State, Pipeline>),
     {
         let mut this = self.into_phase::<Wired>();
         let broker = Arc::new(broker);
@@ -512,13 +524,13 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
         label: impl Into<String>,
         broker: B,
         build: F,
-    ) -> RustStream<L, St, PP, Wired>
+    ) -> RustStream<Layers, State, Pipeline, Wired>
     where
         B: DescribeServer + 'static,
-        L: Clone,
-        PP: Clone,
-        St: Send + Sync + 'static,
-        F: FnOnce(&mut BrokerScope<B, L, (), St, PP>),
+        Layers: Clone,
+        Pipeline: Clone,
+        State: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, Layers, (), State, Pipeline>),
     {
         let mut this = self.into_phase::<Wired>();
         let label = this.record_server(label, &broker);
@@ -542,14 +554,14 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
         broker: B,
         codec: C,
         build: F,
-    ) -> RustStream<L, St, PP, Wired>
+    ) -> RustStream<Layers, State, Pipeline, Wired>
     where
         B: DescribeServer + 'static,
         C: Codec + Clone + 'static,
-        L: Clone,
-        PP: Clone,
-        St: Send + Sync + 'static,
-        F: FnOnce(&mut BrokerScope<B, L, C, St, PP>),
+        Layers: Clone,
+        Pipeline: Clone,
+        State: Send + Sync + 'static,
+        F: FnOnce(&mut BrokerScope<B, Layers, C, State, Pipeline>),
     {
         let mut this = self.into_phase::<Wired>();
         let label = this.record_server(label, &broker);
@@ -571,12 +583,16 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     }
 
     /// Builds a fresh scope bound to `broker` carrying `codec` and the app's publishers / pipeline.
-    fn new_scope<B, C>(&self, broker: &Arc<B>, codec: C) -> BrokerScope<B, L, C, St, PP>
+    fn new_scope<B, C>(
+        &self,
+        broker: &Arc<B>,
+        codec: C,
+    ) -> BrokerScope<B, Layers, C, State, Pipeline>
     where
         B: Broker + 'static,
-        L: Clone,
-        PP: Clone,
-        St: Send + Sync + 'static,
+        Layers: Clone,
+        Pipeline: Clone,
+        State: Send + Sync + 'static,
     {
         BrokerScope {
             broker: broker.clone(),
@@ -593,11 +609,11 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     fn collect_scope<B, C>(
         &mut self,
         broker: &Arc<B>,
-        scope: BrokerScope<B, L, C, St, PP>,
+        scope: BrokerScope<B, Layers, C, State, Pipeline>,
         label: Option<String>,
     ) where
         B: Broker + 'static,
-        St: Send + Sync + 'static,
+        State: Send + Sync + 'static,
     {
         let lifecycle: Arc<dyn BrokerLifecycle> = broker.clone();
         // The scope id is the index this broker will occupy once pushed below; the harness uses it
@@ -649,7 +665,7 @@ impl<L, St, PP, Phase> RustStream<L, St, PP, Phase> {
     /// the brokers, the deferred starters, the lifecycle hooks, and the shared test-hooks slot.
     /// Handlers metadata and `AsyncAPI` servers are dropped (the harness does not need them).
     #[cfg(feature = "testing")]
-    pub(crate) fn into_test_parts(self) -> TestParts<St> {
+    pub(crate) fn into_test_parts(self) -> TestParts<State> {
         TestParts {
             brokers: self.brokers,
             starters: self.starters,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,7 +20,7 @@ mod router;
 mod subscriber_def;
 mod typed;
 
-pub use app::{App, AppInfo, BrokerScope, RunningApp, RustStream, RustStreamError};
+pub use app::{App, AppInfo, BrokerScope, RunningApp, RustStream, RustStreamError, Setup, Wired};
 #[cfg(feature = "testing")]
 pub(crate) use app::{LifecycleHook, RegisteredBroker, Starter, TestParts};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -34,7 +34,7 @@ use super::{
 ///
 /// Build it by chaining (each call consumes the router and returns a new type that carries the
 /// added registration), then mount it with
-/// [`include_router`](crate::runtime::BrokerScope::include_router). The registration list `R` is
+/// [`include_router`](crate::runtime::BrokerScope::include_router). The registration list `Routes` is
 /// an opaque nested tuple, so a builder function returns `impl RouterDef<B>` instead of naming the
 /// type.
 ///
@@ -42,7 +42,7 @@ use super::{
 /// with. It starts as `()`, meaning the [`DefaultCodec`](crate::codec::DefaultCodec); switch it
 /// for the rest of the chain with [`with_codec`](Self::with_codec).
 ///
-/// The layer parameter `L` is the router's own middleware stack, grown with
+/// The layer parameter `Layers` is the router's own middleware stack, grown with
 /// [`layer`](Self::layer). It wraps every handler in the router when the router is mounted, inside
 /// the app's global stack.
 ///
@@ -65,10 +65,10 @@ use super::{
 /// // later: app.with_broker(broker, |b| b.include_router(routes()));
 /// # }
 /// ```
-pub struct Router<B, R = (), C = (), L = Identity> {
-    pub(super) routes: R,
+pub struct Router<B, Routes = (), C = (), Layers = Identity> {
+    pub(super) routes: Routes,
     pub(super) codec: C,
-    pub(super) layers: L,
+    pub(super) layers: Layers,
     pub(super) _broker: PhantomData<fn() -> B>,
 }
 
@@ -83,7 +83,7 @@ impl<B: Broker + 'static> Default for Router<B, (), (), Identity> {
     }
 }
 
-impl<B, R, C, L> std::fmt::Debug for Router<B, R, C, L> {
+impl<B, Routes, C, Layers> std::fmt::Debug for Router<B, Routes, C, Layers> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Router").finish_non_exhaustive()
     }
@@ -97,14 +97,16 @@ impl<B: Broker + 'static> Router<B, ()> {
     }
 }
 
-impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
+impl<B: Broker + 'static, Routes, RouteCodec, RouteLayers>
+    Router<B, Routes, RouteCodec, RouteLayers>
+{
     /// Sets the codec that subsequent `include` / `include_on` / `include_publishing*` calls
     /// decode with, replacing the default.
     ///
     /// Registrations already in the chain keep the codec they were mounted with, so the codec can
     /// change mid-chain.
     #[must_use]
-    pub fn with_codec<C>(self, codec: C) -> Router<B, R, C, RL> {
+    pub fn with_codec<C>(self, codec: C) -> Router<B, Routes, C, RouteLayers> {
         Router {
             routes: self.routes,
             codec,
@@ -121,7 +123,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
     /// The layer must be a [`BlanketLayer`] (it applies to handlers whose concrete types the
     /// router hides), like the app-global stack.
     #[must_use]
-    pub fn layer<N>(self, layer: N) -> Router<B, R, RC, Stack<N, RL>> {
+    pub fn layer<N>(self, layer: N) -> Router<B, Routes, RouteCodec, Stack<N, RouteLayers>> {
         Router {
             routes: self.routes,
             codec: self.codec,
@@ -139,7 +141,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
     pub fn merge<R2, C2, L2>(
         self,
         other: Router<B, R2, C2, L2>,
-    ) -> MergedRouter<B, R2, C2, L2, RC, RL, R>
+    ) -> MergedRouter<B, R2, C2, L2, RouteCodec, RouteLayers, Routes>
     where
         L2: BlanketLayer,
     {
@@ -160,7 +162,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         subscriber: S,
         handler: H,
         meta: HandlerMetadata,
-    ) -> Router<B, (HandleRoute<S, H>, R), RC, RL>
+    ) -> Router<B, (HandleRoute<S, H>, Routes), RouteCodec, RouteLayers>
     where
         S: Subscriber + Send + 'static,
         H: Handler<S::Message> + 'static,
@@ -190,7 +192,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         source: S,
         handler: H,
         meta: HandlerMetadata,
-    ) -> Router<B, (SubscribeRoute<S, H>, R), RC, RL>
+    ) -> Router<B, (SubscribeRoute<S, H>, Routes), RouteCodec, RouteLayers>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
@@ -221,7 +223,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         handler: H,
         codec: C,
         meta: HandlerMetadata,
-    ) -> SubscribedBatchRouter<B, S, T, C, H, RC, RL, R>
+    ) -> SubscribedBatchRouter<B, S, T, C, H, RouteCodec, RouteLayers, Routes>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
@@ -253,7 +255,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         source: S,
         def: D,
         codec: C,
-    ) -> IncludedRouter<B, S, D, C, RC, RL, R>
+    ) -> IncludedRouter<B, S, D, C, RouteCodec, RouteLayers, Routes>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
@@ -290,7 +292,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         source: S,
         def: D,
         codec: C,
-    ) -> IncludedBatchRouter<B, S, D, C, RC, RL, R>
+    ) -> IncludedBatchRouter<B, S, D, C, RouteCodec, RouteLayers, Routes>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
@@ -329,7 +331,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         def: D,
         codec: C,
         publisher: RP,
-    ) -> BatchPublishingRouter<B, S, D, C, RP, RC, RL, R>
+    ) -> BatchPublishingRouter<B, S, D, C, RP, RouteCodec, RouteLayers, Routes>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
@@ -372,7 +374,7 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
         def: D,
         codec: C,
         publisher: TypedPublisher<P, PC, PL>,
-    ) -> PublishingRouter<B, S, D, C, P, PC, PL, RC, RL, R>
+    ) -> PublishingRouter<B, S, D, C, P, PC, PL, RouteCodec, RouteLayers, Routes>
     where
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
@@ -410,7 +412,9 @@ impl<B: Broker + 'static, R, RC, RL> Router<B, R, RC, RL> {
     }
 }
 
-impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
+impl<B, S, H, Routes, RouteCodec, RouteLayers>
+    Router<B, (SubscribeRoute<S, H>, Routes), RouteCodec, RouteLayers>
+{
     /// Sets the concurrency policy of the registration just added (the preceding `subscribe` /
     /// `include` call), replacing its default.
     ///
@@ -444,7 +448,9 @@ impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
     }
 }
 
-impl<B, S, H, R, RC, RL> Router<B, (BatchRoute<S, H>, R), RC, RL> {
+impl<B, S, H, Routes, RouteCodec, RouteLayers>
+    Router<B, (BatchRoute<S, H>, Routes), RouteCodec, RouteLayers>
+{
     /// Sets the concurrency policy of the batch registration just added (the preceding
     /// `subscribe_batch` / `include_batch` call), replacing its default.
     ///
@@ -458,7 +464,7 @@ impl<B, S, H, R, RC, RL> Router<B, (BatchRoute<S, H>, R), RC, RL> {
     }
 }
 
-impl<B: Broker + 'static, R: RouterHandlers, C, L> Router<B, R, C, L> {
+impl<B: Broker + 'static, Routes: RouterHandlers, C, Layers> Router<B, Routes, C, Layers> {
     /// Returns metadata for every registered handler, in registration order.
     #[must_use]
     pub fn handlers(&self) -> Vec<HandlerMetadata> {
@@ -488,17 +494,17 @@ impl<Outer: BlanketLayer, Inner: BlanketLayer> BlanketLayer for ComposedBlanket<
     }
 }
 
-impl<B, R, C, L, St> RouterDef<B, St> for Router<B, R, C, L>
+impl<B, Routes, C, Layers, State> RouterDef<B, State> for Router<B, Routes, C, Layers>
 where
     B: Broker + 'static,
-    R: RouterDef<B, St>,
-    L: BlanketLayer,
+    Routes: RouterDef<B, State>,
+    Layers: BlanketLayer,
 {
     fn mount<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         let composed = ComposedBlanket {
             outer: global,
@@ -508,9 +514,9 @@ where
     }
 }
 
-impl<B, R, C, L> RouterHandlers for Router<B, R, C, L>
+impl<B, Routes, C, Layers> RouterHandlers for Router<B, Routes, C, Layers>
 where
-    R: RouterHandlers,
+    Routes: RouterHandlers,
 {
     fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>) {
         self.routes.collect_handlers(out);
@@ -518,26 +524,26 @@ where
 }
 
 // Lets a whole router be a single registration inside another router's list (`Router::merge`).
-impl<B, R, C, L, St> MountRoute<B, St> for Router<B, R, C, L>
+impl<B, Routes, C, Layers, State> MountRoute<B, State> for Router<B, Routes, C, Layers>
 where
     B: Broker + 'static,
-    R: RouterDef<B, St>,
-    L: BlanketLayer,
+    Routes: RouterDef<B, State>,
+    Layers: BlanketLayer,
 {
     fn mount_one<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         RouterDef::mount(self, global, pipeline, sink);
     }
 }
 
 // Lets a merged router contribute its registrations' metadata to the outer router's `handlers()`.
-impl<B, R, C, L> RouteMeta for Router<B, R, C, L>
+impl<B, Routes, C, Layers> RouteMeta for Router<B, Routes, C, Layers>
 where
-    R: RouterHandlers,
+    Routes: RouterHandlers,
 {
     fn collect(&self, out: &mut Vec<HandlerMetadata>) {
         self.routes.collect_handlers(out);

--- a/src/runtime/router/routes.rs
+++ b/src/runtime/router/routes.rs
@@ -55,14 +55,14 @@ pub struct BatchRoute<S, H> {
 }
 
 /// One mountable registration: applies the global blanket layer to its handler and registers it.
-/// `St` is the app's shared-state type, threaded so a route only mounts on a sink whose state type
+/// `State` is the app's shared-state type, threaded so a route only mounts on a sink whose state type
 /// its handler matches (a state-agnostic handler matches any).
-pub(super) trait MountRoute<B, St> {
+pub(super) trait MountRoute<B, State> {
     fn mount_one<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     );
 }
 
@@ -90,40 +90,40 @@ impl<S, H> RouteMeta for HandleRoute<S, H> {
     }
 }
 
-impl<B, S, H, St> MountRoute<B, St> for SubscribeRoute<S, H>
+impl<B, S, H, State> MountRoute<B, State> for SubscribeRoute<S, H>
 where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: Send + 'static,
     SourceMessage<B, S>: Send + Sync + 'static,
-    St: Send + Sync + 'static,
-    H: Handler<SourceMessage<B, S>, (), St> + 'static,
+    State: Send + Sync + 'static,
+    H: Handler<SourceMessage<B, S>, (), State> + 'static,
 {
     fn mount_one<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         _pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
-        let handler = global.apply::<SourceMessage<B, S>, (), St, H>(self.handler);
+        let handler = global.apply::<SourceMessage<B, S>, (), State, H>(self.handler);
         sink.push_subscribe_workers(self.source, handler, self.meta, self.policies, self.workers);
     }
 }
 
-impl<B, S, H, St> MountRoute<B, St> for BatchRoute<S, H>
+impl<B, S, H, State> MountRoute<B, State> for BatchRoute<S, H>
 where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: BatchSubscriber + Send + 'static,
     SourceMessage<B, S>: Send + 'static,
-    St: Send + Sync + 'static,
-    H: BatchHandler<SourceMessage<B, S>, St> + 'static,
+    State: Send + Sync + 'static,
+    H: BatchHandler<SourceMessage<B, S>, State> + 'static,
 {
     fn mount_one<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         _global: &G,
         _pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         // Per-message layers cannot wrap a whole-batch handler, so neither the app-global stack
         // nor the router's own layers apply to batch registrations.
@@ -137,21 +137,21 @@ where
     }
 }
 
-impl<B, S, H, St> MountRoute<B, St> for HandleRoute<S, H>
+impl<B, S, H, State> MountRoute<B, State> for HandleRoute<S, H>
 where
     B: Broker + 'static,
     S: Subscriber + Send + 'static,
     S::Message: Send + Sync + 'static,
-    St: Send + Sync + 'static,
-    H: Handler<S::Message, (), St> + 'static,
+    State: Send + Sync + 'static,
+    H: Handler<S::Message, (), State> + 'static,
 {
     fn mount_one<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         _pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
-        let handler = global.apply::<S::Message, (), St, H>(self.handler);
+        let handler = global.apply::<S::Message, (), State, H>(self.handler);
         sink.push_handle(self.subscriber, handler, self.meta, self.policies);
     }
 }
@@ -214,14 +214,14 @@ impl<S, D, C, R> RouteMeta for BatchPublishingRoute<S, D, C, R> {
     }
 }
 
-impl<B, S, D, C, P, PC, PL, St> MountRoute<B, St> for PublishingRoute<S, D, C, P, PC, PL>
+impl<B, S, D, C, P, PC, PL, State> MountRoute<B, State> for PublishingRoute<S, D, C, P, PC, PL>
 where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: Send + 'static,
     SourceMessage<B, S>: Send + Sync + 'static,
-    St: Send + Sync + 'static,
-    D: PublishingCall<St> + 'static,
+    State: Send + Sync + 'static,
+    D: PublishingCall<State> + 'static,
     D::Input: DeserializeOwned + Send + Sync + 'static,
     D::Reply: Serialize + Send + Sync + 'static,
     D::Context: crate::BuildContext<SourceMessage<B, S>> + Send + Sync + 'static,
@@ -234,29 +234,30 @@ where
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         // Build the handler now that the app's pipeline is known, then wrap it with the global
         // blanket layer (as a directly-mounted publishing handler is).
-        let handler = global.apply::<SourceMessage<B, S>, D::Context, St, _>(PublishingHandler {
-            def: self.def,
-            codec: self.codec,
-            publisher: self.publisher,
-            pipeline: pipeline.clone(),
-            decode: self.policies.decode,
-        });
+        let handler =
+            global.apply::<SourceMessage<B, S>, D::Context, State, _>(PublishingHandler {
+                def: self.def,
+                codec: self.codec,
+                publisher: self.publisher,
+                pipeline: pipeline.clone(),
+                decode: self.policies.decode,
+            });
         sink.push_subscribe_workers(self.source, handler, self.meta, self.policies, self.workers);
     }
 }
 
-impl<B, S, D, C, R, St> MountRoute<B, St> for BatchPublishingRoute<S, D, C, R>
+impl<B, S, D, C, R, State> MountRoute<B, State> for BatchPublishingRoute<S, D, C, R>
 where
     B: Broker + 'static,
     S: SubscriptionSource<B> + Send + 'static,
     S::Subscriber: BatchSubscriber + Send + 'static,
     SourceMessage<B, S>: Send + Sync + 'static,
-    St: Send + Sync + 'static,
-    D: BatchPublishingCall<St> + 'static,
+    State: Send + Sync + 'static,
+    D: BatchPublishingCall<State> + 'static,
     D::Input: DeserializeOwned + Send + Sync + 'static,
     D::Reply: Serialize + Send + Sync + 'static,
     C: Codec + 'static,
@@ -266,7 +267,7 @@ where
         self,
         _global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         // Batch handlers are not wrapped by the per-message global stack, but they do pick up the
         // app's publish pipeline for their replies.
@@ -289,17 +290,17 @@ where
 /// obtain one from a builder and pass it to
 /// [`include_router`](crate::runtime::BrokerScope::include_router). You do not implement it.
 ///
-/// `St` is the app's shared-state type: a router whose handlers read typed state is
-/// `RouterDef<B, St>` only for that `St`, while a state-agnostic router is generic over it, so it
+/// `State` is the app's shared-state type: a router whose handlers read typed state is
+/// `RouterDef<B, State>` only for that `State`, while a state-agnostic router is generic over it, so it
 /// mounts on any app.
-pub trait RouterDef<B, St = ()> {
+pub trait RouterDef<B, State = ()> {
     /// Applies `global` to every registration and pushes it into `sink`. Called by `include_router`.
     #[doc(hidden)]
     fn mount<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     );
 }
 
@@ -313,12 +314,12 @@ pub trait RouterHandlers {
     fn collect_handlers(&self, out: &mut Vec<HandlerMetadata>);
 }
 
-impl<B: Broker + 'static, St> RouterDef<B, St> for () {
+impl<B: Broker + 'static, State> RouterDef<B, State> for () {
     fn mount<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         _global: &G,
         _pipeline: &PP,
-        _sink: &mut RouterSink<B, St>,
+        _sink: &mut RouterSink<B, State>,
     ) {
     }
 }
@@ -327,17 +328,17 @@ impl RouterHandlers for () {
     fn collect_handlers(&self, _out: &mut Vec<HandlerMetadata>) {}
 }
 
-impl<B, Head, Tail, St> RouterDef<B, St> for (Head, Tail)
+impl<B, Head, Tail, State> RouterDef<B, State> for (Head, Tail)
 where
     B: Broker + 'static,
-    Head: MountRoute<B, St>,
-    Tail: RouterDef<B, St>,
+    Head: MountRoute<B, State>,
+    Tail: RouterDef<B, State>,
 {
     fn mount<G: BlanketLayer, PP: PublishPipeline + Clone + 'static>(
         self,
         global: &G,
         pipeline: &PP,
-        sink: &mut RouterSink<B, St>,
+        sink: &mut RouterSink<B, State>,
     ) {
         // Registrations are prepended, so the tail holds the earlier ones; mount it first to keep
         // registration order.

--- a/src/runtime/router/sink.rs
+++ b/src/runtime/router/sink.rs
@@ -21,10 +21,10 @@ use super::SourceMessage;
 /// A deferred registration: given the broker (after connect), shared state, the per-scope publish
 /// [`Delivery`] context, and the shutdown token, it opens the subscription and spawns the dispatch
 /// task. The source and handler are captured and type-erased.
-pub(crate) type BoundStarter<B, St> = Box<
+pub(crate) type BoundStarter<B, State> = Box<
     dyn FnOnce(
             Arc<B>,
-            Arc<St>,
+            Arc<State>,
             Arc<Delivery>,
             ErrorShutdown,
             CancellationToken,
@@ -34,18 +34,18 @@ pub(crate) type BoundStarter<B, St> = Box<
 
 /// The runtime collector a router mounts into: type-erased starters plus handler metadata.
 ///
-/// `St` is the app's shared state type, threaded so a handler is only mounted on a sink whose state
+/// `State` is the app's shared state type, threaded so a handler is only mounted on a sink whose state
 /// type it matches.
 ///
 /// Created and drained inside the application; a [`RouterDef`](crate::runtime::RouterDef) pushes
 /// into it during [`include_router`](crate::runtime::BrokerScope::include_router). You do not
 /// construct one directly.
-pub struct RouterSink<B, St = ()> {
-    starters: Vec<BoundStarter<B, St>>,
+pub struct RouterSink<B, State = ()> {
+    starters: Vec<BoundStarter<B, State>>,
     handlers: Vec<HandlerMetadata>,
 }
 
-impl<B, St> std::fmt::Debug for RouterSink<B, St> {
+impl<B, State> std::fmt::Debug for RouterSink<B, State> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RouterSink")
             .field("handlers", &self.handlers.len())
@@ -53,7 +53,7 @@ impl<B, St> std::fmt::Debug for RouterSink<B, St> {
     }
 }
 
-impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
+impl<B: Broker + 'static, State: Send + Sync + 'static> RouterSink<B, State> {
     pub(crate) fn new() -> Self {
         Self {
             starters: Vec::new(),
@@ -71,7 +71,7 @@ impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
     ) where
         S: Subscriber + Send + 'static,
         Cx: crate::BuildContext<S::Message> + Send + 'static,
-        H: Handler<S::Message, Cx, St> + 'static,
+        H: Handler<S::Message, Cx, State> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -101,7 +101,7 @@ impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: BatchSubscriber + Send + 'static,
         SourceMessage<B, S>: Send + 'static,
-        H: BatchHandler<SourceMessage<B, S>, St> + 'static,
+        H: BatchHandler<SourceMessage<B, S>, State> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -136,7 +136,7 @@ impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
         S::Subscriber: Send + 'static,
         SourceMessage<B, S>: Send + Sync + 'static,
         Cx: crate::BuildContext<SourceMessage<B, S>> + Send + 'static,
-        H: Handler<SourceMessage<B, S>, Cx, St> + 'static,
+        H: Handler<SourceMessage<B, S>, Cx, State> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -168,7 +168,7 @@ impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
         S: SubscriptionSource<B> + Send + 'static,
         S::Subscriber: Send + 'static,
         Cx: crate::BuildContext<SourceMessage<B, S>> + Send + 'static,
-        H: Handler<SourceMessage<B, S>, Cx, St> + 'static,
+        H: Handler<SourceMessage<B, S>, Cx, State> + 'static,
     {
         let handler = Arc::new(handler);
         let name: Arc<str> = Arc::from(meta.name.as_ref());
@@ -189,7 +189,7 @@ impl<B: Broker + 'static, St: Send + Sync + 'static> RouterSink<B, St> {
         self.handlers.push(meta);
     }
 
-    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B, St>>, Vec<HandlerMetadata>) {
+    pub(crate) fn into_parts(self) -> (Vec<BoundStarter<B, State>>, Vec<HandlerMetadata>) {
         (self.starters, self.handlers)
     }
 }

--- a/src/testing/harness.rs
+++ b/src/testing/harness.rs
@@ -11,8 +11,8 @@ use tokio_util::task::TaskTracker;
 
 use crate::OutgoingMessage;
 use crate::runtime::{
-    BrokerLifecycle, ErrorShutdown, LifecycleHook, RegisteredBroker, RustStream, RustStreamError,
-    Starter, TestParts,
+    BrokerLifecycle, ErrorShutdown, LifecycleHook, PublishIdentity, RegisteredBroker, RustStream,
+    RustStreamError, Starter, TestParts,
 };
 
 use super::assertions::{PublishedAssertions, SubscriberAssertions};
@@ -210,7 +210,9 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     ///
     /// Returns [`TestError::Startup`] if a lifecycle hook fails, or [`TestError::Subscribe`] if a
     /// subscription fails to open.
-    pub async fn start<L>(app: RustStream<L, St>) -> Result<Self, TestError> {
+    pub async fn start<L, Phase>(
+        app: RustStream<L, St, PublishIdentity, Phase>,
+    ) -> Result<Self, TestError> {
         let (coordinator, entries, parts) = Self::setup(app);
         let TestParts {
             starters,
@@ -241,7 +243,10 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     /// # Errors
     ///
     /// Returns [`TestError::Subscribe`] if a subscription fails to open.
-    pub async fn with_state<L, F>(app: RustStream<L, St>, build: F) -> Result<Self, TestError>
+    pub async fn with_state<L, F, Phase>(
+        app: RustStream<L, St, PublishIdentity, Phase>,
+        build: F,
+    ) -> Result<Self, TestError>
     where
         F: FnOnce(&TestBrokers<'_>) -> St,
     {
@@ -269,7 +274,9 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     /// Installs a fresh coordinator into the app's hooks slot and each broker's bus, and recovers
     /// the per-broker transports. Returns the coordinator, the broker entries, and the remaining
     /// parts (the brokers field is now consumed and empty).
-    fn setup<L>(app: RustStream<L, St>) -> (Coordinator, Vec<BrokerEntry>, TestParts<St>) {
+    fn setup<L, Phase>(
+        app: RustStream<L, St, PublishIdentity, Phase>,
+    ) -> (Coordinator, Vec<BrokerEntry>, TestParts<St>) {
         let mut parts = app.into_test_parts();
         let coordinator = Coordinator::new(DEFAULT_MAX_STEPS);
         parts.test_hooks.install(coordinator.clone());

--- a/src/testing/harness.rs
+++ b/src/testing/harness.rs
@@ -181,11 +181,11 @@ impl TestBrokers<'_> {
 /// # Ok(())
 /// # }
 /// ```
-pub struct TestApp<St> {
+pub struct TestApp<State> {
     entries: Vec<BrokerEntry>,
     coordinator: Coordinator,
     #[allow(dead_code)]
-    state: Arc<St>,
+    state: Arc<State>,
     error_shutdown: ErrorShutdown,
     token: CancellationToken,
     handles: Vec<JoinHandle<()>>,
@@ -193,7 +193,7 @@ pub struct TestApp<St> {
     shutdown_timeout: Option<Duration>,
 }
 
-impl<St> std::fmt::Debug for TestApp<St> {
+impl<State> std::fmt::Debug for TestApp<State> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TestApp")
             .field("brokers", &self.entries.len())
@@ -202,7 +202,7 @@ impl<St> std::fmt::Debug for TestApp<St> {
     }
 }
 
-impl<St: Send + Sync + 'static> TestApp<St> {
+impl<State: Send + Sync + 'static> TestApp<State> {
     /// Starts the harness by running the app's real `on_startup` (the existing state and its
     /// publishers bind to the in-process bus). No broker `connect` runs.
     ///
@@ -210,8 +210,8 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     ///
     /// Returns [`TestError::Startup`] if a lifecycle hook fails, or [`TestError::Subscribe`] if a
     /// subscription fails to open.
-    pub async fn start<L, Phase>(
-        app: RustStream<L, St, PublishIdentity, Phase>,
+    pub async fn start<Layers, Phase>(
+        app: RustStream<Layers, State, PublishIdentity, Phase>,
     ) -> Result<Self, TestError> {
         let (coordinator, entries, parts) = Self::setup(app);
         let TestParts {
@@ -243,12 +243,12 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     /// # Errors
     ///
     /// Returns [`TestError::Subscribe`] if a subscription fails to open.
-    pub async fn with_state<L, F, Phase>(
-        app: RustStream<L, St, PublishIdentity, Phase>,
+    pub async fn with_state<Layers, F, Phase>(
+        app: RustStream<Layers, State, PublishIdentity, Phase>,
         build: F,
     ) -> Result<Self, TestError>
     where
-        F: FnOnce(&TestBrokers<'_>) -> St,
+        F: FnOnce(&TestBrokers<'_>) -> State,
     {
         let (coordinator, entries, parts) = Self::setup(app);
         let TestParts {
@@ -274,9 +274,9 @@ impl<St: Send + Sync + 'static> TestApp<St> {
     /// Installs a fresh coordinator into the app's hooks slot and each broker's bus, and recovers
     /// the per-broker transports. Returns the coordinator, the broker entries, and the remaining
     /// parts (the brokers field is now consumed and empty).
-    fn setup<L, Phase>(
-        app: RustStream<L, St, PublishIdentity, Phase>,
-    ) -> (Coordinator, Vec<BrokerEntry>, TestParts<St>) {
+    fn setup<Layers, Phase>(
+        app: RustStream<Layers, State, PublishIdentity, Phase>,
+    ) -> (Coordinator, Vec<BrokerEntry>, TestParts<State>) {
         let mut parts = app.into_test_parts();
         let coordinator = Coordinator::new(DEFAULT_MAX_STEPS);
         parts.test_hooks.install(coordinator.clone());
@@ -296,7 +296,7 @@ impl<St: Send + Sync + 'static> TestApp<St> {
 
     /// Spawns the dispatch loops against the (uninstalled) bus and runs `after_startup`, completing
     /// the harness. No broker `connect` runs.
-    async fn spawn(args: SpawnArgs<St>) -> Result<Self, TestError> {
+    async fn spawn(args: SpawnArgs<State>) -> Result<Self, TestError> {
         let SpawnArgs {
             coordinator,
             entries,
@@ -511,14 +511,14 @@ impl<St: Send + Sync + 'static> TestApp<St> {
 }
 
 /// The pieces [`TestApp::spawn`] needs to start the dispatch loops.
-struct SpawnArgs<St> {
+struct SpawnArgs<State> {
     coordinator: Coordinator,
     entries: Vec<BrokerEntry>,
-    starters: Vec<Starter<St>>,
-    after_startup: Vec<LifecycleHook<St>>,
+    starters: Vec<Starter<State>>,
+    after_startup: Vec<LifecycleHook<State>>,
     continuations: TaskTracker,
     shutdown_timeout: Option<Duration>,
-    state: Arc<St>,
+    state: Arc<State>,
 }
 
 /// A handle to one broker in a [`TestApp`]: inject input and assert on its handlers and publishes.

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -171,3 +171,13 @@ async fn start_is_reachable_through_the_app_trait() {
         .expect("handler never saw the message");
     running.shutdown().await.expect("graceful shutdown failed");
 }
+
+#[test]
+#[should_panic(expected = "on_startup must be called before lifecycle hooks")]
+fn on_startup_after_a_lifecycle_hook_panics() {
+    // A hook registered first closes over the previous state type and cannot be carried across
+    // the state change, so the builder refuses loudly instead of dropping it silently.
+    let _app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .after_startup(async move |_state| Ok::<_, Infallible>(()))
+        .on_startup(async move |()| Ok::<_, Infallible>(42_u32));
+}

--- a/tests/ui/app_layer_after_with_broker.rs
+++ b/tests/ui/app_layer_after_with_broker.rs
@@ -1,0 +1,11 @@
+//! A global layer added after `with_broker` could not wrap the already-registered handlers, so
+//! the builder leaves the phase where `layer` exists and this must not compile.
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::layers::TracingLayer;
+use ruststream::runtime::{AppInfo, RustStream};
+
+fn main() {
+    let _app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |_b| {})
+        .layer(TracingLayer::default());
+}

--- a/tests/ui/app_layer_after_with_broker.stderr
+++ b/tests/ui/app_layer_after_with_broker.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no method named `layer` found for struct `RustStream` in the current scope
+  --> tests/ui/app_layer_after_with_broker.rs:10:10
+   |
+ 8 |       let _app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+   |  ________________-
+ 9 | |         .with_broker(MemoryBroker::new(), |_b| {})
+10 | |         .layer(TracingLayer::default());
+   | |         -^^^^^ method not found in `RustStream`
+   | |_________|
+   |
+   |
+   = note: the method was found for `RustStream<L, St, PP, Setup>`

--- a/tests/ui/app_on_startup_after_with_broker.rs
+++ b/tests/ui/app_on_startup_after_with_broker.rs
@@ -1,0 +1,10 @@
+//! `on_startup` fixes the app's state type; handlers already registered against another state
+//! type could not be carried across, so after `with_broker` the method no longer exists.
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, RustStream};
+
+fn main() {
+    let _app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |_b| {})
+        .on_startup(async move |()| Ok::<_, std::io::Error>(42_u32));
+}

--- a/tests/ui/app_on_startup_after_with_broker.stderr
+++ b/tests/ui/app_on_startup_after_with_broker.stderr
@@ -1,0 +1,17 @@
+error[E0599]: no method named `on_startup` found for struct `RustStream` in the current scope
+ --> tests/ui/app_on_startup_after_with_broker.rs:9:10
+  |
+7 |       let _app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+  |                  ---------------------------------------------
+  |                  |
+  |  ________________method `on_startup` is available on `RustStream<Identity, (), PublishIdentity, Setup>`
+  | |
+8 | |         .with_broker(MemoryBroker::new(), |_b| {})
+9 | |         .on_startup(async move |()| Ok::<_, std::io::Error>(42_u32));
+  | |_________-^^^^^^^^^^
+  |
+help: there is a method `start` with a similar name, but with different arguments
+ --> src/runtime/app/run.rs
+  |
+  |     pub async fn start(self) -> Result<RunningApp, RustStreamError> {
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

Adds a `Phase` type parameter to the `RustStream` builder. `new()` starts in `Setup`, where `on_startup`, `layer`, and `publish_layer` are available; the first `with_broker*` call moves the builder to `Wired`, where those methods no longer exist. A configuration call that could not apply to already-registered handlers - previously a silent drop of registered starters (with AsyncAPI metadata still listing them), or a layer that silently wrapped nothing - is now a compile error. Two trybuild cases pin the rejection.

`on_startup` additionally panics (documented) if a lifecycle hook was registered before it: hooks close over the state type and cannot be carried across the state change; this is the one ordering hole the two-phase model does not express in types.

`Phase` defaults to `Wired`, so existing signatures that name `RustStream` (which almost always means the built service) keep compiling unchanged; construction sites resolve by inference and are unaffected. `App`, `run`/`start`, and the `TestApp` harness are generic over the phase.

Breaking (pre-1.0 minor bump, 0.6): `with_broker*` now return a phase-changed type, and misordered builder chains no longer compile. No version bump in this PR.

Fixes #162

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable