### PR TITLE
docs: link the Grafana dashboard template from the observability guides

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -58,3 +58,8 @@ curl http://127.0.0.1:8080/metrics
 ```rust
 --8<-- "examples/metrics_http.rs"
 ```
+
+For services exporting through the `otel` feature instead, a ready-made Grafana dashboard over
+the full metrics inventory lives in
+[`ruststream-grafana`](https://github.com/powersemmi/ruststream-grafana); see the
+[OpenTelemetry guide](opentelemetry.md).

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -90,6 +90,11 @@ counter built anywhere in user code rides the same OTLP pipeline:
 --8<-- "examples/otel_export.rs:business_metric"
 ```
 
+A ready-made Grafana dashboard over exactly this inventory lives in
+[`ruststream-grafana`](https://github.com/powersemmi/ruststream-grafana): import
+`dashboards/ruststream.json`, point it at any Prometheus-compatible backend receiving the OTLP
+metrics, and the panels light up per handler; its README doubles as the metrics contract.
+
 Call `otel.shutdown()` at the end of `main`, after the app's graceful shutdown, to flush the last
 spans and points. To compose the span bridge into your own subscriber stack (for example with the
 `logging` feature's fmt layer), build with `.tracing_bridge(false)` and install the bridge


### PR DESCRIPTION
# Description

The Grafana dashboard template over the `otel` feature's metrics inventory now lives in its own repository, [ruststream-grafana](https://github.com/powersemmi/ruststream-grafana): a provisioning-ready `dashboards/ruststream.json` (overview / per-handler / failures rows, per-handler variable driven by `messaging.destination.name`, works against any Prometheus-compatible backend receiving the OTLP metrics) plus a README that doubles as the human-readable metrics contract, documenting both the OpenTelemetry instrument names and their Prometheus renderings.

This PR is the core-side half of the issue's definition of done: the OpenTelemetry and metrics guides link the template, so the dashboard is discoverable from the docs site. Stacked on #178 (the guide section it extends lands there).

Fixes #173

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)