### PR TITLE
feat: take NonZeroUsize in Buffered max_size and Workers counts

### DIFF
--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -281,13 +281,27 @@ fn workers_method(args: &SubscriberArgs) -> syn::Result<TokenStream2> {
         }
         return Ok(quote! {
             fn workers(&self) -> ::ruststream::runtime::Workers {
-                ::ruststream::runtime::Workers::keyed(#count)
+                // The macro rejects workers(0) at expansion, so the None arm is unreachable;
+                // MIN keeps the lowering panic-free.
+                ::ruststream::runtime::Workers::keyed(
+                    match ::core::num::NonZeroUsize::new(#count) {
+                        ::core::option::Option::Some(count) => count,
+                        ::core::option::Option::None => ::core::num::NonZeroUsize::MIN,
+                    },
+                )
             }
         });
     }
     Ok(quote! {
         fn workers(&self) -> ::ruststream::runtime::Workers {
-            ::ruststream::runtime::Workers::pool(#count)
+            // The macro rejects workers(0) at expansion, so the None arm is unreachable;
+            // MIN keeps the lowering panic-free.
+            ::ruststream::runtime::Workers::pool(
+                match ::core::num::NonZeroUsize::new(#count) {
+                    ::core::option::Option::Some(count) => count,
+                    ::core::option::Option::None => ::core::num::NonZeroUsize::MIN,
+                },
+            )
         }
     })
 }

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -5,14 +5,13 @@
 //! cargo run --example subscribers --features macros,memory,json -- run
 //! ```
 
-use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use ruststream::codec::JsonCodec;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, RustStream, typed};
 use ruststream::subscriber;
-use ruststream::{Buffered, Name};
+use ruststream::{Buffered, Name, nonzero};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -87,7 +86,7 @@ async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
 // 20 ms after its first one. The macro recovers the source type from the constructor path, so
 // the generic parameter is spelled out.
 #[subscriber(batch(Buffered::<Name>::new(Name::new("orders"))
-    .max_size(NonZeroUsize::new(128).unwrap())
+    .max_size(nonzero!(128))
     .max_wait(Duration::from_millis(20))))]
 async fn drain(orders: &[Order]) -> HandlerResult {
     println!("draining {} orders", orders.len());

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -5,6 +5,7 @@
 //! cargo run --example subscribers --features macros,memory,json -- run
 //! ```
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use ruststream::codec::JsonCodec;
@@ -86,7 +87,7 @@ async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
 // 20 ms after its first one. The macro recovers the source type from the constructor path, so
 // the generic parameter is spelled out.
 #[subscriber(batch(Buffered::<Name>::new(Name::new("orders"))
-    .max_size(128)
+    .max_size(NonZeroUsize::new(128).unwrap())
     .max_wait(Duration::from_millis(20))))]
 async fn drain(orders: &[Order]) -> HandlerResult {
     println!("draining {} orders", orders.len());

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -6,13 +6,14 @@
 //! robbing broker crates of their native implementations (coherence), hence the explicit
 //! wrapper.
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use futures::{Stream, StreamExt};
 
 use crate::{BatchSubscriber, Broker, Subscriber, SubscriptionSource};
 
-const DEFAULT_MAX_SIZE: usize = 64;
+const DEFAULT_MAX_SIZE: NonZeroUsize = NonZeroUsize::new(64).unwrap();
 const DEFAULT_MAX_WAIT: Duration = Duration::from_millis(10);
 
 /// A [`SubscriptionSource`] adapter that buffers the wrapped source's subscriber into a
@@ -25,19 +26,20 @@ const DEFAULT_MAX_WAIT: Duration = Duration::from_millis(10);
 /// # Examples
 ///
 /// ```
+/// use std::num::NonZeroUsize;
 /// use std::time::Duration;
 ///
 /// use ruststream::{Buffered, Name};
 ///
 /// let source = Buffered::new(Name::new("orders"))
-///     .max_size(128)
+///     .max_size(NonZeroUsize::new(128).unwrap())
 ///     .max_wait(Duration::from_millis(20));
 /// # let _ = source;
 /// ```
 #[derive(Debug, Clone)]
 pub struct Buffered<S> {
     source: S,
-    max_size: usize,
+    max_size: NonZeroUsize,
     max_wait: Duration,
 }
 
@@ -52,10 +54,9 @@ impl<S> Buffered<S> {
         }
     }
 
-    /// Caps how many deliveries one batch may carry. A batch always carries at least one
-    /// delivery, so zero behaves like one.
+    /// Caps how many deliveries one batch may carry.
     #[must_use]
-    pub fn max_size(mut self, max_size: usize) -> Self {
+    pub fn max_size(mut self, max_size: NonZeroUsize) -> Self {
         self.max_size = max_size;
         self
     }
@@ -83,7 +84,7 @@ where
     async fn subscribe(self, broker: &B) -> Result<Self::Subscriber, B::Error> {
         Ok(BufferedSubscriber {
             inner: self.source.subscribe(broker).await?,
-            max_size: self.max_size.max(1),
+            max_size: self.max_size,
             max_wait: self.max_wait,
         })
     }
@@ -96,7 +97,7 @@ where
 #[derive(Debug)]
 pub struct BufferedSubscriber<S> {
     inner: S,
-    max_size: usize,
+    max_size: NonZeroUsize,
     max_wait: Duration,
 }
 
@@ -128,7 +129,7 @@ impl<S: Subscriber> BatchSubscriber for BufferedSubscriber<S> {
     fn batches(
         &mut self,
     ) -> impl Stream<Item = Result<Self::Batch, <Self as Subscriber>::Error>> + Send + '_ {
-        let max_size = self.max_size.max(1);
+        let max_size = self.max_size.get();
         let max_wait = self.max_wait;
         let inner = Box::pin(self.inner.stream());
         futures::stream::unfold(
@@ -193,7 +194,7 @@ mod tests {
         max_wait: Duration,
     ) -> BufferedSubscriber<crate::memory::MemorySubscriber> {
         Buffered::new(Name::new("buffered"))
-            .max_size(max_size)
+            .max_size(NonZeroUsize::new(max_size).expect("test sizes are nonzero"))
             .max_wait(max_wait)
             .subscribe(broker)
             .await

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -26,13 +26,12 @@ const DEFAULT_MAX_WAIT: Duration = Duration::from_millis(10);
 /// # Examples
 ///
 /// ```
-/// use std::num::NonZeroUsize;
 /// use std::time::Duration;
 ///
-/// use ruststream::{Buffered, Name};
+/// use ruststream::{Buffered, Name, nonzero};
 ///
 /// let source = Buffered::new(Name::new("orders"))
-///     .max_size(NonZeroUsize::new(128).unwrap())
+///     .max_size(nonzero!(128))
 ///     .max_wait(Duration::from_millis(20));
 /// # let _ = source;
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,3 +210,37 @@ pub mod __private {
         }
     }
 }
+
+/// Builds a [`NonZero`](core::num::NonZero) integer from a literal, rejecting zero at compile
+/// time.
+///
+/// The expansion is an inline `const` block, so `nonzero!(0)` fails the build instead of
+/// panicking at runtime, and the `NonZero` width is inferred from the call site - the same
+/// literal works for [`Buffered::max_size`](crate::Buffered::max_size) (`NonZeroUsize`) and any
+/// other `NonZero` parameter.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::{Buffered, Name, nonzero};
+///
+/// let source = Buffered::new(Name::new("orders")).max_size(nonzero!(128));
+/// # let _ = source;
+/// ```
+///
+/// Zero does not compile:
+///
+/// ```compile_fail
+/// let _: core::num::NonZeroUsize = ruststream::nonzero!(0);
+/// ```
+#[macro_export]
+macro_rules! nonzero {
+    ($value:expr) => {
+        const {
+            match ::core::num::NonZero::new($value) {
+                ::core::option::Option::Some(value) => value,
+                ::core::option::Option::None => panic!("nonzero!(..) requires a non-zero value"),
+            }
+        }
+    };
+}

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -3,6 +3,7 @@
 //! [`RustStream`](super::RustStream) can own task spawning directly.
 
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
@@ -83,22 +84,22 @@ impl Workers {
         }
     }
 
-    /// A pool of up to `count` concurrent deliveries. Zero behaves like one (sequential).
+    /// A pool of up to `count` concurrent deliveries. One behaves like sequential dispatch.
     #[must_use]
-    pub const fn pool(count: usize) -> Self {
+    pub const fn pool(count: NonZeroUsize) -> Self {
         Self {
-            count: if count == 0 { 1 } else { count },
+            count: count.get(),
             by_key: false,
         }
     }
 
     /// `count` sequential lanes keyed by the message
     /// [`partition_key`](crate::IncomingMessage::partition_key): per-key ordering is preserved.
-    /// Zero or one lane behaves like sequential dispatch.
+    /// One lane behaves like sequential dispatch.
     #[must_use]
-    pub const fn keyed(count: usize) -> Self {
+    pub const fn keyed(count: NonZeroUsize) -> Self {
         Self {
-            count: if count == 0 { 1 } else { count },
+            count: count.get(),
             by_key: true,
         }
     }

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -424,7 +424,7 @@ impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
     /// ```no_run
     /// # #[cfg(feature = "memory")]
     /// # fn build() {
-    /// use std::num::NonZeroUsize;
+    /// use ruststream::nonzero;
     ///
     /// use ruststream::Name;
     /// use ruststream::memory::MemoryBroker;
@@ -436,7 +436,7 @@ impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
     ///         |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
     ///         HandlerMetadata::raw("jobs"),
     ///     )
-    ///     .workers(Workers::pool(NonZeroUsize::new(4).unwrap()));
+    ///     .workers(Workers::pool(nonzero!(4)));
     /// # }
     /// ```
     #[must_use]

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -424,6 +424,8 @@ impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
     /// ```no_run
     /// # #[cfg(feature = "memory")]
     /// # fn build() {
+    /// use std::num::NonZeroUsize;
+    ///
     /// use ruststream::Name;
     /// use ruststream::memory::MemoryBroker;
     /// use ruststream::runtime::{Context, HandlerMetadata, HandlerResult, Router, Workers};
@@ -434,7 +436,7 @@ impl<B, S, H, R, RC, RL> Router<B, (SubscribeRoute<S, H>, R), RC, RL> {
     ///         |_msg: &_, _ctx: &mut Context| async { HandlerResult::Ack },
     ///         HandlerMetadata::raw("jobs"),
     ///     )
-    ///     .workers(Workers::pool(4));
+    ///     .workers(Workers::pool(NonZeroUsize::new(4).unwrap()));
     /// # }
     /// ```
     #[must_use]

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use std::{
+    num::NonZeroUsize,
     sync::{
         Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -135,7 +136,7 @@ static BUFFERED_SEEN: AtomicUsize = AtomicUsize::new(0);
 /// A handler mounted on a `Buffered`-wrapped source directly in the macro. The macro recovers
 /// the source type from the constructor path, so a generic source spells its parameter
 /// (turbofish).
-#[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(2)))]
+#[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(NonZeroUsize::new(2).unwrap())))]
 async fn drain(events: &[Order]) -> HandlerResult {
     BUFFERED_SEEN.fetch_add(events.len(), Ordering::SeqCst);
     HandlerResult::Ack

--- a/tests/batch_subscriber.rs
+++ b/tests/batch_subscriber.rs
@@ -8,7 +8,6 @@
 mod common;
 
 use std::{
-    num::NonZeroUsize,
     sync::{
         Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -20,7 +19,7 @@ use common::wait_for;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream, TypedPublisher};
 use ruststream::testing::expect_published;
-use ruststream::{Buffered, Name, OutgoingMessage, Publisher, subscriber};
+use ruststream::{Buffered, Name, OutgoingMessage, Publisher, nonzero, subscriber};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -136,7 +135,7 @@ static BUFFERED_SEEN: AtomicUsize = AtomicUsize::new(0);
 /// A handler mounted on a `Buffered`-wrapped source directly in the macro. The macro recovers
 /// the source type from the constructor path, so a generic source spells its parameter
 /// (turbofish).
-#[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(NonZeroUsize::new(2).unwrap())))]
+#[subscriber(batch(Buffered::<Name>::new(Name::new("events")).max_size(nonzero!(2))))]
 async fn drain(events: &[Order]) -> HandlerResult {
     BUFFERED_SEEN.fetch_add(events.len(), Ordering::SeqCst);
     HandlerResult::Ack

--- a/tests/composition_rules.rs
+++ b/tests/composition_rules.rs
@@ -10,6 +10,7 @@
 mod common;
 
 use std::{
+    num::NonZeroUsize,
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
@@ -88,7 +89,7 @@ static BUF_BATCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Client-side batching under a pool: the size cap or deadline (not the pool) closes a batch.
 #[subscriber(batch(Buffered::<Name>::new(Name::new("buf-in"))
-    .max_size(2)
+    .max_size(NonZeroUsize::new(2).unwrap())
     .max_wait(Duration::from_millis(10))), workers(2))]
 async fn buffered_drain(orders: &[Order]) -> HandlerResult {
     BUF_SEEN.fetch_add(orders.len(), Ordering::SeqCst);

--- a/tests/composition_rules.rs
+++ b/tests/composition_rules.rs
@@ -10,7 +10,6 @@
 mod common;
 
 use std::{
-    num::NonZeroUsize,
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
@@ -19,7 +18,7 @@ use common::wait_for;
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
 use ruststream::testing::expect_published;
-use ruststream::{Buffered, Name, OutgoingMessage, Publisher, subscriber};
+use ruststream::{Buffered, Name, OutgoingMessage, Publisher, nonzero, subscriber};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,7 +88,7 @@ static BUF_BATCHES: AtomicUsize = AtomicUsize::new(0);
 
 /// Client-side batching under a pool: the size cap or deadline (not the pool) closes a batch.
 #[subscriber(batch(Buffered::<Name>::new(Name::new("buf-in"))
-    .max_size(NonZeroUsize::new(2).unwrap())
+    .max_size(nonzero!(2))
     .max_wait(Duration::from_millis(10))), workers(2))]
 async fn buffered_drain(orders: &[Order]) -> HandlerResult {
     BUF_SEEN.fetch_add(orders.len(), Ordering::SeqCst);

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use std::{
+    num::NonZeroUsize,
     sync::{
         Arc, LazyLock, Mutex,
         atomic::{AtomicU32, AtomicUsize, Ordering},
@@ -170,7 +171,7 @@ async fn batch_pool_dispatches_batches() {
     running.shutdown().await.expect("graceful shutdown failed");
 }
 
-/// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(3))`.
+/// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(NonZeroUsize::new(3).unwrap()))`.
 /// Three deliveries must be in flight at once to pass the barrier; the default sequential loop
 /// would deadlock on the first one.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -201,7 +202,7 @@ async fn closure_subscription_pool_runs_concurrently() {
             handler,
             HandlerMetadata::raw("fn-jobs"),
         )
-        .workers(Workers::pool(3));
+        .workers(Workers::pool(NonZeroUsize::new(3).unwrap()));
 
     let app = RustStream::new(AppInfo::new("fn-jobs", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
@@ -253,7 +254,7 @@ async fn closure_batch_subscription_receives_batches() {
             handler,
             HandlerMetadata::raw("fn-pages"),
         )
-        .workers(Workers::pool(2));
+        .workers(Workers::pool(NonZeroUsize::new(2).unwrap()));
 
     let app = RustStream::new(AppInfo::new("fn-pages", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -8,7 +8,6 @@
 mod common;
 
 use std::{
-    num::NonZeroUsize,
     sync::{
         Arc, LazyLock, Mutex,
         atomic::{AtomicU32, AtomicUsize, Ordering},
@@ -22,7 +21,7 @@ use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
     AppInfo, Context, HandlerMetadata, HandlerResult, Router, RustStream, Workers, typed,
 };
-use ruststream::{Headers, Name, OutgoingMessage, Publisher, subscriber};
+use ruststream::{Headers, Name, OutgoingMessage, Publisher, nonzero, subscriber};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Barrier;
 
@@ -171,7 +170,7 @@ async fn batch_pool_dispatches_batches() {
     running.shutdown().await.expect("graceful shutdown failed");
 }
 
-/// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(NonZeroUsize::new(3).unwrap()))`.
+/// The functional-path pool: a `Router::subscribe` closure with `.workers(Workers::pool(nonzero!(3)))`.
 /// Three deliveries must be in flight at once to pass the barrier; the default sequential loop
 /// would deadlock on the first one.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -202,7 +201,7 @@ async fn closure_subscription_pool_runs_concurrently() {
             handler,
             HandlerMetadata::raw("fn-jobs"),
         )
-        .workers(Workers::pool(NonZeroUsize::new(3).unwrap()));
+        .workers(Workers::pool(nonzero!(3)));
 
     let app = RustStream::new(AppInfo::new("fn-jobs", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));
@@ -254,7 +253,7 @@ async fn closure_batch_subscription_receives_batches() {
             handler,
             HandlerMetadata::raw("fn-pages"),
         )
-        .workers(Workers::pool(NonZeroUsize::new(2).unwrap()));
+        .workers(Workers::pool(nonzero!(2)));
 
     let app = RustStream::new(AppInfo::new("fn-pages", "0.1.0"))
         .with_broker(broker, |b| b.include_router(router));


### PR DESCRIPTION
# Description

`Buffered::max_size`, `Workers::pool`, and `Workers::keyed` now take `NonZeroUsize`. A zero bound was previously accepted and silently clamped to one (twice on the buffered path), while the macro form `workers(0)` was a hard compile error - the two registration paths disagreed on the same invalid value. With the parameter type carrying the invariant, the clamps are gone and both paths reject zero at compile time; the macro lowering constructs the `NonZeroUsize` through an unreachable-safe match with no panic path.

Breaking (pre-1.0 minor bump, 0.6): three public signatures change from `usize` to `NonZeroUsize`. No version bump in this PR.

Fixes #164

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable