### PR TITLE
feat: tighten the TransactionalPublisher contract

### DIFF
--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -94,7 +94,7 @@ without the capability simply do not call it. Each suite takes the same factory 
 |---|---|---|
 | `capabilities::request_reply` | `RequestReply` | the request reaches a responder with a usable `reply-to` header, the correlated reply resolves the request, an unanswered request fails after its timeout |
 | `capabilities::batches` | `BatchSubscriber` | every published message arrives in publish order, distributed over non-empty batches |
-| `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it |
+| `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it; misuse errors - `commit` / `abort` with no open transaction, a second `begin_transaction` while one is open (which must leave it untouched) |
 
 <!-- inline-rust: worked request-reply capability check against the external ruststream-nats crate; its real gated suite lives in that repo, so it has no compiled home here -->
 ```rust

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -43,7 +43,10 @@ in-process semantics, not a simulation of another broker's:
   batches ship immediately, so no deadline timer is involved.
 - **Transactions.** `MemoryPublisher` implements `TransactionalPublisher`: publishes between
   `begin_transaction` and `commit` are buffered and fan out together in publish order; `abort`
-  discards them. Clones of a publisher handle do not share its transaction.
+  discards them. Misuse errors with `MemoryError` per the trait contract: a second
+  `begin_transaction` returns `TransactionBusy` (the open transaction is untouched), and
+  `commit` / `abort` without one return `NoTransaction`. Clones of a publisher handle do not
+  share its transaction.
 - **Partition keys.** `MemoryMessage` implements `Partitioned`, reading the key from the
   well-known `partition-key` header (`memory::PARTITION_KEY_HEADER`).
 

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -37,8 +37,15 @@ pub trait BatchSubscriber: Subscriber {
 /// Implementations must guarantee that messages published between [`begin_transaction`] and
 /// [`commit`] either all become visible to subscribers or none of them do.
 ///
+/// Misuse is an error, never a silent no-op: a [`commit`] or [`abort`] with no open transaction,
+/// and a [`begin_transaction`] while one is open, must return `Self::Error`. A caller can
+/// therefore trust that `Ok` from `commit` means "an open transaction committed", not "there was
+/// nothing to commit". The [`conformance`](crate::conformance) transactional suite checks these
+/// paths.
+///
 /// [`begin_transaction`]: Self::begin_transaction
 /// [`commit`]: Self::commit
+/// [`abort`]: Self::abort
 pub trait TransactionalPublisher: Publisher {
     /// Begins a new transaction on this publisher.
     ///
@@ -47,8 +54,9 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker refuses to start a transaction, for example
-    /// because transactions are already in progress or the broker is misconfigured.
+    /// Returns `Self::Error` when a transaction is already open on this handle (a second begin
+    /// must not silently join or restart it), or when the broker refuses to start one. A
+    /// rejected begin must leave an already-open transaction untouched.
     ///
     /// [`commit`]: Self::commit
     /// [`abort`]: Self::abort
@@ -58,15 +66,21 @@ pub trait TransactionalPublisher: Publisher {
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker rejects the commit. The transaction state after
-    /// a failed commit is implementation-defined; implementors must document it.
+    /// Returns `Self::Error` when no transaction is open on this handle, or when the broker
+    /// rejects the commit. After a failed commit the transaction is closed: the implementation
+    /// discards or aborts the broker-side transaction rather than leaving it open, and a
+    /// subsequent [`begin_transaction`](Self::begin_transaction) either starts a fresh
+    /// transaction or returns an error - the handle must never wedge permanently. Messages of a
+    /// failed transaction are lost to this handle; redelivery of the inputs, not resubmission of
+    /// the buffer, is the recovery path.
     fn commit(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Aborts the active transaction, discarding all buffered messages.
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the broker rejects the abort.
+    /// Returns `Self::Error` when no transaction is open on this handle, or when the broker
+    /// fails to abort.
     fn abort(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 

--- a/src/conformance/capabilities.rs
+++ b/src/conformance/capabilities.rs
@@ -227,7 +227,10 @@ pub async fn batches<B, MkBroker, Src, MkSrc, Pub, MkPub>(
 /// Verifies the [`TransactionalPublisher`] contract.
 ///
 /// Nothing published inside a transaction is visible before `commit`, a commit makes every
-/// buffered message visible in publish order, and an abort discards the buffer.
+/// buffered message visible in publish order, and an abort discards the buffer. Misuse must
+/// error rather than silently succeed: `commit` / `abort` with no open transaction, and a
+/// second `begin_transaction` while one is open (which must also leave the open transaction
+/// untouched).
 ///
 /// # Examples
 ///
@@ -316,6 +319,43 @@ pub async fn transactions<B, MkBroker, Src, MkSrc, Pub, MkPub>(
         .expect("publish inside transaction failed");
     publisher.abort().await.expect("abort failed");
     expect_no_more(&mut stream, "transactions: after abort").await;
+
+    // Misuse must surface as errors, never as silent success.
+    assert!(
+        publisher.commit().await.is_err(),
+        "commit with no open transaction must error",
+    );
+    assert!(
+        publisher.abort().await.is_err(),
+        "abort with no open transaction must error",
+    );
+    publisher
+        .begin_transaction()
+        .await
+        .expect("begin_transaction failed");
+    assert!(
+        publisher.begin_transaction().await.is_err(),
+        "begin_transaction while a transaction is open must error",
+    );
+    // The rejected second begin must not have disturbed the open transaction.
+    publisher
+        .publish(OutgoingMessage::new(SUBJECT, b"third".as_slice()))
+        .await
+        .expect("publish inside transaction failed");
+    publisher
+        .commit()
+        .await
+        .expect("commit after a rejected double begin failed");
+    let third = expect_next(&mut stream, "transactions: after rejected double begin").await;
+    assert_eq!(
+        third.payload(),
+        b"third",
+        "a rejected double begin must leave the open transaction intact",
+    );
+    match third.ack().await {
+        Ok(()) | Err(AckError::Unsupported) => {}
+        Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+    }
 
     Broker::shutdown(&broker)
         .await

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -7,7 +7,6 @@
 //! them.
 
 use std::{
-    convert::Infallible,
     sync::{Arc, atomic::Ordering},
     task::Poll,
     time::Duration,
@@ -18,7 +17,9 @@ use futures::Stream;
 use thiserror::Error;
 use tokio::{sync::mpsc, time::timeout};
 
-use super::{MemoryDelivery, MemoryMessage, MemoryPublisher, MemoryState, MemorySubscriber};
+use super::{
+    MemoryDelivery, MemoryError, MemoryMessage, MemoryPublisher, MemoryState, MemorySubscriber,
+};
 use crate::{
     BatchSubscriber, IncomingMessage, OutgoingMessage, Partitioned, Publisher, RequestReply,
     Subscriber, TransactionalPublisher,
@@ -205,37 +206,41 @@ impl BatchSubscriber for MemorySubscriber {
 /// switches this handle to buffering, [`commit`](TransactionalPublisher::commit) fans out the
 /// buffer in publish order, [`abort`](TransactionalPublisher::abort) discards it.
 ///
-/// Every operation is total, matching the infallible publisher: `begin_transaction` inside an
-/// active transaction continues that transaction, and `commit` / `abort` without one are no-ops.
-/// Clones of the handle do not share the transaction (see [`MemoryPublisher`]).
+/// Misuse errors per the trait contract: a second `begin_transaction` returns
+/// [`MemoryError::TransactionBusy`] (leaving the open transaction untouched), and `commit` /
+/// `abort` without an open transaction return [`MemoryError::NoTransaction`]. Clones of the
+/// handle do not share the transaction (see [`MemoryPublisher`]).
 impl TransactionalPublisher for MemoryPublisher {
-    async fn begin_transaction(&self) -> Result<(), Infallible> {
+    async fn begin_transaction(&self) -> Result<(), MemoryError> {
         let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
-        if txn.is_none() {
-            *txn = Some(Vec::new());
+        if txn.is_some() {
+            return Err(MemoryError::TransactionBusy);
         }
+        *txn = Some(Vec::new());
         drop(txn);
         Ok(())
     }
 
-    async fn commit(&self) -> Result<(), Infallible> {
+    async fn commit(&self) -> Result<(), MemoryError> {
         let buffered = self
             .txn
             .lock()
             .expect("memory broker mutex poisoned")
-            .take();
-        for delivery in buffered.into_iter().flatten() {
+            .take()
+            .ok_or(MemoryError::NoTransaction)?;
+        for delivery in buffered {
             self.state.fanout(&delivery);
         }
         Ok(())
     }
 
-    async fn abort(&self) -> Result<(), Infallible> {
+    async fn abort(&self) -> Result<(), MemoryError> {
         self.txn
             .lock()
             .expect("memory broker mutex poisoned")
-            .take();
-        Ok(())
+            .take()
+            .map(|_| ())
+            .ok_or(MemoryError::NoTransaction)
     }
 }
 
@@ -381,6 +386,24 @@ mod tests {
         let second = stream.next().await.unwrap().unwrap();
         assert_eq!(second.payload(), b"buffered");
         second.ack().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn transactional_misuse_errors() {
+        let broker = MemoryBroker::new();
+        let publisher = broker.publisher();
+
+        assert_eq!(publisher.commit().await, Err(MemoryError::NoTransaction));
+        assert_eq!(publisher.abort().await, Err(MemoryError::NoTransaction));
+
+        publisher.begin_transaction().await.unwrap();
+        assert_eq!(
+            publisher.begin_transaction().await,
+            Err(MemoryError::TransactionBusy),
+        );
+        // The rejected second begin left the transaction open; an abort settles it.
+        publisher.abort().await.unwrap();
+        assert_eq!(publisher.abort().await, Err(MemoryError::NoTransaction));
     }
 
     #[tokio::test]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::Stream;
+use thiserror::Error;
 use tokio::sync::{Notify, mpsc};
 
 type Sender = mpsc::UnboundedSender<MemoryDelivery>;
@@ -369,8 +370,24 @@ impl std::fmt::Debug for MemoryPublisher {
     }
 }
 
+/// Error returned by [`MemoryPublisher`].
+///
+/// Publishing itself cannot fail (the bus is in-process); the variants cover transactional
+/// misuse, which the [`TransactionalPublisher`](crate::TransactionalPublisher) contract requires
+/// to surface as errors rather than silent no-ops.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MemoryError {
+    /// `begin_transaction` was called while a transaction is already open on this handle.
+    #[error("a transaction is already open on this publisher handle")]
+    TransactionBusy,
+    /// `commit` or `abort` was called with no open transaction on this handle.
+    #[error("no transaction is open on this publisher handle")]
+    NoTransaction,
+}
+
 impl Publisher for MemoryPublisher {
-    type Error = Infallible;
+    type Error = MemoryError;
 
     async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
         let delivery = MemoryDelivery {

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -789,11 +789,12 @@ where
                 return Err(err);
             }
         }
-        if let Err(err) = publisher.commit().await {
-            abort_quietly(publisher).await;
-            return Err(Box::new(err) as BoxError);
-        }
-        Ok(())
+        // Per the TransactionalPublisher contract a failed commit closes the transaction, so
+        // there is nothing left to abort here; the error alone settles the batch as failed.
+        publisher
+            .commit()
+            .await
+            .map_err(|err| Box::new(err) as BoxError)
     }
 }
 
@@ -911,16 +912,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns the publisher's error when the broker rejects the commit. The scope aborts the
-    /// transaction on a best-effort basis first (an abort failure is logged, not propagated), so
-    /// the handle does not stay wedged on a transaction that can no longer complete.
+    /// Returns the publisher's error when the broker rejects the commit. Per the
+    /// [`TransactionalPublisher`] contract a failed commit closes the transaction, so the spent
+    /// scope leaves the handle free for a fresh [`begin`](Transactional::begin).
     pub async fn commit(mut self) -> Result<(), P::Error> {
         self.open = false;
-        if let Err(err) = self.publisher.commit().await {
-            abort_quietly(self.publisher).await;
-            return Err(err);
-        }
-        Ok(())
+        self.publisher.commit().await
     }
 
     /// Aborts the transaction: nothing published through the scope becomes visible.

--- a/tests/router_include.rs
+++ b/tests/router_include.rs
@@ -27,7 +27,7 @@ fn order_bytes(id: u32) -> Vec<u8> {
 /// Publishes `payload` once to each topic (the app is already started, so the subscriptions are
 /// open and every publish lands), then waits until every counter is non-zero.
 async fn publish_and_await_all(
-    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    publisher: &impl Publisher,
     topics: &[&str],
     counters: &[&AtomicUsize],
 ) {

--- a/tests/router_publishing.rs
+++ b/tests/router_publishing.rs
@@ -44,7 +44,7 @@ fn order_bytes(id: u32) -> Vec<u8> {
 /// subscriptions are open and every publish lands), then waits until every reply counter is
 /// non-zero.
 async fn publish_and_await_replies(
-    publisher: &impl Publisher<Error = std::convert::Infallible>,
+    publisher: &impl Publisher,
     topics: &[&str],
     counters: &[&AtomicUsize],
 ) {


### PR DESCRIPTION
# Description

Tightens the `TransactionalPublisher` contract so misuse surfaces as errors instead of silent success:

- `commit` / `abort` with no open transaction must return an error, so `Ok` from `commit` always means "an open transaction committed".
- A second `begin_transaction` while one is open must error and leave the open transaction untouched.
- The state after a failed commit is now defined: the transaction is closed (the implementation discards or aborts broker-side), the handle stays usable, and a later `begin_transaction` must work or error - it must never wedge permanently. The runtime accordingly no longer issues a follow-up abort after a failed commit (in the batch reply path and the transaction scope).

The in-memory broker is the executable reference: its publisher error changes from `Infallible` to a new `MemoryError` (`TransactionBusy` / `NoTransaction`), and `conformance::capabilities::transactions` now drives all three misuse paths, holding broker crates to the same rules.

Expressing the atomic vs best-effort guarantee level in types was considered and deferred: it needs its own design pass and touches broker crates directly, so it stays follow-up work rather than a rider on this contract change.

Stacked on #166 (the transaction scope). Breaking (pre-1.0 minor bump, 0.6) for all broker crates; no version bump in this PR.

Fixes #163

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable