### PR TITLE
feat: de-box the publish hot path

### DIFF
--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -6,9 +6,6 @@
 //! cargo run --example publishing --features macros,memory,json -- run
 //! ```
 
-use std::future::Future;
-use std::pin::Pin;
-
 use ruststream::codec::{Codec, JsonCodec};
 use ruststream::memory::{MemoryBroker, MemoryPublisher};
 use ruststream::runtime::{
@@ -91,17 +88,13 @@ impl<C> PublishTransform<C> for EnvelopeTransform {
 struct AuditPublish;
 
 impl PublishLayer for AuditPublish {
-    fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
+    async fn on_publish<'a, N: ruststream::runtime::PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> Pin<
-        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
-    > {
-        Box::pin(async move {
-            println!("publishing to {}", out.name());
-            next.run(out).await
-        })
+        next: PublishNext<'a, N, P>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        println!("publishing to {}", out.name());
+        next.run(out).await
     }
 }
 // --8<-- [end:app_layer]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use prometheus::{
@@ -41,9 +40,6 @@ use crate::runtime::{
 const DURATION_BUCKETS: &[f64] = &[
     0.000_5, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
 ];
-
-type PublishFut<'a> =
-    Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>>;
 
 struct Inner {
     registry: Registry,
@@ -258,13 +254,14 @@ impl std::fmt::Debug for MetricsPublish {
 }
 
 impl PublishLayer for MetricsPublish {
-    fn on_publish<'a, N: PublishPipeline>(
+    fn on_publish<'a, N: PublishPipeline, P: crate::Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> PublishFut<'a> {
+        next: PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
+    {
         let name = out.name().to_owned();
-        Box::pin(async move {
+        async move {
             let result = next.run(out).await;
             let status = if result.is_ok() { "ok" } else { "error" };
             self.inner
@@ -272,7 +269,7 @@ impl PublishLayer for MetricsPublish {
                 .with_label_values(&[name.as_str(), status])
                 .inc();
             result
-        })
+        }
     }
 }
 

--- a/src/runtime/publish.rs
+++ b/src/runtime/publish.rs
@@ -13,15 +13,17 @@ use serde::Serialize;
 use tracing::warn;
 
 use super::lifecycle::BoxError;
-use super::publisher_registry::ErasedPublisher;
 use crate::codec::Codec;
 // `DefaultCodec` only exists when a codec feature is on; the impl that names it is gated the same
 // way, so an ungated import would break `--no-default-features`.
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::codec::DefaultCodec;
 use crate::runtime::publish::sealed::Sealed;
-use crate::{Headers, Publisher, TransactionalPublisher};
+use crate::{Headers, OutgoingMessage, Publisher, TransactionalPublisher};
 
+// The boxed future of the DYNAMIC middleware path only (PublishDynLayer / PublishDynNext).
+// The static pipeline returns unboxed RPITIT futures; only the opt-in runtime-composed list
+// pays this allocation.
 type PublishFut<'a> = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'a>>;
 
 /// A mutable outgoing message flowing through the publish pipeline.
@@ -106,11 +108,11 @@ impl<'a> Outgoing<'a> {
 /// this contract.)
 pub trait PublishPipeline: Send + Sync {
     /// Runs `out` through the remaining middleware, then sends it via `send`.
-    fn run<'a>(
+    fn run<'a, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        send: &'a dyn ErasedPublisher,
-    ) -> PublishFut<'a>;
+        send: &'a P,
+    ) -> impl Future<Output = Result<(), BoxError>> + Send + 'a;
 }
 
 /// The terminal [`PublishPipeline`]: no middleware, just the broker send. The default for an app
@@ -119,12 +121,14 @@ pub trait PublishPipeline: Send + Sync {
 pub struct PublishIdentity;
 
 impl PublishPipeline for PublishIdentity {
-    fn run<'a>(
+    async fn run<'a, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        send: &'a dyn ErasedPublisher,
-    ) -> PublishFut<'a> {
-        send.publish_message(out.name(), out.payload(), out.headers())
+        send: &'a P,
+    ) -> Result<(), BoxError> {
+        let msg =
+            OutgoingMessage::new(out.name(), out.payload()).with_headers(out.headers().clone());
+        send.publish(msg).await.map_err(|e| Box::new(e) as BoxError)
     }
 }
 
@@ -144,11 +148,11 @@ impl<Head, Tail> PublishStack<Head, Tail> {
 }
 
 impl<Head: PublishLayer, Tail: PublishPipeline> PublishPipeline for PublishStack<Head, Tail> {
-    fn run<'a>(
+    fn run<'a, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        send: &'a dyn ErasedPublisher,
-    ) -> PublishFut<'a> {
+        send: &'a P,
+    ) -> impl Future<Output = Result<(), BoxError>> + Send + 'a {
         self.head.on_publish(
             out,
             PublishNext {
@@ -167,29 +171,31 @@ impl<Head: PublishLayer, Tail: PublishPipeline> PublishPipeline for PublishStack
 /// [`RustStream::publish_layer`](super::RustStream::publish_layer).
 pub trait PublishLayer: Send + Sync {
     /// Handle the outgoing message, calling `next` to continue the pipeline.
-    fn on_publish<'a, N: PublishPipeline>(
+    fn on_publish<'a, N: PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> PublishFut<'a>;
+        next: PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), BoxError>> + Send + 'a;
 }
 
 /// A cursor over the rest of the publish pipeline, ending in the broker send. Handed to a
 /// [`PublishLayer`]; call [`run`](Self::run) to continue.
-pub struct PublishNext<'a, N> {
+pub struct PublishNext<'a, N, P> {
     tail: &'a N,
-    send: &'a dyn ErasedPublisher,
+    send: &'a P,
 }
 
-impl<'a, N: PublishPipeline> PublishNext<'a, N> {
+impl<'a, N: PublishPipeline, P: Publisher> PublishNext<'a, N, P> {
     /// Runs the rest of the pipeline (the remaining middleware, then the send).
-    #[must_use]
-    pub fn run(self, out: &'a mut Outgoing<'a>) -> PublishFut<'a> {
+    pub fn run(
+        self,
+        out: &'a mut Outgoing<'a>,
+    ) -> impl Future<Output = Result<(), BoxError>> + Send + 'a {
         self.tail.run(out, self.send)
     }
 }
 
-impl<N> std::fmt::Debug for PublishNext<'_, N> {
+impl<N, P> std::fmt::Debug for PublishNext<'_, N, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PublishNext").finish_non_exhaustive()
     }
@@ -294,16 +300,17 @@ impl std::fmt::Debug for PublishDynStack {
 }
 
 impl PublishLayer for PublishDynStack {
-    fn on_publish<'a, N: PublishPipeline>(
+    fn on_publish<'a, N: PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> PublishFut<'a> {
+        next: PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), BoxError>> + Send + 'a {
         // Erase the static continuation into a one-shot closure so the object-safe walker can end
-        // by handing control back to the surrounding static pipeline.
+        // by handing control back to the surrounding static pipeline. Boxing starts here: only
+        // the dynamic list pays it.
         PublishDynNext {
             rest: &self.0,
-            tail: Box::new(move |out| next.run(out)),
+            tail: Box::new(move |out| Box::pin(next.run(out)) as PublishFut<'a>),
         }
         .run(out)
     }

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -7,8 +7,6 @@
 mod common;
 
 use std::convert::Infallible;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
@@ -342,17 +340,13 @@ static REPLY_TAGGED: AtomicU32 = AtomicU32::new(0);
 struct Tagger;
 
 impl PublishLayer for Tagger {
-    fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
+    async fn on_publish<'a, N: ruststream::runtime::PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> Pin<
-        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
-    > {
-        Box::pin(async move {
-            out.headers_mut().insert("x-envelope", b"1".to_vec());
-            next.run(out).await
-        })
+        next: PublishNext<'a, N, P>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        out.headers_mut().insert("x-envelope", b"1".to_vec());
+        next.run(out).await
     }
 }
 

--- a/tests/publish_context.rs
+++ b/tests/publish_context.rs
@@ -244,9 +244,6 @@ async fn dyn_stack_runs_a_runtime_built_middleware() {
 
 // Two app-wide publish middleware, each appending its letter to an "order" header, pin the
 // documented composition: the LAST `publish_layer` added runs OUTERMOST (so it appends first).
-type PubFut<'a> =
-    Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>>;
-
 fn append_order(out: &mut Outgoing<'_>, letter: &str) {
     let mut order = out
         .headers()
@@ -261,11 +258,12 @@ fn append_order(out: &mut Outgoing<'_>, letter: &str) {
 struct AppendA;
 
 impl PublishLayer for AppendA {
-    fn on_publish<'a, N: PublishPipeline>(
+    fn on_publish<'a, N: PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> PubFut<'a> {
+        next: PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
+    {
         append_order(out, "A");
         next.run(out)
     }
@@ -275,11 +273,12 @@ impl PublishLayer for AppendA {
 struct AppendB;
 
 impl PublishLayer for AppendB {
-    fn on_publish<'a, N: PublishPipeline>(
+    fn on_publish<'a, N: PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: PublishNext<'a, N>,
-    ) -> PubFut<'a> {
+        next: PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
+    {
         append_order(out, "B");
         next.run(out)
     }

--- a/tests/router_publishing.rs
+++ b/tests/router_publishing.rs
@@ -292,13 +292,12 @@ async fn chain_codec_router_batch_publishing_replies() {
 struct StampApp;
 
 impl ruststream::runtime::PublishLayer for StampApp {
-    fn on_publish<'a, N: ruststream::runtime::PublishPipeline>(
+    fn on_publish<'a, N: ruststream::runtime::PublishPipeline, P: Publisher>(
         &'a self,
         out: &'a mut Outgoing<'a>,
-        next: ruststream::runtime::PublishNext<'a, N>,
-    ) -> std::pin::Pin<
-        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
-    > {
+        next: ruststream::runtime::PublishNext<'a, N, P>,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
+    {
         out.headers_mut().insert("x-app", b"1".to_vec());
         next.run(out)
     }


### PR DESCRIPTION
# Description

`PublishPipeline::run` and `PublishLayer::on_publish` move to RPITIT, and the pipeline takes the concrete `P: Publisher` the caller already holds instead of erasing it into `&dyn ErasedPublisher` right before the call. The static default path (no middleware) now compiles to a direct, allocation-free send; previously every published reply paid one boxed future plus two dynamic dispatches. Boxing survives only inside the opt-in `PublishDynStack`, where the runtime-composed middleware list is the point and the per-layer boxed future is the documented cost.

Behavior is unchanged everywhere - same ordering, error flow, and middleware semantics - which the existing publish/middleware test suites pin (`publish_context` composition ordering, `router_publishing` stamping, `macro_subscriber` tagging, metrics counters). Migration for `PublishLayer` implementors is a signature-line change; bodies may now be plain `async fn` with no `Box::pin`. The `retry_after` fallback publisher inside `Delivery` stays erased: cold path, shared across tasks by design.

Note for merge ordering: touches `examples/publishing.rs` near the region #166 also edits; whichever merges second needs a trivial conflict resolution there.

Breaking for `PublishLayer` / `PublishPipeline` implementors (0.6). No version bump in this PR.

Fixes #175

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)