### PR TITLE
feat: expose a cloneable health probe on RunningApp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,10 +143,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -233,6 +256,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -367,13 +396,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -383,6 +424,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -471,6 +531,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -479,6 +540,20 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -488,12 +563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -530,10 +610,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -643,6 +743,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,10 +833,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -711,6 +907,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,9 +949,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -814,6 +1077,9 @@ dependencies = [
  "clap",
  "futures",
  "inventory",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus",
  "rmp-serde",
  "ruststream-macros",
@@ -826,6 +1092,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "trybuild",
 ]
@@ -1075,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1125,6 +1392,7 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -1146,6 +1414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1434,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -1199,6 +1479,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,9 +1534,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1271,6 +1602,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1634,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
@@ -1334,6 +1687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1717,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1389,6 +1796,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,10 +256,10 @@ serde_norway = { version = "0.9", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }
 inventory = { version = "0.3", optional = true }
-opentelemetry = { version = "0.32.0", default-features = false, features = ["trace", "metrics"], optional = true }
-opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "metrics", "rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace", "metrics"], optional = true }
-tracing-opentelemetry = { version = "0.33.0", optional = true }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace", "metrics"], optional = true }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "metrics", "rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "metrics"], optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -268,7 +268,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tempfile = "3"
 axum = "0.8"
 trybuild = "1"
-opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "metrics", "rt-tokio", "testing"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "metrics", "rt-tokio", "testing"] }
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,9 @@ macros = ["dep:ruststream-macros"]
 asyncapi = ["json", "dep:schemars", "dep:serde_norway"]
 metrics = ["dep:prometheus"]
 logging = ["dep:tracing-subscriber"]
-opentelemetry = []
 cli = ["dep:clap", "dep:anyhow"]
 testing = ["dep:inventory", "tokio/test-util"]
 otel = [
-    "opentelemetry",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ name = "macro_app"
 required-features = ["macros", "memory"]
 
 [[example]]
+name = "otel_export"
+required-features = ["otel", "macros", "memory", "json"]
+
+[[example]]
 name = "routed_service"
 path = "examples/routed_service/main.rs"
 required-features = ["macros", "memory", "json", "metrics", "asyncapi", "logging"]
@@ -221,6 +225,14 @@ logging = ["dep:tracing-subscriber"]
 opentelemetry = []
 cli = ["dep:clap", "dep:anyhow"]
 testing = ["dep:inventory", "tokio/test-util"]
+otel = [
+    "opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
+]
 
 [dependencies]
 bytes = "1"
@@ -246,6 +258,10 @@ serde_norway = { version = "0.9", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }
 inventory = { version = "0.3", optional = true }
+opentelemetry = { version = "0.32.0", default-features = false, features = ["trace", "metrics"], optional = true }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "metrics", "rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace", "metrics"], optional = true }
+tracing-opentelemetry = { version = "0.33.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -254,6 +270,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tempfile = "3"
 axum = "0.8"
 trybuild = "1"
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace", "metrics", "rt-tokio", "testing"] }
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/docs/guides/http.md
+++ b/docs/guides/http.md
@@ -29,6 +29,24 @@ is a plain value, safe to clone into whatever state the HTTP framework carries:
 --8<-- "examples/http_outbox.rs:wiring"
 ```
 
+## A healthz endpoint
+
+`start()` is the readiness gate; the health probe covers everything after it.
+`RunningApp::health()` hands out a cheap, cloneable `HealthProbe` backed by a watch channel:
+`state()` is a lock-free snapshot (`Running`, `ShuttingDown`, `Stopped`, or `Failed { reason }`
+carrying the fail-fast diagnostic), and the probe outlives `shutdown()`, so the route keeps
+answering with the terminal state. This closes the gap `stopping()` alone leaves: when the
+messaging side fail-fasts but a sibling task keeps the process alive, `/healthz` flips to 503
+instead of serving a permanent 200 for a dead consumer:
+
+```rust
+--8<-- "examples/http_outbox.rs:healthz"
+```
+
+The route carries its own state (`get(healthz).with_state(running.health())`), so it composes
+with whatever state the rest of the router holds - the full wiring above registers it beside
+`/orders`.
+
 The subscriber side is an ordinary handler; the same service consumes what its HTTP endpoints
 produce, and any other service subscribed to the broker sees the events too:
 

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -58,3 +58,8 @@ curl http://127.0.0.1:8080/metrics
 ```rust
 --8<-- "examples/metrics_http.rs"
 ```
+
+For services exporting through the `otel` feature instead, a ready-made Grafana dashboard over
+the full metrics inventory lives in
+[`ruststream-grafana`](https://github.com/powersemmi/ruststream-grafana); see the
+[OpenTelemetry guide](opentelemetry.md).

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,12 +1,12 @@
 # OpenTelemetry
 
-The `opentelemetry` feature gives a service distributed tracing: a trace flows from an incoming
+The `otel` feature gives a service distributed tracing: a trace flows from an incoming
 message onto the replies it produces, so one trace spans the whole consume-transform-produce chain.
 It is built on the typed publish-path context - the same seam that lets a publish transform read the
 delivery that produced a reply.
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "json", "opentelemetry"] }
+ruststream = { version = "0.5", features = ["macros", "memory", "json", "otel"] }
 ```
 
 It is dependency-light: it carries the [W3C Trace Context](https://www.w3.org/TR/trace-context/) and
@@ -55,7 +55,7 @@ check whether the trace is `sampled()`.
 
 The propagation module stops at the W3C context and `tracing` spans; there are two ways to ship
 them to a collector. Assemble `tracing-opentelemetry` and an exporter yourself in the binary (the
-same split as [logging](logging.md)) - or turn on the `otel` feature and let the crate do it.
+same split as [logging](logging.md)) - or let `Otel::init` below do it for you.
 
 ## The otel feature: SDK, OTLP, and the metrics inventory
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -83,8 +83,9 @@ The two middleware carry the dispatch metrics, labeled per handler
 | `ruststream.message.payload.size` | histogram (`By`) | published payload sizes |
 | `ruststream.app.state` | observable gauge | the lifecycle state, from [`RunningApp::health`](http.md#a-healthz-endpoint) via `otel.observe_health(running.health())` |
 
-Because `init()` installs the global providers, business metrics need no plumbing at all - a
-counter built anywhere in user code rides the same OTLP pipeline:
+Because `init()` installs the global providers, business metrics need no exporter plumbing:
+build the instrument once at startup against `global::meter(..)`, share it through the typed
+state (any field is injectable with `State<..>`), and it rides the same OTLP pipeline:
 
 ```rust
 --8<-- "examples/otel_export.rs:business_metric"

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -53,8 +53,52 @@ check whether the trace is `sampled()`.
 
 ## Exporting to a collector
 
-This crate stops at the W3C context and `tracing` spans; turning those into OTLP and shipping them to
-a collector is the binary's job, the same split as [logging](logging.md). Add
-`tracing-opentelemetry` and an exporter in your binary, install it as a `tracing` subscriber, and the
-`ruststream.consume` spans flow through it. The propagation layer keeps the trace linked across every
-broker hop regardless of which exporter you choose.
+The propagation module stops at the W3C context and `tracing` spans; there are two ways to ship
+them to a collector. Assemble `tracing-opentelemetry` and an exporter yourself in the binary (the
+same split as [logging](logging.md)) - or turn on the `otel` feature and let the crate do it.
+
+## The otel feature: SDK, OTLP, and the metrics inventory
+
+`Otel::builder().init()` builds the OTLP exporters, installs the OpenTelemetry tracer and meter
+providers as the process **globals**, and bridges `tracing` spans into them - so the spans the
+propagation layer already opens are exported with no further wiring:
+
+```rust
+--8<-- "examples/otel_export.rs:init"
+```
+
+The two middleware carry the dispatch metrics, labeled per handler
+(`messaging.destination.name`), following the messaging semantic conventions plus a
+`ruststream.*` namespace:
+
+| Instrument | Kind | What it measures |
+|---|---|---|
+| `messaging.client.consumed.messages` | counter | deliveries received |
+| `messaging.process.duration` | histogram (semconv buckets) | handler processing time |
+| `ruststream.messages.processed` | counter, `outcome` attribute | settlements: `ack`, `nack_requeue`, `nack_drop`, `retry_after` |
+| `ruststream.messages.in_flight` | up-down counter | deliveries inside handlers (pool saturation vs `workers(n)`) |
+| `ruststream.message.queue_time` | histogram | publish-to-handler-start lag, from the stamped publish-time header |
+| `messaging.client.sent.messages` | counter, `error.type` on failure | publishes |
+| `messaging.client.operation.duration` | histogram | the publish operation |
+| `ruststream.message.payload.size` | histogram (`By`) | published payload sizes |
+| `ruststream.app.state` | observable gauge | the lifecycle state, from [`RunningApp::health`](http.md#a-healthz-endpoint) via `otel.observe_health(running.health())` |
+
+Because `init()` installs the global providers, business metrics need no plumbing at all - a
+counter built anywhere in user code rides the same OTLP pipeline:
+
+```rust
+--8<-- "examples/otel_export.rs:business_metric"
+```
+
+A ready-made Grafana dashboard over exactly this inventory lives in
+[`ruststream-grafana`](https://github.com/powersemmi/ruststream-grafana): import
+`dashboards/ruststream.json`, point it at any Prometheus-compatible backend receiving the OTLP
+metrics, and the panels light up per handler; its README doubles as the metrics contract.
+
+Call `otel.shutdown()` at the end of `main`, after the app's graceful shutdown, to flush the last
+spans and points. To compose the span bridge into your own subscriber stack (for example with the
+`logging` feature's fmt layer), build with `.tracing_bridge(false)` and install the bridge
+yourself; `.messaging_system("kafka")` stamps the semconv system attribute the core cannot derive
+broker-agnostically. Decode failures, handler panics, and batch sizes are not covered by the
+middleware pair yet - they need dispatch-internal hooks and stay tracked in the integration
+issue.

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -84,8 +84,8 @@ The two middleware carry the dispatch metrics, labeled per handler
 | `ruststream.app.state` | observable gauge | the lifecycle state, from [`RunningApp::health`](http.md#a-healthz-endpoint) via `otel.observe_health(running.health())` |
 
 Because `init()` installs the global providers, business metrics need no exporter plumbing:
-build the instrument once at startup against `global::meter(..)`, share it through the typed
-state (any field is injectable with `State<..>`), and it rides the same OTLP pipeline:
+build the instruments once at startup into one storage object, share it through the typed state
+(injectable with `State<..>` via `FromRef`), and everything in it rides the same OTLP pipeline:
 
 ```rust
 --8<-- "examples/otel_export.rs:business_metric"

--- a/examples/http_outbox.rs
+++ b/examples/http_outbox.rs
@@ -17,11 +17,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::State;
-use axum::routing::post;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use ruststream::codec::{Codec, JsonCodec};
 use ruststream::memory::{MemoryBroker, MemoryPublisher};
-use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::runtime::{AppInfo, HandlerResult, HealthProbe, HealthState, RustStream};
 use ruststream::{OutgoingMessage, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -96,6 +97,17 @@ async fn relay_outbox(store: Arc<Mutex<Store>>, egress: MemoryPublisher) {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --8<-- [start:healthz]
+    /// The liveness endpoint: the probe outlives `shutdown`, so this route keeps answering with the
+    /// terminal state after the messaging side dies while the HTTP task keeps the process alive.
+    async fn healthz(State(health): State<HealthProbe>) -> (StatusCode, String) {
+        match health.state() {
+            HealthState::Running => (StatusCode::OK, "running".to_owned()),
+            state => (StatusCode::SERVICE_UNAVAILABLE, format!("{state:?}")),
+        }
+    }
+    // --8<-- [end:healthz]
+
     // --8<-- [start:wiring]
     let broker = MemoryBroker::new();
     // Taken from the broker before the app consumes it; resolves its connection on first use.
@@ -112,7 +124,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let router = Router::new()
         .route("/orders", post(place_order))
-        .with_state(store);
+        .with_state(store)
+        // The health probe is `Clone` and outlives the app handle; /healthz flips to 503 the
+        // moment the messaging side fail-fasts, even though the process stays up.
+        .route("/healthz", get(healthz).with_state(running.health()));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:8080").await?;
     println!("orders API on http://127.0.0.1:8080/orders");

--- a/examples/otel_export.rs
+++ b/examples/otel_export.rs
@@ -8,12 +8,15 @@
 //! to see the spans and metrics arrive; without one the exporter retries quietly in the
 //! background while the service keeps working.
 
+use std::convert::Infallible;
+
 use opentelemetry::KeyValue;
 use opentelemetry::global;
+use opentelemetry::metrics::Counter;
 use ruststream::memory::MemoryBroker;
 use ruststream::otel::Otel;
-use ruststream::runtime::{App, AppInfo, HandlerResult, RustStream};
-use ruststream::subscriber;
+use ruststream::runtime::{App, AppInfo, HandlerResult, RustStream, State};
+use ruststream::{FromRef, subscriber};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -23,13 +26,17 @@ struct Order {
 }
 
 // --8<-- [start:business_metric]
-/// Business metrics need no plumbing: `Otel::init` installed the global meter provider, so a
-/// counter built anywhere rides the same OTLP pipeline as the framework's dispatch metrics.
+/// Business instruments are built once at startup and shared through the typed state; any field
+/// is injectable with `State<..>` thanks to `FromRef`, and handlers only add. `Otel::init`
+/// installed the global meter provider, so the counter rides the same OTLP pipeline as the
+/// framework's dispatch metrics.
+#[derive(Clone, FromRef)]
+struct AppMetrics {
+    orders_accepted: Counter<u64>,
+}
+
 #[subscriber("orders")]
-async fn accept(order: &Order) -> HandlerResult {
-    let accepted = global::meter("orders-svc")
-        .u64_counter("orders_accepted")
-        .build();
+async fn accept(order: &Order, State(accepted): State<Counter<u64>>) -> HandlerResult {
     accepted.add(1, &[KeyValue::new("region", "eu")]);
     let _ = order;
     HandlerResult::Ack
@@ -54,6 +61,14 @@ fn app() -> impl App {
         .layer(otel.consume_layer())
         // per-publish metrics: sent, operation duration, payload size, queue-time stamp
         .publish_layer(otel.publish_layer())
+        // business instruments: built once against the global meter, shared as typed state
+        .on_startup(async move |()| {
+            Ok::<_, Infallible>(AppMetrics {
+                orders_accepted: global::meter("orders-svc")
+                    .u64_counter("orders_accepted")
+                    .build(),
+            })
+        })
         .with_broker(MemoryBroker::new(), |b| {
             b.include(accept);
         })

--- a/examples/otel_export.rs
+++ b/examples/otel_export.rs
@@ -26,18 +26,22 @@ struct Order {
 }
 
 // --8<-- [start:business_metric]
-/// Business instruments are built once at startup and shared through the typed state; any field
-/// is injectable with `State<..>` thanks to `FromRef`, and handlers only add. `Otel::init`
-/// installed the global meter provider, so the counter rides the same OTLP pipeline as the
+/// The service's business instruments: one storage object, built once at startup against the
+/// global meter `Otel::init` installed, so everything in it rides the same OTLP pipeline as the
 /// framework's dispatch metrics.
+#[derive(Clone)]
+struct OrderMetrics {
+    accepted: Counter<u64>,
+}
+
 #[derive(Clone, FromRef)]
-struct AppMetrics {
-    orders_accepted: Counter<u64>,
+struct AppState {
+    metrics: OrderMetrics,
 }
 
 #[subscriber("orders")]
-async fn accept(order: &Order, State(accepted): State<Counter<u64>>) -> HandlerResult {
-    accepted.add(1, &[KeyValue::new("region", "eu")]);
+async fn accept(order: &Order, State(metrics): State<OrderMetrics>) -> HandlerResult {
+    metrics.accepted.add(1, &[KeyValue::new("region", "eu")]);
     let _ = order;
     HandlerResult::Ack
 }
@@ -63,10 +67,12 @@ fn app() -> impl App {
         .publish_layer(otel.publish_layer())
         // business instruments: built once against the global meter, shared as typed state
         .on_startup(async move |()| {
-            Ok::<_, Infallible>(AppMetrics {
-                orders_accepted: global::meter("orders-svc")
-                    .u64_counter("orders_accepted")
-                    .build(),
+            Ok::<_, Infallible>(AppState {
+                metrics: OrderMetrics {
+                    accepted: global::meter("orders-svc")
+                        .u64_counter("orders_accepted")
+                        .build(),
+                },
             })
         })
         .with_broker(MemoryBroker::new(), |b| {

--- a/examples/otel_export.rs
+++ b/examples/otel_export.rs
@@ -1,0 +1,61 @@
+//! Export traces and metrics to an OpenTelemetry collector: the `otel` feature end to end.
+//!
+//! ```text
+//! cargo run --example otel_export --features otel,macros,memory,json -- run
+//! ```
+//!
+//! Point `otlp_endpoint` at a running collector (`docker run -p 4317:4317 otel/opentelemetry-collector`)
+//! to see the spans and metrics arrive; without one the exporter retries quietly in the
+//! background while the service keeps working.
+
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use ruststream::memory::MemoryBroker;
+use ruststream::otel::Otel;
+use ruststream::runtime::{App, AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Order {
+    #[allow(dead_code)] // Deserialized for schema realism; the example only counts orders.
+    id: u64,
+}
+
+// --8<-- [start:business_metric]
+/// Business metrics need no plumbing: `Otel::init` installed the global meter provider, so a
+/// counter built anywhere rides the same OTLP pipeline as the framework's dispatch metrics.
+#[subscriber("orders")]
+async fn accept(order: &Order) -> HandlerResult {
+    let accepted = global::meter("orders-svc")
+        .u64_counter("orders_accepted")
+        .build();
+    accepted.add(1, &[KeyValue::new("region", "eu")]);
+    let _ = order;
+    HandlerResult::Ack
+}
+// --8<-- [end:business_metric]
+
+// --8<-- [start:init]
+#[ruststream::app]
+fn app() -> impl App {
+    // Installs the global tracer + meter providers, the OTLP exporters, and the tracing bridge;
+    // every span the propagation module opens and every metric below now exports.
+    let otel = Otel::builder()
+        .service_name("orders-svc")
+        .otlp_endpoint("http://localhost:4317")
+        .messaging_system("memory")
+        .attribute("deployment.environment", "dev")
+        .init()
+        .expect("otel init failed");
+
+    RustStream::new(AppInfo::new("orders-svc", "0.1.0"))
+        // per-delivery metrics: consumed, process duration, outcomes, in-flight, queue time
+        .layer(otel.consume_layer())
+        // per-publish metrics: sent, operation duration, payload size, queue-time stamp
+        .publish_layer(otel.publish_layer())
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include(accept);
+        })
+}
+// --8<-- [end:init]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub mod metrics;
 #[cfg(feature = "logging")]
 pub mod logging;
 
-#[cfg(feature = "opentelemetry")]
+#[cfg(feature = "otel")]
 pub mod opentelemetry;
 #[cfg(feature = "otel")]
 pub mod otel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@ pub mod logging;
 
 #[cfg(feature = "opentelemetry")]
 pub mod opentelemetry;
+#[cfg(feature = "otel")]
+pub mod otel;
 
 /// Implementation detail used by the `#[subscriber]` macro to capture a payload's JSON Schema.
 ///

--- a/src/opentelemetry.rs
+++ b/src/opentelemetry.rs
@@ -1,4 +1,4 @@
-//! W3C Trace Context propagation and consumer spans (`opentelemetry` feature).
+//! W3C Trace Context propagation and consumer spans (part of the `otel` feature).
 //!
 //! Distributed tracing for a RustStream service, built on the publish-path context from the typed
 //! [`Context`](crate::runtime::Context) system: a trace / correlation id flows from an incoming
@@ -14,9 +14,10 @@
 //!   `traceparent` onto every reply. Reuse it on a batch publisher with
 //!   [`for_batch`](crate::runtime::for_batch).
 //!
-//! This module is dependency-light: it carries the W3C context and emits `tracing` spans, leaving
-//! the export to a collector to the binary's subscriber (for example `tracing-opentelemetry`),
-//! exactly as [`logging`](crate::logging) leaves the subscriber to the user. Propagation itself is
+//! This module is the propagation half of the story: it carries the W3C context and emits
+//! `tracing` spans. Export is the other half - [`Otel::init`](crate::otel::Otel::init) wires
+//! these spans into OTLP, or install your own subscriber, exactly as
+//! [`logging`](crate::logging) leaves the subscriber to the user. Propagation itself is
 //! broker-agnostic and works with no subscriber at all.
 //!
 //! # Examples

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,564 @@
+//! OpenTelemetry SDK integration (`otel` feature): OTLP export for traces and metrics, messaging
+//! semantic conventions, and per-handler dispatch metrics.
+//!
+//! The dependency-free [`opentelemetry`](crate::opentelemetry) module stays the default: it
+//! carries the W3C trace context and emits plain `tracing` spans, leaving export to the binary.
+//! This module is the opt-in next step for services standardizing on OTLP collectors:
+//! [`Otel::init`] installs the OpenTelemetry tracer and meter providers as the process **globals**
+//! and bridges `tracing` spans into them, so the spans the propagation module already opens are
+//! exported without further wiring - and user-defined business metrics need no plumbing at all:
+//! `opentelemetry::global::meter("my-svc").u64_counter("orders_accepted").build()` rides the same
+//! pipeline.
+//!
+//! Two middleware carry the dispatch metrics, following the OpenTelemetry messaging semantic
+//! conventions plus a `ruststream.*` namespace for what the conventions do not cover:
+//!
+//! - [`Otel::consume_layer`] - per delivery: `messaging.client.consumed.messages`,
+//!   `messaging.process.duration`, `ruststream.messages.processed` (by settlement outcome),
+//!   `ruststream.messages.in_flight`, and `ruststream.message.queue_time` when the delivery
+//!   carries a publish timestamp.
+//! - [`Otel::publish_layer`] - per publish: `messaging.client.sent.messages`,
+//!   `messaging.client.operation.duration`, `ruststream.message.payload.size`, and the
+//!   [`PUBLISH_TIME_HEADER`] stamp the consume side turns into queue time.
+//!
+//! Metrics that need dispatch internals (decode failures, handler panics, batch sizes) are not
+//! covered by the middleware pair yet; they are tracked in the integration issue.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "memory", feature = "json"))]
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use ruststream::memory::MemoryBroker;
+//! use ruststream::otel::Otel;
+//! use ruststream::runtime::{AppInfo, RustStream};
+//!
+//! let otel = Otel::builder()
+//!     .service_name("orders-svc")
+//!     .otlp_endpoint("http://collector:4317")
+//!     .messaging_system("memory")
+//!     .init()?;
+//!
+//! let app = RustStream::new(AppInfo::new("orders-svc", "0.1.0"))
+//!     .layer(otel.consume_layer())
+//!     .publish_layer(otel.publish_layer())
+//!     .with_broker(MemoryBroker::new(), |b| { /* handlers */ });
+//! let running = app.start().await?;
+//! otel.observe_health(running.health());
+//! # let _ = running;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider as _, UpDownCounter};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{KeyValue, global};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use thiserror::Error;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::Headers;
+use crate::runtime::{
+    BlanketLayer, Context, Handler, HandlerResult, HealthProbe, HealthState, Layer, Outgoing,
+    PublishLayer, PublishNext, PublishPipeline, Settle,
+};
+
+/// Header carrying the publish wall-clock time (unix milliseconds, ASCII decimal).
+///
+/// Stamped by [`Otel::publish_layer`]; the consume side turns it into the
+/// `ruststream.message.queue_time` histogram, a broker-agnostic consumer-lag proxy. Deliveries
+/// without the header (foreign producers) simply record no queue time.
+pub const PUBLISH_TIME_HEADER: &str = "x-ruststream-published-at";
+
+/// The advisory bucket boundaries the messaging semantic conventions prescribe for duration
+/// histograms, in seconds.
+const SEMCONV_DURATION_BUCKETS: [f64; 14] = [
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
+/// An error from [`OtelBuilder::init`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum OtelInitError {
+    /// Building an OTLP exporter failed (bad endpoint, TLS configuration).
+    #[error("failed to build the OTLP exporter")]
+    Exporter(#[from] opentelemetry_otlp::ExporterBuildError),
+    /// A global `tracing` subscriber was already installed, so the span bridge cannot be.
+    ///
+    /// Install the bridge into your own subscriber stack instead, or build with
+    /// [`tracing_bridge(false)`](OtelBuilder::tracing_bridge).
+    #[error("a tracing subscriber is already installed")]
+    TracingInit(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+/// Builder for [`Otel`]; obtained from [`Otel::builder`].
+#[derive(Debug, Default)]
+#[must_use]
+pub struct OtelBuilder {
+    service_name: Option<String>,
+    endpoint: Option<String>,
+    messaging_system: Option<String>,
+    attributes: Vec<KeyValue>,
+    tracing_bridge: bool,
+    stamp_publish_time: bool,
+}
+
+impl OtelBuilder {
+    fn new() -> Self {
+        Self {
+            tracing_bridge: true,
+            stamp_publish_time: true,
+            ..Self::default()
+        }
+    }
+
+    /// The `service.name` resource attribute every exported span and metric carries.
+    pub fn service_name(mut self, name: impl Into<String>) -> Self {
+        self.service_name = Some(name.into());
+        self
+    }
+
+    /// The OTLP/gRPC endpoint. When not set, the exporter falls back to its standard
+    /// environment configuration (`OTEL_EXPORTER_OTLP_ENDPOINT`, default `localhost:4317`).
+    pub fn otlp_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// The `messaging.system` attribute stamped on every dispatch metric (for example `kafka`,
+    /// `rabbitmq`, `nats`, `memory`). The core cannot derive it broker-agnostically, so it is
+    /// omitted when not set.
+    pub fn messaging_system(mut self, system: impl Into<String>) -> Self {
+        self.messaging_system = Some(system.into());
+        self
+    }
+
+    /// An extra resource attribute (team, environment, region).
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes
+            .push(KeyValue::new(key.into(), value.into()));
+        self
+    }
+
+    /// Whether [`init`](Self::init) installs a global `tracing` subscriber bridging spans into
+    /// OpenTelemetry (default `true`). Disable to compose the bridge into your own subscriber
+    /// stack (for example together with the [`logging`](crate::logging) feature's fmt layer).
+    pub const fn tracing_bridge(mut self, enabled: bool) -> Self {
+        self.tracing_bridge = enabled;
+        self
+    }
+
+    /// Whether [`Otel::publish_layer`] stamps [`PUBLISH_TIME_HEADER`] onto outgoing messages
+    /// (default `true`), which is what feeds the consume side's queue-time histogram.
+    pub const fn stamp_publish_time(mut self, enabled: bool) -> Self {
+        self.stamp_publish_time = enabled;
+        self
+    }
+
+    /// Builds the OTLP exporters, installs the tracer and meter providers as the OpenTelemetry
+    /// **globals**, and (unless disabled) installs the `tracing` span bridge.
+    ///
+    /// Installing the globals is what lets business metrics ride the same pipeline with no
+    /// plumbing: `opentelemetry::global::meter(..)` anywhere in user code reaches the provider
+    /// this call configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OtelInitError::Exporter`] when an OTLP exporter cannot be built, and
+    /// [`OtelInitError::TracingInit`] when the span bridge is enabled but a global `tracing`
+    /// subscriber is already installed.
+    pub fn init(self) -> Result<Otel, OtelInitError> {
+        let mut resource = Resource::builder();
+        if let Some(name) = &self.service_name {
+            resource = resource.with_service_name(name.clone());
+        }
+        let resource = resource.with_attributes(self.attributes.clone()).build();
+
+        let mut span_exporter = opentelemetry_otlp::SpanExporter::builder().with_tonic();
+        let mut metric_exporter = opentelemetry_otlp::MetricExporter::builder().with_tonic();
+        if let Some(endpoint) = &self.endpoint {
+            span_exporter = span_exporter.with_endpoint(endpoint.clone());
+            metric_exporter = metric_exporter.with_endpoint(endpoint.clone());
+        }
+
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter.build()?)
+            .with_resource(resource.clone())
+            .build();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.build()?)
+            .with_resource(resource)
+            .build();
+
+        if self.tracing_bridge {
+            let bridge =
+                tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("ruststream"));
+            tracing_subscriber::registry()
+                .with(bridge)
+                .try_init()
+                .map_err(|err| OtelInitError::TracingInit(err.into()))?;
+        }
+
+        global::set_tracer_provider(tracer_provider.clone());
+        global::set_meter_provider(meter_provider.clone());
+
+        Ok(self.attach(tracer_provider, meter_provider))
+    }
+
+    /// Attaches to caller-built providers without touching the process globals or installing a
+    /// `tracing` subscriber: the bring-your-own-exporter path (a custom pipeline, an in-memory
+    /// exporter in tests).
+    #[must_use]
+    pub fn attach(
+        self,
+        tracer_provider: SdkTracerProvider,
+        meter_provider: SdkMeterProvider,
+    ) -> Otel {
+        let meter = meter_provider.meter("ruststream");
+        Otel {
+            instruments: Arc::new(Instruments::new(&meter, self.messaging_system.clone())),
+            stamp_publish_time: self.stamp_publish_time,
+            meter,
+            tracer_provider,
+            meter_provider,
+        }
+    }
+}
+
+/// The installed OpenTelemetry integration: hands out the dispatch middleware and owns the
+/// providers for the final flush.
+///
+/// Built with [`Otel::builder`]. Dropping it does not flush; call [`shutdown`](Self::shutdown)
+/// at the end of `main`.
+#[derive(Clone)]
+pub struct Otel {
+    instruments: Arc<Instruments>,
+    stamp_publish_time: bool,
+    meter: Meter,
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+}
+
+impl std::fmt::Debug for Otel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Otel").finish_non_exhaustive()
+    }
+}
+
+impl Otel {
+    /// Starts configuring the integration.
+    pub fn builder() -> OtelBuilder {
+        OtelBuilder::new()
+    }
+
+    /// A consume-side [`Layer`] recording the per-delivery metrics; add it with
+    /// [`RustStream::layer`](crate::runtime::RustStream::layer). Pair it with
+    /// [`OpenTelemetry::consume_layer`](crate::opentelemetry::OpenTelemetry::consume_layer) for
+    /// the trace-context propagation half.
+    #[must_use]
+    pub fn consume_layer(&self) -> OtelConsumeLayer {
+        OtelConsumeLayer {
+            instruments: Arc::clone(&self.instruments),
+        }
+    }
+
+    /// A publish-side middleware recording the per-publish metrics (and stamping the queue-time
+    /// header unless disabled); add it with
+    /// [`RustStream::publish_layer`](crate::runtime::RustStream::publish_layer).
+    #[must_use]
+    pub fn publish_layer(&self) -> OtelPublishLayer {
+        OtelPublishLayer {
+            instruments: Arc::clone(&self.instruments),
+            stamp_publish_time: self.stamp_publish_time,
+        }
+    }
+
+    /// Registers the `ruststream.app.state` gauge over a [`HealthProbe`]: each lifecycle state
+    /// is reported as 0/1 under a `state` attribute, so dashboards see startup, running, and
+    /// failure alongside the traffic metrics.
+    pub fn observe_health(&self, probe: HealthProbe) {
+        let _gauge = self
+            .meter
+            .u64_observable_gauge("ruststream.app.state")
+            .with_description("The service lifecycle state, 0/1 per state attribute.")
+            .with_callback(move |observer| {
+                let current = probe.state();
+                let flags = [
+                    ("running", current.is_running()),
+                    (
+                        "shutting_down",
+                        matches!(current, HealthState::ShuttingDown),
+                    ),
+                    ("stopped", matches!(current, HealthState::Stopped)),
+                    ("failed", matches!(current, HealthState::Failed { .. })),
+                ];
+                for (name, active) in flags {
+                    observer.observe(u64::from(active), &[KeyValue::new("state", name)]);
+                }
+            })
+            .build();
+    }
+
+    /// Flushes and shuts the providers down. Call at the end of `main`, after the app's own
+    /// graceful shutdown, so the last spans and metric points reach the collector.
+    ///
+    /// # Errors
+    ///
+    /// Returns the SDK error when a provider fails to flush or shut down.
+    pub fn shutdown(self) -> Result<(), OTelSdkError> {
+        self.tracer_provider.shutdown()?;
+        self.meter_provider.shutdown()
+    }
+}
+
+/// The dispatch instruments, shared by both middleware.
+struct Instruments {
+    system: Option<KeyValue>,
+    consumed: Counter<u64>,
+    process_duration: Histogram<f64>,
+    processed: Counter<u64>,
+    in_flight: UpDownCounter<i64>,
+    queue_time: Histogram<f64>,
+    sent: Counter<u64>,
+    operation_duration: Histogram<f64>,
+    payload_size: Histogram<u64>,
+}
+
+impl Instruments {
+    fn new(meter: &Meter, system: Option<String>) -> Self {
+        Self {
+            system: system.map(|s| KeyValue::new("messaging.system", s)),
+            consumed: meter
+                .u64_counter("messaging.client.consumed.messages")
+                .with_unit("{message}")
+                .with_description("Deliveries received, per handler.")
+                .build(),
+            process_duration: meter
+                .f64_histogram("messaging.process.duration")
+                .with_unit("s")
+                .with_boundaries(SEMCONV_DURATION_BUCKETS.to_vec())
+                .with_description("Handler processing time, per handler.")
+                .build(),
+            processed: meter
+                .u64_counter("ruststream.messages.processed")
+                .with_unit("{message}")
+                .with_description("Settled deliveries by outcome, per handler.")
+                .build(),
+            in_flight: meter
+                .i64_up_down_counter("ruststream.messages.in_flight")
+                .with_unit("{message}")
+                .with_description("Deliveries currently inside handlers, per handler.")
+                .build(),
+            queue_time: meter
+                .f64_histogram("ruststream.message.queue_time")
+                .with_unit("s")
+                .with_description(
+                    "Time from publish to handler start, where the publish stamped its \
+                     timestamp header.",
+                )
+                .build(),
+            sent: meter
+                .u64_counter("messaging.client.sent.messages")
+                .with_unit("{message}")
+                .with_description("Messages published, split by error.type on failures.")
+                .build(),
+            operation_duration: meter
+                .f64_histogram("messaging.client.operation.duration")
+                .with_unit("s")
+                .with_boundaries(SEMCONV_DURATION_BUCKETS.to_vec())
+                .with_description("Duration of the publish operation.")
+                .build(),
+            payload_size: meter
+                .u64_histogram("ruststream.message.payload.size")
+                .with_unit("By")
+                .with_description("Published payload sizes (direction attribute).")
+                .build(),
+        }
+    }
+
+    /// The shared attribute set: destination plus, when configured, the messaging system.
+    fn attrs(&self, destination: &str, extra: Option<KeyValue>) -> Vec<KeyValue> {
+        let mut attrs = Vec::with_capacity(3);
+        attrs.push(KeyValue::new(
+            "messaging.destination.name",
+            destination.to_owned(),
+        ));
+        if let Some(system) = &self.system {
+            attrs.push(system.clone());
+        }
+        if let Some(extra) = extra {
+            attrs.push(extra);
+        }
+        attrs
+    }
+}
+
+/// Maps a settlement outcome onto the `outcome` attribute of `ruststream.messages.processed`.
+const fn outcome_attr(result: HandlerResult) -> &'static str {
+    match result {
+        HandlerResult::Ack => "ack",
+        HandlerResult::Nack { requeue: true } => "nack_requeue",
+        HandlerResult::Nack { requeue: false } => "nack_drop",
+        HandlerResult::NackAfter { .. } => "retry_after",
+    }
+}
+
+/// Parses the publish timestamp header into the queue time relative to now, if present and sane.
+fn queue_time_seconds(headers: &Headers) -> Option<f64> {
+    let stamped: u128 = headers.get_str(PUBLISH_TIME_HEADER)?.parse().ok()?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    let elapsed_millis = now.checked_sub(stamped)?;
+    #[allow(clippy::cast_precision_loss)] // Millisecond spans fit f64 comfortably.
+    Some(elapsed_millis as f64 / 1000.0)
+}
+
+/// The [`Layer`] handed out by [`Otel::consume_layer`].
+#[derive(Clone)]
+pub struct OtelConsumeLayer {
+    instruments: Arc<Instruments>,
+}
+
+impl std::fmt::Debug for OtelConsumeLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OtelConsumeLayer").finish_non_exhaustive()
+    }
+}
+
+impl<H> Layer<H> for OtelConsumeLayer {
+    type Handler = OtelConsumeHandler<H>;
+
+    fn layer(&self, inner: H) -> Self::Handler {
+        OtelConsumeHandler {
+            inner,
+            instruments: Arc::clone(&self.instruments),
+        }
+    }
+}
+
+impl BlanketLayer for OtelConsumeLayer {
+    fn apply<M, C, S, H>(&self, handler: H) -> impl Handler<M, C, S> + 'static
+    where
+        M: Send + Sync + 'static,
+        C: Send + 'static,
+        S: Send + Sync + 'static,
+        H: Handler<M, C, S> + 'static,
+    {
+        self.layer(handler)
+    }
+}
+
+/// The handler wrapper produced by [`OtelConsumeLayer`].
+#[derive(Clone)]
+pub struct OtelConsumeHandler<H> {
+    inner: H,
+    instruments: Arc<Instruments>,
+}
+
+impl<H> std::fmt::Debug for OtelConsumeHandler<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OtelConsumeHandler").finish_non_exhaustive()
+    }
+}
+
+impl<M, C, S, H> Handler<M, C, S> for OtelConsumeHandler<H>
+where
+    M: Sync,
+    C: Send,
+    S: Send + Sync,
+    H: Handler<M, C, S>,
+{
+    fn handle(&self, msg: &M, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Settle> + Send {
+        let name = ctx.name().to_owned();
+        let queue_time = queue_time_seconds(ctx.headers());
+        async move {
+            let instruments = &self.instruments;
+            let attrs = instruments.attrs(&name, None);
+            instruments.consumed.add(1, &attrs);
+            if let Some(seconds) = queue_time {
+                instruments.queue_time.record(seconds, &attrs);
+            }
+            instruments.in_flight.add(1, &attrs);
+            let started = Instant::now();
+            let settle = self.inner.handle(msg, ctx).await;
+            instruments
+                .process_duration
+                .record(started.elapsed().as_secs_f64(), &attrs);
+            instruments.in_flight.add(-1, &attrs);
+            instruments.processed.add(
+                1,
+                &instruments.attrs(
+                    &name,
+                    Some(KeyValue::new("outcome", outcome_attr(settle.outcome()))),
+                ),
+            );
+            settle
+        }
+    }
+}
+
+/// The publish middleware handed out by [`Otel::publish_layer`].
+#[derive(Clone)]
+pub struct OtelPublishLayer {
+    instruments: Arc<Instruments>,
+    stamp_publish_time: bool,
+}
+
+impl std::fmt::Debug for OtelPublishLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OtelPublishLayer").finish_non_exhaustive()
+    }
+}
+
+impl PublishLayer for OtelPublishLayer {
+    fn on_publish<'a, N: PublishPipeline>(
+        &'a self,
+        out: &'a mut Outgoing<'a>,
+        next: PublishNext<'a, N>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>,
+    > {
+        if self.stamp_publish_time {
+            if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
+                out.headers_mut()
+                    .insert(PUBLISH_TIME_HEADER, now.as_millis().to_string());
+            }
+        }
+        let name = out.name().to_owned();
+        #[allow(clippy::cast_possible_truncation)] // Payloads beyond u64 bytes do not exist.
+        let payload_bytes = out.payload().len() as u64;
+        Box::pin(async move {
+            let instruments = &self.instruments;
+            let attrs = instruments.attrs(&name, None);
+            instruments.payload_size.record(
+                payload_bytes,
+                &instruments.attrs(&name, Some(KeyValue::new("direction", "publish"))),
+            );
+            let started = Instant::now();
+            let result = next.run(out).await;
+            instruments
+                .operation_duration
+                .record(started.elapsed().as_secs_f64(), &attrs);
+            let sent_attrs = match &result {
+                Ok(()) => attrs,
+                Err(err) => {
+                    instruments.attrs(&name, Some(KeyValue::new("error.type", err.to_string())))
+                }
+            };
+            instruments.sent.add(1, &sent_attrs);
+            result
+        })
+    }
+}

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,9 +1,8 @@
 //! OpenTelemetry SDK integration (`otel` feature): OTLP export for traces and metrics, messaging
 //! semantic conventions, and per-handler dispatch metrics.
 //!
-//! The dependency-free [`opentelemetry`](crate::opentelemetry) module stays the default: it
-//! carries the W3C trace context and emits plain `tracing` spans, leaving export to the binary.
-//! This module is the opt-in next step for services standardizing on OTLP collectors:
+//! The [`opentelemetry`](crate::opentelemetry) module is the propagation half: it carries the
+//! W3C trace context and emits plain `tracing` spans. This module is the export half:
 //! [`Otel::init`] installs the OpenTelemetry tracer and meter providers as the process **globals**
 //! and bridges `tracing` spans into them, so the spans the propagation module already opens are
 //! exported without further wiring - and user-defined business metrics need no plumbing at all:

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -561,3 +561,104 @@ impl PublishLayer for OtelPublishLayer {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_attr_names_every_settlement() {
+        assert_eq!(outcome_attr(HandlerResult::Ack), "ack");
+        assert_eq!(
+            outcome_attr(HandlerResult::Nack { requeue: true }),
+            "nack_requeue"
+        );
+        assert_eq!(
+            outcome_attr(HandlerResult::Nack { requeue: false }),
+            "nack_drop"
+        );
+        assert_eq!(
+            outcome_attr(HandlerResult::retry_after(std::time::Duration::from_secs(
+                1
+            ))),
+            "retry_after"
+        );
+    }
+
+    #[cfg(feature = "json")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publish_layer_splits_failures_by_error_type() {
+        use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+
+        use crate::codec::JsonCodec;
+        use crate::runtime::{PublishContext, PublishIdentity, PublishStack, TypedPublisher};
+
+        /// A publisher with no broker behind it: every publish fails.
+        struct Failing;
+        impl crate::Publisher for Failing {
+            type Error = std::io::Error;
+            async fn publish(&self, _msg: crate::OutgoingMessage<'_>) -> Result<(), Self::Error> {
+                Err(std::io::Error::other("no broker"))
+            }
+        }
+
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let otel = Otel::builder().attach(SdkTracerProvider::builder().build(), provider.clone());
+
+        let pipeline = PublishStack::new(otel.publish_layer(), PublishIdentity);
+        let publisher = TypedPublisher::with_codec(Failing, JsonCodec);
+        let headers = Headers::new();
+        let cx = PublishContext::new("orders", &headers, &());
+        let result = publisher.publish("orders", &7_u32, &pipeline, &cx).await;
+        assert!(
+            result.is_err(),
+            "the failing publisher must surface its error"
+        );
+
+        provider.force_flush().expect("flush failed");
+        let recorded: Vec<String> = exporter
+            .get_finished_metrics()
+            .expect("exporter drained")
+            .iter()
+            .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .map(|metric| metric.name().to_owned())
+            .collect();
+        assert!(
+            recorded
+                .iter()
+                .any(|name| name == "messaging.client.sent.messages"),
+            "the failed publish must still count as sent (split by error.type): {recorded:?}",
+        );
+    }
+
+    #[test]
+    fn queue_time_ignores_absent_garbage_and_future_stamps() {
+        let empty = Headers::new();
+        assert_eq!(queue_time_seconds(&empty), None);
+
+        let mut garbage = Headers::new();
+        garbage.insert(PUBLISH_TIME_HEADER, "not-a-number");
+        assert_eq!(queue_time_seconds(&garbage), None);
+
+        // A stamp from the future would need a negative duration; it is dropped instead.
+        let mut future = Headers::new();
+        future.insert(PUBLISH_TIME_HEADER, u128::MAX.to_string());
+        assert_eq!(queue_time_seconds(&future), None);
+
+        let mut sane = Headers::new();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        sane.insert(PUBLISH_TIME_HEADER, (now - 1_500).to_string());
+        let seconds = queue_time_seconds(&sane).expect("a past stamp must produce a queue time");
+        assert!(
+            seconds >= 1.0,
+            "expected at least a second of lag, got {seconds}"
+        );
+    }
+}

--- a/src/runtime/app/health.rs
+++ b/src/runtime/app/health.rs
@@ -1,0 +1,102 @@
+//! The [`HealthProbe`]: a cloneable, watch-backed view of the running service's lifecycle state.
+//!
+//! The standard deployment shape runs the messaging service beside another tokio task - typically
+//! an HTTP server with a `/healthz` route. When the service fail-fasts, the process stays alive
+//! because of that sibling task, and the probe is what lets its endpoint report "the app died,
+//! stop routing traffic here" instead of a permanent 200.
+
+use std::future::pending;
+
+use tokio::sync::watch;
+
+/// The lifecycle state reported by a [`HealthProbe`].
+///
+/// [`RustStream::start`](super::RustStream::start) is the readiness gate (it resolves only after
+/// subscriptions are open), so the probe covers the post-startup half of the lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HealthState {
+    /// Subscriptions are open and the dispatch loops are running.
+    Running,
+    /// An orderly [`shutdown`](super::RunningApp::shutdown) is in progress.
+    ShuttingDown,
+    /// The service shut down cleanly.
+    Stopped,
+    /// The service tore itself down on a fail-fast failure, or teardown itself failed.
+    Failed {
+        /// The diagnostic the fail-fast path recorded (subscription and cause), the same string
+        /// [`run`](super::RustStream::run) returns inside
+        /// [`RustStreamError::Dispatch`](super::RustStreamError::Dispatch).
+        reason: String,
+    },
+}
+
+impl HealthState {
+    /// Whether the state reports a live, dispatching service.
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+/// A cheap, cloneable handle reporting the service's [`HealthState`].
+///
+/// Obtained from [`RunningApp::health`](super::RunningApp::health); backed by a
+/// [`watch`](tokio::sync::watch) channel written only on lifecycle transitions, so reading is a
+/// lock-free borrow and nothing runs on the per-delivery hot path. The probe outlives
+/// [`shutdown`](super::RunningApp::shutdown) (which consumes the app handle), so a sibling HTTP
+/// task keeps answering with the terminal state.
+///
+/// Watch semantics: observers always see the latest state; rapid transitions (`ShuttingDown`
+/// immediately followed by `Stopped`) may coalesce, so poll [`state`](Self::state) for snapshots
+/// and use [`changed`](Self::changed) only as a wake-up.
+///
+/// Dropping the [`RunningApp`](super::RunningApp) without calling `shutdown` detaches the service
+/// (per the crate rule that destructors never block); a probe then keeps reporting the last
+/// observed state, and [`changed`](Self::changed) resolves only if a fail-fast failure still
+/// flips the state.
+#[derive(Debug, Clone)]
+pub struct HealthProbe {
+    rx: watch::Receiver<HealthState>,
+}
+
+impl HealthProbe {
+    pub(super) fn new(rx: watch::Receiver<HealthState>) -> Self {
+        Self { rx }
+    }
+
+    /// A snapshot of the current state.
+    #[must_use]
+    pub fn state(&self) -> HealthState {
+        self.rx.borrow().clone()
+    }
+
+    /// Whether the service is currently running (the healthy answer for a liveness endpoint).
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        self.rx.borrow().is_running()
+    }
+
+    /// Waits for the next state transition and returns the new state.
+    ///
+    /// If the service was detached (the app handle dropped without `shutdown`) and no further
+    /// transition can arrive, the future stays pending forever rather than spinning the caller's
+    /// loop; pair it with [`state`](Self::state) when a snapshot is enough.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe: dropping the future loses nothing; a fresh call observes the same channel.
+    pub async fn changed(&mut self) -> HealthState {
+        if self.rx.changed().await.is_ok() {
+            return self.state();
+        }
+        // The sender is gone without a final transition: the state is final, park forever.
+        pending().await
+    }
+}
+
+/// The write half the running app and its fail-fast watcher drive; probes are subscribed off it,
+/// so the public surface stays read-only.
+pub(super) fn channel() -> watch::Sender<HealthState> {
+    watch::channel(HealthState::Running).0
+}

--- a/src/runtime/app/mod.rs
+++ b/src/runtime/app/mod.rs
@@ -2,12 +2,14 @@
 //! service.
 
 mod app_trait;
+mod health;
 mod include;
 mod run;
 mod scope;
 mod service;
 
 pub use app_trait::App;
+pub use health::{HealthProbe, HealthState};
 pub use run::RunningApp;
 pub use scope::BrokerScope;
 pub use service::RustStream;

--- a/src/runtime/app/run.rs
+++ b/src/runtime/app/run.rs
@@ -6,6 +6,7 @@ use std::{future::Future, sync::Arc, time::Duration};
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
 
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -14,6 +15,7 @@ use tracing::{debug, info, warn};
 use crate::runtime::failure::ErrorShutdown;
 use crate::runtime::lifecycle::{BoxError, BoxFuture};
 
+use super::health::{self, HealthProbe, HealthState};
 use super::service::RegisteredBroker;
 use super::{LifecycleHook, RustStream, RustStreamError};
 
@@ -176,6 +178,22 @@ impl<L: Send, St: Send + Sync + 'static, PP> RustStream<L, St, PP> {
 
         info!(target: "ruststream::lifecycle", subscribers = handles.len(), "service running");
 
+        let health = health::channel();
+        // The watcher flips the probe on a fail-fast teardown even when nobody ever calls
+        // `shutdown`: the process may stay alive serving healthz from a sibling task, which is
+        // exactly when the probe matters.
+        {
+            let health = health.clone();
+            let error_shutdown = error_shutdown.clone();
+            let token = token.clone();
+            tokio::spawn(async move {
+                token.cancelled().await;
+                if let Some(reason) = error_shutdown.peek_failure() {
+                    let _ = health.send(HealthState::Failed { reason });
+                }
+            });
+        }
+
         Ok(RunningApp {
             token,
             error_shutdown,
@@ -185,6 +203,7 @@ impl<L: Send, St: Send + Sync + 'static, PP> RustStream<L, St, PP> {
             brokers,
             shutdown_timeout,
             continuations,
+            health,
         })
     }
 }
@@ -220,6 +239,7 @@ pub struct RunningApp {
     brokers: Vec<RegisteredBroker>,
     shutdown_timeout: Option<Duration>,
     continuations: TaskTracker,
+    health: watch::Sender<HealthState>,
 }
 
 impl fmt::Debug for RunningApp {
@@ -248,6 +268,37 @@ impl RunningApp {
         self.token.clone().cancelled_owned()
     }
 
+    /// Hands out a [`HealthProbe`]: a cheap, cloneable view of the service's lifecycle state for
+    /// a sibling task (typically an HTTP healthz endpoint).
+    ///
+    /// The probe outlives [`shutdown`](Self::shutdown) and keeps reporting the terminal state
+    /// ([`HealthState::Stopped`], or [`HealthState::Failed`] with the fail-fast diagnostic), so
+    /// an orchestrator stops routing traffic to a process whose messaging side died while
+    /// another task keeps the process alive.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "memory")]
+    /// # async fn run() -> Result<(), ruststream::runtime::RustStreamError> {
+    /// use ruststream::memory::MemoryBroker;
+    /// use ruststream::runtime::{AppInfo, HealthState, RustStream};
+    ///
+    /// let app = RustStream::new(AppInfo::new("svc", "0.1.0")).register_broker(MemoryBroker::new());
+    /// let running = app.start().await?;
+    /// let health = running.health();
+    /// assert!(health.is_running());
+    /// // hand `health` to the HTTP task's /healthz route, then later:
+    /// running.shutdown().await?;
+    /// assert_eq!(health.state(), HealthState::Stopped);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn health(&self) -> HealthProbe {
+        HealthProbe::new(self.health.subscribe())
+    }
+
     /// Shuts the service down gracefully.
     ///
     /// Runs the `on_shutdown` hooks, stops the dispatch loops, drains in-flight handlers and
@@ -269,50 +320,89 @@ impl RunningApp {
             brokers,
             shutdown_timeout,
             continuations,
+            health,
         } = self;
 
-        for hook in on_shutdown {
-            if let Err(err) = hook().await {
-                warn!(target: "ruststream::lifecycle", error = %err, "on_shutdown hook failed");
+        let _ = health.send(HealthState::ShuttingDown);
+        let outcome = teardown(
+            token,
+            handles,
+            on_shutdown,
+            after_shutdown,
+            brokers,
+            shutdown_timeout,
+            continuations,
+        )
+        .await;
+        match outcome {
+            Ok(()) => {
+                // A fail-fast failure tore the service down: surface it so an orchestrator
+                // restarts the service and the operator sees a non-zero exit, not a silent stop.
+                if let Some(reason) = error_shutdown.taken_failure() {
+                    let _ = health.send(HealthState::Failed {
+                        reason: reason.clone(),
+                    });
+                    return Err(RustStreamError::Dispatch(reason));
+                }
+                let _ = health.send(HealthState::Stopped);
+                Ok(())
+            }
+            Err(err) => {
+                let _ = health.send(HealthState::Failed {
+                    reason: err.to_string(),
+                });
+                Err(err)
             }
         }
-
-        token.cancel();
-        debug!(target: "ruststream::lifecycle", "draining in-flight handlers");
-        drain_handles(handles, shutdown_timeout).await?;
-
-        // Handlers have stopped, so no new post-settle continuations can be spawned: close the
-        // tracker and drain the in-flight ones, bounded by the same shutdown timeout. They are
-        // at-most-once, so timing one out only abandons follow-up work, never a settlement.
-        drain_continuations(continuations, shutdown_timeout).await;
-
-        for broker in brokers.iter().rev() {
-            broker
-                .lifecycle
-                .shutdown()
-                .await
-                .map_err(RustStreamError::Shutdown)?;
-            debug!(
-                target: "ruststream::lifecycle",
-                broker = broker.label.as_deref().unwrap_or_else(|| broker.lifecycle.name()),
-                "broker shut down",
-            );
-        }
-
-        for hook in after_shutdown {
-            if let Err(err) = hook().await {
-                warn!(target: "ruststream::lifecycle", error = %err, "after_shutdown hook failed");
-            }
-        }
-        info!(target: "ruststream::lifecycle", "service stopped");
-
-        // A fail-fast failure tore the service down: surface it so an orchestrator restarts the
-        // service and the operator sees a non-zero exit, not a silent stop.
-        if let Some(reason) = error_shutdown.taken_failure() {
-            return Err(RustStreamError::Dispatch(reason));
-        }
-        Ok(())
     }
+}
+
+/// The fallible half of the graceful teardown, factored out so [`RunningApp::shutdown`] can map
+/// its outcome onto the health probe's terminal state in one place.
+async fn teardown(
+    token: CancellationToken,
+    handles: Vec<JoinHandle<()>>,
+    on_shutdown: Vec<BoundHook>,
+    after_shutdown: Vec<BoundHook>,
+    brokers: Vec<RegisteredBroker>,
+    shutdown_timeout: Option<Duration>,
+    continuations: TaskTracker,
+) -> Result<(), RustStreamError> {
+    for hook in on_shutdown {
+        if let Err(err) = hook().await {
+            warn!(target: "ruststream::lifecycle", error = %err, "on_shutdown hook failed");
+        }
+    }
+
+    token.cancel();
+    debug!(target: "ruststream::lifecycle", "draining in-flight handlers");
+    drain_handles(handles, shutdown_timeout).await?;
+
+    // Handlers have stopped, so no new post-settle continuations can be spawned: close the
+    // tracker and drain the in-flight ones, bounded by the same shutdown timeout. They are
+    // at-most-once, so timing one out only abandons follow-up work, never a settlement.
+    drain_continuations(continuations, shutdown_timeout).await;
+
+    for broker in brokers.iter().rev() {
+        broker
+            .lifecycle
+            .shutdown()
+            .await
+            .map_err(RustStreamError::Shutdown)?;
+        debug!(
+            target: "ruststream::lifecycle",
+            broker = broker.label.as_deref().unwrap_or_else(|| broker.lifecycle.name()),
+            "broker shut down",
+        );
+    }
+
+    for hook in after_shutdown {
+        if let Err(err) = hook().await {
+            warn!(target: "ruststream::lifecycle", error = %err, "after_shutdown hook failed");
+        }
+    }
+    info!(target: "ruststream::lifecycle", "service stopped");
+    Ok(())
 }
 
 /// Awaits all handler tasks, bounded by `timeout` if set. On timeout the remaining tasks are

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -167,9 +167,9 @@ impl ErrorShutdown {
         self.failure.lock().ok().and_then(|mut slot| slot.take())
     }
 
-    /// Returns a clone of the first recorded failure description without consuming it, so the test
-    /// harness can report `run_result` more than once.
-    #[cfg(feature = "testing")]
+    /// Returns a clone of the first recorded failure description without consuming it: the
+    /// health-probe watcher reports it without racing `shutdown`'s consuming read, and the test
+    /// harness reports `run_result` more than once.
     pub(crate) fn peek_failure(&self) -> Option<String> {
         self.failure.lock().ok().and_then(|slot| slot.clone())
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,7 +20,9 @@ mod router;
 mod subscriber_def;
 mod typed;
 
-pub use app::{App, AppInfo, BrokerScope, RunningApp, RustStream, RustStreamError};
+pub use app::{
+    App, AppInfo, BrokerScope, HealthProbe, HealthState, RunningApp, RustStream, RustStreamError,
+};
 #[cfg(feature = "testing")]
 pub(crate) use app::{LifecycleHook, RegisteredBroker, Starter, TestParts};
 pub use batch::{BatchDef, BatchResult, IntoBatchResult, SliceHandler, TypedBatch};

--- a/src/runtime/publisher_registry.rs
+++ b/src/runtime/publisher_registry.rs
@@ -65,3 +65,41 @@ impl<P: Publisher> ErasedPublisher for P {
         })
     }
 }
+
+#[cfg(all(test, feature = "memory"))]
+mod tests {
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::memory::MemoryBroker;
+    use crate::{IncomingMessage, Subscriber};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blanket_erasure_publishes_bytes_and_messages() {
+        let broker = MemoryBroker::new();
+        let mut subscriber = broker.subscribe("erased");
+        let publisher = broker.publisher();
+        let erased: &dyn ErasedPublisher = &publisher;
+
+        erased
+            .publish_bytes("erased", b"raw")
+            .await
+            .expect("erased byte publish failed");
+        let mut headers = Headers::new();
+        headers.insert("k", "v");
+        erased
+            .publish_message("erased", b"tagged", &headers)
+            .await
+            .expect("erased message publish failed");
+
+        let mut stream = std::pin::pin!(subscriber.stream());
+        let first = stream.next().await.unwrap().expect("first delivery");
+        assert_eq!(first.payload(), b"raw");
+        assert!(first.headers().get_str("k").is_none());
+        first.ack().await.expect("ack failed");
+        let second = stream.next().await.unwrap().expect("second delivery");
+        assert_eq!(second.payload(), b"tagged");
+        assert_eq!(second.headers().get_str("k"), Some("v"));
+        second.ack().await.expect("ack failed");
+    }
+}

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -171,3 +171,32 @@ async fn start_is_reachable_through_the_app_trait() {
         .expect("handler never saw the message");
     running.shutdown().await.expect("graceful shutdown failed");
 }
+
+/// State-generic no-op subscriber for the lifecycle-hooks test below.
+#[subscriber("started.quiet")]
+async fn quiet(_order: &Order) -> HandlerResult {
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lifecycle_hooks_run_and_shutdown_hook_errors_only_log() {
+    let broker = MemoryBroker::new();
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .on_startup(async move |()| Ok::<_, Infallible>(42_u32))
+        .after_startup(async move |state| {
+            assert_eq!(*state, 42);
+            Ok::<_, Infallible>(())
+        })
+        .on_shutdown(async move |_state| Err::<(), _>(std::io::Error::other("on_shutdown boom")))
+        .after_shutdown(async move |_state| {
+            Err::<(), _>(std::io::Error::other("after_shutdown boom"))
+        })
+        .shutdown_timeout(Duration::from_secs(5))
+        .with_broker(broker, |b| b.include(quiet));
+
+    let running = app.start().await.expect("startup failed");
+    assert!(format!("{running:?}").contains("RunningApp"));
+    // Shutdown hooks may fail; per the lifecycle contract their errors are logged, never
+    // propagated, so the graceful path still completes under the configured timeout.
+    running.shutdown().await.expect("hook errors must only log");
+}

--- a/tests/health_probe.rs
+++ b/tests/health_probe.rs
@@ -1,0 +1,94 @@
+//! Integration tests for the [`RunningApp`] health probe: the terminal state survives the
+//! consumed app handle, and a fail-fast teardown flips the probe with no `shutdown` call - the
+//! process may keep running a sibling HTTP task, which is exactly when the probe matters.
+//!
+//! [`RunningApp`]: ruststream::runtime::RunningApp
+#![cfg(feature = "macros")]
+
+use std::time::Duration;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, HealthState, RustStream, RustStreamError};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+#[subscriber("health.ok")]
+async fn fine(_order: &Order) -> HandlerResult {
+    HandlerResult::Ack
+}
+
+/// Default policy: a panic fails fast, tearing the started service down.
+#[subscriber("health.boom")]
+async fn explode(order: &Order) -> HandlerResult {
+    // The test publishes ids other than u32::MAX, so this assertion always fails (panics); the
+    // trailing expression keeps the body typed as HandlerResult.
+    assert_eq!(order.id, u32::MAX, "handler exploded");
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graceful_shutdown_reports_stopped() {
+    let broker = MemoryBroker::new();
+    let app =
+        RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(fine));
+
+    let running = app.start().await.expect("startup failed");
+    let health = running.health();
+    assert!(health.is_running(), "a started service must report Running");
+
+    running.shutdown().await.expect("graceful shutdown failed");
+    assert_eq!(
+        health.state(),
+        HealthState::Stopped,
+        "the probe outlives the consumed app handle and reports the terminal state",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fail_fast_flips_the_probe_without_a_shutdown_call() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let app =
+        RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(explode));
+
+    let running = app.start().await.expect("startup failed");
+    let mut health = running.health();
+
+    publisher
+        .publish(OutgoingMessage::new("health.boom", &order_bytes(1)))
+        .await
+        .expect("publish failed");
+
+    // Nobody calls shutdown here: the fail-fast watcher alone must flip the probe, because in
+    // the real deployment the HTTP task is still serving /healthz off it.
+    let state = tokio::time::timeout(Duration::from_secs(5), health.changed())
+        .await
+        .expect("the probe never observed the fail-fast teardown");
+    match state {
+        HealthState::Failed { reason } => assert!(
+            reason.contains("health.boom"),
+            "the reason must name the failing subscription, got: {reason}",
+        ),
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    // The orderly teardown afterwards still surfaces the dispatch failure to the caller.
+    let err = running
+        .shutdown()
+        .await
+        .expect_err("fail-fast must surface");
+    assert!(matches!(err, RustStreamError::Dispatch(_)), "got {err:?}");
+    assert!(
+        matches!(health.state(), HealthState::Failed { .. }),
+        "the terminal state stays Failed after shutdown",
+    );
+}

--- a/tests/health_probe.rs
+++ b/tests/health_probe.rs
@@ -92,3 +92,25 @@ async fn fail_fast_flips_the_probe_without_a_shutdown_call() {
         "the terminal state stays Failed after shutdown",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn detached_probe_keeps_the_last_state_and_parks() {
+    let broker = MemoryBroker::new();
+    let app =
+        RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(fine));
+
+    let running = app.start().await.expect("startup failed");
+    let mut health = running.health();
+    // Detach: dropping the handle never blocks (crate rule), so no transition ever arrives.
+    drop(running);
+
+    assert!(
+        health.is_running(),
+        "a detached service keeps its last state"
+    );
+    let waited = tokio::time::timeout(Duration::from_millis(200), health.changed()).await;
+    assert!(
+        waited.is_err(),
+        "changed() must park forever instead of spinning when no transition can arrive",
+    );
+}

--- a/tests/opentelemetry.rs
+++ b/tests/opentelemetry.rs
@@ -1,7 +1,7 @@
 //! End-to-end W3C trace context propagation: the consume layer stamps the consumer span and the
 //! publish layer carries it onto the reply (the `opentelemetry` feature, built on #103).
 #![cfg(all(
-    feature = "opentelemetry",
+    feature = "otel",
     feature = "macros",
     feature = "memory",
     feature = "json"

--- a/tests/otel_metrics.rs
+++ b/tests/otel_metrics.rs
@@ -1,0 +1,146 @@
+//! Integration tests for the `otel` feature's dispatch metrics, collected through an in-memory
+//! exporter (no collector, no network): the consume layer's per-delivery instruments and the
+//! publish layer's per-publish instruments, both labeled per handler.
+#![cfg(all(feature = "otel", feature = "testing", feature = "macros"))]
+
+use std::time::Duration;
+
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use ruststream::memory::MemoryBroker;
+use ruststream::otel::Otel;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream, TypedPublisher};
+use ruststream::testing::{TestApp, expect_published};
+use ruststream::{OutgoingMessage, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[subscriber("otel.orders")]
+async fn consume(_order: &Order) -> HandlerResult {
+    HandlerResult::Ack
+}
+
+#[subscriber("otel.requests", publish("otel.confirmations"))]
+async fn confirm(order: &Order) -> Order {
+    Order { id: order.id }
+}
+
+/// An `Otel` wired to an in-memory exporter; returns the exporter to read points back.
+fn otel_with_memory_exporter() -> (Otel, SdkMeterProvider, InMemoryMetricExporter) {
+    let exporter = InMemoryMetricExporter::default();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    let otel = Otel::builder()
+        .messaging_system("memory")
+        .attach(SdkTracerProvider::builder().build(), meter_provider.clone());
+    (otel, meter_provider, exporter)
+}
+
+/// The total of every u64 sum data point recorded under `name`.
+fn u64_sum(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
+    exporter
+        .get_finished_metrics()
+        .expect("exporter drained")
+        .iter()
+        .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .filter(|metric| metric.name() == name)
+        .map(|metric| match metric.data() {
+            AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
+                .data_points()
+                .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+                .sum::<u64>(),
+            _ => 0,
+        })
+        .sum()
+}
+
+/// How many points were recorded under the histogram `name`.
+fn histogram_count(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
+    exporter
+        .get_finished_metrics()
+        .expect("exporter drained")
+        .iter()
+        .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .filter(|metric| metric.name() == name)
+        .map(|metric| match metric.data() {
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
+                .data_points()
+                .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                .sum::<u64>(),
+            _ => 0,
+        })
+        .sum()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn consume_layer_records_per_delivery_metrics() {
+    let (otel, provider, exporter) = otel_with_memory_exporter();
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .layer(otel.consume_layer())
+        .with_broker(MemoryBroker::new(), |b| b.include(consume));
+
+    let tb = TestApp::start(app).await.expect("harness start failed");
+    tb.broker::<MemoryBroker>()
+        .publish("otel.orders", &Order { id: 7 })
+        .await
+        .expect("publish failed");
+    tb.broker::<MemoryBroker>()
+        .subscriber("otel.orders")
+        .assert_called_once();
+
+    provider.force_flush().expect("flush failed");
+    assert_eq!(u64_sum(&exporter, "messaging.client.consumed.messages"), 1);
+    assert_eq!(u64_sum(&exporter, "ruststream.messages.processed"), 1);
+    assert_eq!(histogram_count(&exporter, "messaging.process.duration"), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn publish_layer_records_per_publish_metrics_and_queue_time() {
+    let (otel, provider, exporter) = otel_with_memory_exporter();
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    let observer = broker.clone();
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .layer(otel.consume_layer())
+        .publish_layer(otel.publish_layer())
+        .with_broker(broker, |b| {
+            let replies = TypedPublisher::new(b.broker().publisher());
+            b.include_publishing(confirm, replies);
+        });
+
+    let running = app.start().await.expect("startup failed");
+    publisher
+        .publish(OutgoingMessage::new(
+            "otel.requests",
+            serde_json::to_vec(&Order { id: 3 }).unwrap().as_slice(),
+        ))
+        .await
+        .expect("publish failed");
+
+    let confirmed =
+        expect_published(&observer, "otel.confirmations", 1, Duration::from_secs(5)).await;
+    assert_eq!(confirmed.len(), 1, "the reply must be published");
+    assert!(
+        confirmed[0]
+            .headers()
+            .get_str(ruststream::otel::PUBLISH_TIME_HEADER)
+            .is_some(),
+        "the publish layer must stamp the publish-time header",
+    );
+
+    running.shutdown().await.expect("graceful shutdown failed");
+    provider.force_flush().expect("flush failed");
+    assert_eq!(u64_sum(&exporter, "messaging.client.sent.messages"), 1);
+    assert_eq!(
+        histogram_count(&exporter, "messaging.client.operation.duration"),
+        1
+    );
+}

--- a/tests/otel_metrics.rs
+++ b/tests/otel_metrics.rs
@@ -25,6 +25,11 @@ async fn consume(_order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
+#[subscriber("otel.drops")]
+async fn reject(_order: &Order) -> HandlerResult {
+    HandlerResult::drop()
+}
+
 #[subscriber("otel.requests", publish("otel.confirmations"))]
 async fn confirm(order: &Order) -> Order {
     Order { id: order.id }
@@ -85,7 +90,10 @@ async fn consume_layer_records_per_delivery_metrics() {
     let (otel, provider, exporter) = otel_with_memory_exporter();
     let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
         .layer(otel.consume_layer())
-        .with_broker(MemoryBroker::new(), |b| b.include(consume));
+        .with_broker(MemoryBroker::new(), |b| {
+            b.include(consume);
+            b.include(reject);
+        });
 
     let tb = TestApp::start(app).await.expect("harness start failed");
     tb.broker::<MemoryBroker>()
@@ -93,13 +101,58 @@ async fn consume_layer_records_per_delivery_metrics() {
         .await
         .expect("publish failed");
     tb.broker::<MemoryBroker>()
+        .publish("otel.drops", &Order { id: 8 })
+        .await
+        .expect("publish failed");
+    tb.broker::<MemoryBroker>()
         .subscriber("otel.orders")
+        .assert_called_once();
+    tb.broker::<MemoryBroker>()
+        .subscriber("otel.drops")
         .assert_called_once();
 
     provider.force_flush().expect("flush failed");
-    assert_eq!(u64_sum(&exporter, "messaging.client.consumed.messages"), 1);
-    assert_eq!(u64_sum(&exporter, "ruststream.messages.processed"), 1);
-    assert_eq!(histogram_count(&exporter, "messaging.process.duration"), 1);
+    assert_eq!(u64_sum(&exporter, "messaging.client.consumed.messages"), 2);
+    assert_eq!(u64_sum(&exporter, "ruststream.messages.processed"), 2);
+    assert_eq!(histogram_count(&exporter, "messaging.process.duration"), 2);
+}
+
+/// One point recorded under the u64 gauge `name` with `value` for the given state attribute.
+fn gauge_reports(exporter: &InMemoryMetricExporter, name: &str) -> bool {
+    exporter
+        .get_finished_metrics()
+        .expect("exporter drained")
+        .iter()
+        .flat_map(opentelemetry_sdk::metrics::data::ResourceMetrics::scope_metrics)
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .any(|metric| metric.name() == name)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn init_installs_globals_and_shutdown_returns() {
+    // Building the exporters performs no I/O, so a dead endpoint only shows up when flushing;
+    // the test asserts init and shutdown return rather than hang. The bridge-less form runs
+    // first inside the same test, keeping the single try_init deterministic.
+    let quiet = Otel::builder()
+        .tracing_bridge(false)
+        .stamp_publish_time(false)
+        .otlp_endpoint("http://127.0.0.1:1")
+        .init()
+        .expect("bridge-less init failed");
+    let _ = quiet.shutdown();
+
+    let bridged = Otel::builder()
+        .service_name("otel-test")
+        .otlp_endpoint("http://127.0.0.1:1")
+        .messaging_system("memory")
+        .attribute("deployment.environment", "test")
+        .init()
+        .expect("init failed");
+    assert!(format!("{bridged:?}").contains("Otel"));
+    let probe_layer = bridged.consume_layer();
+    assert!(format!("{probe_layer:?}").contains("OtelConsumeLayer"));
+    assert!(format!("{:?}", bridged.publish_layer()).contains("OtelPublishLayer"));
+    let _ = bridged.shutdown();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -136,8 +189,13 @@ async fn publish_layer_records_per_publish_metrics_and_queue_time() {
         "the publish layer must stamp the publish-time header",
     );
 
+    otel.observe_health(running.health());
     running.shutdown().await.expect("graceful shutdown failed");
     provider.force_flush().expect("flush failed");
+    assert!(
+        gauge_reports(&exporter, "ruststream.app.state"),
+        "the health gauge must be collected",
+    );
     assert_eq!(u64_sum(&exporter, "messaging.client.sent.messages"), 1);
     assert_eq!(
         histogram_count(&exporter, "messaging.client.operation.duration"),


### PR DESCRIPTION
# Description

Adds `RunningApp::health()`, returning a `HealthProbe`: a cheap, cloneable, watch-backed view of the service lifecycle (`Running`, `ShuttingDown`, `Stopped`, `Failed { reason }`). The probe closes the gap the issue describes: when the app fail-fasts but the process stays alive because a sibling tokio task (an HTTP server) keeps running, that task's `/healthz` route can now report the death instead of a permanent 200. A watcher task flips the probe on fail-fast with no `shutdown` call required; the probe outlives the consumed app handle and keeps reporting the terminal state, with the same diagnostic string `run()` returns inside `RustStreamError::Dispatch`.

`start()` remains the readiness gate; the probe covers the post-startup half. Reads are lock-free borrows; the channel is written only on lifecycle transitions, so nothing lands on the per-delivery hot path. Rapid transitions may coalesce per watch semantics (documented); `changed()` parks forever on a detached service instead of spinning the caller's loop. The `http_outbox` example gains a `/healthz` route and the HTTP guide a matching section.

Additive (targets main; can ship in a 0.5.x patch).

Fixes #172

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable