### PR TITLE
docs: refresh the README and version pins for 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">RustStream</h1>
 
 <p align="center">
-  <i>An async messaging framework for Rust: broker-agnostic traits, a router runtime, codecs, AsyncAPI generation, Prometheus metrics, and a conformance harness for broker authors.</i>
+  <i>An async messaging framework for Rust: broker-agnostic traits, a router runtime, codecs, AsyncAPI generation, Prometheus and OpenTelemetry observability, and a conformance harness for broker authors.</i>
 </p>
 
 <p align="center">
@@ -38,21 +38,33 @@ block, so the guarantee cannot regress.
   crates, and the contract is checked by a conformance harness.
 - **Fully async on tokio.** No blocking APIs in the public surface.
 - **Subscribers are `Stream`s, not callbacks.** Back-pressure comes for free.
-- **Ack consumes `self`.** Double-ack is a compile error.
-- **Pluggable codecs:** JSON, MessagePack, and CBOR behind cargo features.
+- **Misuse does not compile.** Ack consumes `self` (no double-ack); the broker lifecycle is a
+  ladder of consuming transitions (`connect(self)` yields the connected form, `shutdown(self)`
+  a terminal witness), so out-of-order lifecycle calls are compile errors; transactions settle
+  by consuming their scope.
+- **Publishers pair at startup.** Reply wiring and the `Out(..)` handler parameter attach a
+  publish policy where the handler is included; the runtime pairs it against the connected
+  broker, so a handler never sees a "not connected" publisher.
+- **Pluggable codecs:** JSON, MessagePack, and CBOR behind cargo features - or none at all:
+  `raw` subscribers and `publish_raw` replies move payload bytes untouched.
 - **Zero-boilerplate binaries.** `#[ruststream::app]` generates `main`; the `ruststream` CLI
   scaffolds projects, runs them, and generates the AsyncAPI document.
 - **AsyncAPI 3.0 and Prometheus metrics,** served from your own HTTP stack.
+- **OpenTelemetry** behind the `otel` feature: OTLP export for traces and metrics, per-handler
+  dispatch metrics following the messaging semantic conventions, and W3C trace-context
+  propagation across the consume-transform-produce chain.
+- **A cloneable health probe** off the running app, so a sibling healthz route keeps reporting
+  the terminal state after the messaging side stops.
 - **Colored console logging** behind the `logging` feature; the generated CLI installs it on `run`,
   with verbosity driven by `RUST_LOG`.
-- **Capability traits** for optional features (batch subscribe, transactions, request-reply,
-  partitioning); a broker implements only what it supports.
+- **Capability traits** for optional features (batch subscribe, borrowed and owned transactions,
+  request-reply, partitioning); a broker implements only what it supports.
 
 ## Install
 
 ```toml
 [dependencies]
-ruststream = { version = "0.5", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "1"
 ```

--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -12,7 +12,7 @@ Run both: `run_suite` for the dispatch guarantees, `lifecycle` to prove `new` ->
 
 ```toml
 [dev-dependencies]
-ruststream = { version = "0.5", features = ["conformance"] }
+ruststream = { version = "0.6", features = ["conformance"] }
 ```
 
 The `conformance` feature pulls in `testing`, so the one `TestableBroker` your crate ships works with

--- a/docs/broker-authors/example-nats.md
+++ b/docs/broker-authors/example-nats.md
@@ -21,7 +21,7 @@ default = []
 testing = ["ruststream/conformance"]
 
 [dependencies]
-ruststream = { version = "0.5", default-features = false }
+ruststream = { version = "0.6", default-features = false }
 async-nats = "0.46"
 bytes = "1"
 futures = "0.3"

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -6,7 +6,7 @@ any other broker:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.5", default-features = false }
+ruststream = { version = "0.6", default-features = false }
 ```
 
 This page is the contract. Implement the required traits, expose your own `Config`, add capability

--- a/docs/brokers/memory.md
+++ b/docs/brokers/memory.md
@@ -5,7 +5,7 @@ which makes it ideal for examples, unit tests, and prototypes; the default `carg
 (`templates/memory`) uses it so a fresh project runs with zero dependencies.
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json"] }
 ```
 
 <!-- inline-rust: two-line constructor sketch; the broker in context is exercised by every memory-feature example (e.g. quickstart.rs:app) -->

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ features. Add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruststream = { version = "0.5", features = ["macros", "memory", "json"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -43,7 +43,7 @@ Codec features are mutually compatible; enable as many as you need (see
 
 ```toml
 [dependencies]
-ruststream = { version = "0.5", default-features = false }
+ruststream = { version = "0.6", default-features = false }
 ```
 
 ## The CLI

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -18,7 +18,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ruststream = { version = "0.5", features = ["macros", "memory", "json", "asyncapi"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json", "asyncapi"] }
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -5,7 +5,7 @@ document from the application's handlers: each subscriber becomes a channel and 
 operation, and payload types contribute schemas.
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "asyncapi"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "asyncapi"] }
 ```
 
 ## Generating the document

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -15,7 +15,7 @@ When the `logging` feature is enabled, the `#[ruststream::app]` CLI calls the lo
 `run` command, so a scaffolded service logs out of the box:
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "json", "logging"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json", "logging"] }
 ```
 
 ```bash

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -4,7 +4,7 @@ The `metrics` feature collects Prometheus metrics for consumed and published mes
 the `prometheus` crate directly and exposes the data in the Prometheus exposition format.
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "metrics"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "metrics"] }
 ```
 
 ## Wiring it up

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -6,7 +6,7 @@ It is built on the typed publish-path context - the same seam that lets a publis
 delivery that produced a reply.
 
 ```toml
-ruststream = { version = "0.5", features = ["macros", "memory", "json", "otel"] }
+ruststream = { version = "0.6", features = ["macros", "memory", "json", "otel"] }
 ```
 
 The feature has two halves. Propagation carries the

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -49,7 +49,7 @@ Enable the `testing` feature in your dev-dependencies:
 
 ```toml
 [dev-dependencies]
-ruststream = { version = "0.5", features = ["testing", "memory", "macros", "json"] }
+ruststream = { version = "0.6", features = ["testing", "memory", "macros", "json"] }
 ```
 
 ### Addressing brokers


### PR DESCRIPTION
# Description

Refreshes the README for the 0.6 release and bumps every install snippet to the 0.6 pin ahead of publishing.

The feature list catches up with the release line: the compile-time lifecycle and transaction guarantees (consuming connect/shutdown ladder, scopes settling by consumption), publishers pairing at startup with `Out` injection, raw subscribers and `publish_raw` replies, the `otel` feature (OTLP export, per-handler dispatch metrics, W3C propagation), and the cloneable health probe. The intro line mentions OpenTelemetry next to Prometheus. Install snippets across the README and the docs guides move from the 0.5 pin to 0.6, so the docs deployed with the release resolve the crate they document.

## Type of change

- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
