### PR TITLE
feat: conformance suite for the owned transaction capability

### DIFF
--- a/docs/broker-authors/conformance.md
+++ b/docs/broker-authors/conformance.md
@@ -99,6 +99,7 @@ without the capability simply do not call it. Each suite takes the same factory 
 | `capabilities::request_reply` | `RequestReply` | the request reaches a responder with a usable `reply-to` header, the correlated reply resolves the request, an unanswered request fails after its timeout |
 | `capabilities::batches` | `BatchSubscriber` | every published message arrives in publish order, distributed over non-empty batches |
 | `capabilities::transactions` | `TransactionalPublisher` | nothing inside a transaction is visible before `commit`, a commit publishes the buffer in order, an abort discards it; misuse errors - `commit` / `abort` with no open transaction, a second `begin_transaction` while one is open (which must leave it untouched) |
+| `capabilities::owned_transactions` | `OwnedTransactions`, its `Transaction` | nothing published into an open transaction is visible before `commit`, a commit delivers the whole buffer in publish order, an abort discards it, two transactions open at once on one handle settle independently, and the handle keeps publishing directly while one is open |
 | `capabilities::seeking` | `Seekable`, messages `Positioned` | a seek back to a position captured from a delivered message redelivers exactly that message and the ordered suffix after it, a seek forward skips the queued deliveries before the target, and the subscription keeps delivering new publishes after repositioning |
 
 <!-- inline-rust: worked request-reply capability check against the external ruststream-nats crate; its real gated suite lives in that repo, so it has no compiled home here -->
@@ -120,7 +121,7 @@ async fn passes_request_reply() {
 }
 ```
 
-The in-memory broker implements every capability natively and passes all four suites in-process
+The in-memory broker implements every capability natively and passes all five suites in-process
 (see [Memory](../brokers/memory.md#capabilities)); it is the executable reference for what each
 suite expects.
 

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -199,7 +199,8 @@ Implement only the capabilities your broker supports; none are part of the manda
 | Trait | For brokers that support |
 |---|---|
 | `BatchSubscriber` | receiving messages in batches |
-| `TransactionalPublisher` | begin / commit / abort around publishes |
+| `TransactionalPublisher` | begin / commit / abort around publishes on the handle |
+| `OwnedTransactions` / `Transaction` | transactions whose buffer lives in a value, any number open at once per handle |
 | `RequestReply` | native request-reply (NATS yes, Kafka no) |
 | `Partitioned` | a partition key on outgoing messages |
 | `Seekable` / `Seeker` | repositioning a live subscription in a replayable log |

--- a/src/conformance/capabilities.rs
+++ b/src/conformance/capabilities.rs
@@ -1,22 +1,22 @@
 //! Optional conformance suites, one per capability trait.
 //!
 //! A broker crate that implements a capability ([`RequestReply`], [`BatchSubscriber`],
-//! [`TransactionalPublisher`], [`Seekable`]) runs the matching suite to prove the
-//! implementation honours the trait contract; brokers without the capability simply do not call
-//! it. Like [`harness::lifecycle`](super::harness::lifecycle), every suite is built from
+//! [`TransactionalPublisher`], [`OwnedTransactions`], [`Seekable`]) runs the matching suite to
+//! prove the implementation honours the trait contract; brokers without the capability simply do
+//! not call it. Like [`harness::lifecycle`](super::harness::lifecycle), every suite is built from
 //! caller-supplied factories so it stays broker-agnostic, and the in-memory broker is the
 //! executable reference that passes all of them.
 
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use tokio::time::timeout;
 
 use super::harness::{expect_next, expect_no_more};
 use crate::{
     AckError, BatchSubscriber, Broker, Connected, ConnectedBroker, Headers, IncomingMessage,
-    OutgoingMessage, Positioned, Publisher, RequestReply, Seekable, Seeker, Subscriber,
-    SubscriptionSource, TransactionalPublisher,
+    OutgoingMessage, OwnedTransactions, Positioned, Publisher, RequestReply, Seekable, Seeker,
+    Subscriber, SubscriptionSource, Transaction, TransactionalPublisher,
 };
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -362,6 +362,258 @@ pub async fn transactions<B, MkBroker, Src, MkSrc, Pub, MkPub>(
         .shutdown()
         .await
         .expect("broker must shut down cleanly");
+}
+
+/// Verifies the [`OwnedTransactions`] / [`Transaction`] contract.
+///
+/// Nothing published into an open transaction is visible before `commit`, a commit makes the
+/// whole buffer visible atomically in publish order, and an abort discards it. Transactions are
+/// independent: two open at once on one handle settle without affecting each other, and the
+/// handle keeps publishing directly while one is open. That a settled transaction cannot be
+/// reused is enforced by the consuming `commit` / `abort` at compile time, so this suite does not
+/// assert it.
+///
+/// The suite makes no claim about the delivery order between two transactions - only about the
+/// order inside each committed buffer.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "memory")]
+/// # async fn run() {
+/// use ruststream::conformance::capabilities;
+/// use ruststream::memory::{MemoryBroker, MemorySource};
+///
+/// capabilities::owned_transactions(
+///     MemoryBroker::new,
+///     |name| MemorySource::new(name),
+///     |broker| broker.publisher(),
+/// )
+/// .await;
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics with a descriptive message if any step violates the contract.
+pub async fn owned_transactions<B, MkBroker, Src, MkSrc, Pub, MkPub>(
+    make_broker: MkBroker,
+    make_source: MkSrc,
+    make_publisher: MkPub,
+) where
+    B: Broker,
+    MkBroker: Fn() -> B,
+    Src: SubscriptionSource<Connected<B>> + Send,
+    Src::Subscriber: Send,
+    MkSrc: Fn(&str) -> Src,
+    Pub: OwnedTransactions,
+    MkPub: Fn(&Connected<B>) -> Pub,
+{
+    const SUBJECT: &str = "conformance.owned_transactions";
+
+    let connected = make_broker().connect().await.expect("broker must connect");
+
+    let mut subscriber = make_source(SUBJECT)
+        .subscribe(&connected)
+        .await
+        .expect("subscription must open after connect");
+    let publisher = make_publisher(&connected);
+    let mut stream = std::pin::pin!(subscriber.stream());
+
+    owned_settlement(&publisher, &mut stream, SUBJECT).await;
+    owned_concurrent_settlements(&publisher, &mut stream, SUBJECT).await;
+    owned_concurrent_commits(&publisher, &mut stream, SUBJECT).await;
+    owned_direct_publish(&publisher, &mut stream, SUBJECT).await;
+
+    connected
+        .shutdown()
+        .await
+        .expect("broker must shut down cleanly");
+}
+
+/// One transaction at a time: a commit publishes the whole buffer in order, an abort discards it.
+async fn owned_settlement<Pub, S, M, E>(publisher: &Pub, stream: &mut S, subject: &str)
+where
+    Pub: OwnedTransactions,
+    S: Stream<Item = Result<M, E>> + Unpin,
+    M: IncomingMessage,
+    E: fmt::Debug,
+{
+    let mut committed = publisher
+        .transaction()
+        .await
+        .expect("transaction must open");
+    committed
+        .publish(OutgoingMessage::new(subject, b"first".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    committed
+        .publish(OutgoingMessage::new(subject, b"second".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    expect_no_more(stream, "owned_transactions: before commit").await;
+
+    committed.commit().await.expect("commit failed");
+    assert_eq!(
+        collect_payloads(stream, 2, "owned_transactions: after commit").await,
+        vec![b"first".to_vec(), b"second".to_vec()],
+        "commit must make the whole buffer visible in publish order",
+    );
+
+    let mut aborted = publisher
+        .transaction()
+        .await
+        .expect("transaction must open");
+    aborted
+        .publish(OutgoingMessage::new(subject, b"discarded".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    aborted.abort().await.expect("abort failed");
+    expect_no_more(stream, "owned_transactions: after abort").await;
+}
+
+/// Two transactions open at once on one handle, settled the opposite ways: only the committed
+/// buffer arrives, and its sibling's abort leaves it whole.
+async fn owned_concurrent_settlements<Pub, S, M, E>(publisher: &Pub, stream: &mut S, subject: &str)
+where
+    Pub: OwnedTransactions,
+    S: Stream<Item = Result<M, E>> + Unpin,
+    M: IncomingMessage,
+    E: fmt::Debug,
+{
+    let mut kept = publisher
+        .transaction()
+        .await
+        .expect("transaction must open");
+    let mut dropped = publisher
+        .transaction()
+        .await
+        .expect("a second transaction must open while the first is open");
+    kept.publish(OutgoingMessage::new(subject, b"kept-1".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    dropped
+        .publish(OutgoingMessage::new(subject, b"dropped-1".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    kept.publish(OutgoingMessage::new(subject, b"kept-2".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    dropped
+        .publish(OutgoingMessage::new(subject, b"dropped-2".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+
+    dropped.abort().await.expect("abort failed");
+    expect_no_more(stream, "owned_transactions: sibling aborted").await;
+
+    kept.commit().await.expect("commit failed");
+    assert_eq!(
+        collect_payloads(stream, 2, "owned_transactions: sibling committed").await,
+        vec![b"kept-1".to_vec(), b"kept-2".to_vec()],
+        "aborting one transaction must leave a concurrent one whole and in publish order",
+    );
+    expect_no_more(stream, "owned_transactions: after the concurrent pair").await;
+}
+
+/// Two transactions open at once, both committed: each buffer arrives whole and in publish order.
+async fn owned_concurrent_commits<Pub, S, M, E>(publisher: &Pub, stream: &mut S, subject: &str)
+where
+    Pub: OwnedTransactions,
+    S: Stream<Item = Result<M, E>> + Unpin,
+    M: IncomingMessage,
+    E: fmt::Debug,
+{
+    let mut left = publisher
+        .transaction()
+        .await
+        .expect("transaction must open");
+    let mut right = publisher
+        .transaction()
+        .await
+        .expect("a second transaction must open while the first is open");
+    left.publish(OutgoingMessage::new(subject, b"left-1".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    right
+        .publish(OutgoingMessage::new(subject, b"right-1".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    left.publish(OutgoingMessage::new(subject, b"left-2".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+
+    left.commit().await.expect("commit failed");
+    right.commit().await.expect("commit failed");
+
+    let both = collect_payloads(stream, 3, "owned_transactions: both committed").await;
+    let from_left: Vec<Vec<u8>> = both
+        .iter()
+        .filter(|payload| payload.starts_with(b"left"))
+        .cloned()
+        .collect();
+    assert_eq!(
+        from_left,
+        vec![b"left-1".to_vec(), b"left-2".to_vec()],
+        "each committed buffer must arrive whole, in publish order",
+    );
+    assert!(
+        both.iter().any(|payload| payload == b"right-1"),
+        "committing two concurrent transactions must deliver both buffers",
+    );
+}
+
+/// The handle keeps publishing directly while a transaction is open, and neither captures the
+/// other's messages.
+async fn owned_direct_publish<Pub, S, M, E>(publisher: &Pub, stream: &mut S, subject: &str)
+where
+    Pub: OwnedTransactions,
+    S: Stream<Item = Result<M, E>> + Unpin,
+    M: IncomingMessage,
+    E: fmt::Debug,
+{
+    let mut open = publisher
+        .transaction()
+        .await
+        .expect("transaction must open");
+    open.publish(OutgoingMessage::new(subject, b"buffered".as_slice()))
+        .await
+        .expect("publish into a transaction failed");
+    publisher
+        .publish(OutgoingMessage::new(subject, b"direct".as_slice()))
+        .await
+        .expect("the handle must keep publishing directly while a transaction is open");
+    assert_eq!(
+        collect_payloads(stream, 1, "owned_transactions: direct publish").await,
+        vec![b"direct".to_vec()],
+        "a direct publish must be visible immediately, not buffered by an open transaction",
+    );
+
+    open.commit().await.expect("commit failed");
+    assert_eq!(
+        collect_payloads(stream, 1, "owned_transactions: after the direct publish").await,
+        vec![b"buffered".to_vec()],
+        "a direct publish must leave the open transaction's buffer intact",
+    );
+}
+
+/// Collects the payloads of the next `count` deliveries in arrival order, acking each.
+async fn collect_payloads<S, M, E>(stream: &mut S, count: usize, label: &str) -> Vec<Vec<u8>>
+where
+    S: Stream<Item = Result<M, E>> + Unpin,
+    M: IncomingMessage,
+    E: fmt::Debug,
+{
+    let mut payloads = Vec::with_capacity(count);
+    for _ in 0..count {
+        let msg = expect_next(&mut *stream, label).await;
+        payloads.push(msg.payload().to_vec());
+        match msg.ack().await {
+            Ok(()) | Err(AckError::Unsupported) => {}
+            Err(other) => panic!("ack must succeed or be unsupported, got: {other:?}"),
+        }
+    }
+    payloads
 }
 
 /// Verifies the [`Seekable`] contract.

--- a/tests/conformance_self.rs
+++ b/tests/conformance_self.rs
@@ -65,6 +65,17 @@ async fn memory_broker_passes_transactions_suite() {
 
 #[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_owned_transactions_suite() {
+    capabilities::owned_transactions(
+        MemoryBroker::new,
+        |name| MemorySource::new(name),
+        |broker| broker.publisher(),
+    )
+    .await;
+}
+
+#[allow(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn memory_broker_passes_seeking_suite() {
     capabilities::seeking(
         MemoryBroker::new,


### PR DESCRIPTION
# Description

Core ships two transaction capabilities: the borrowed `TransactionalPublisher` (handle-level, one
transaction at a time) and the owned `OwnedTransactions` / `Transaction` pair (buffer-owning value,
settled by consuming it). Only the borrowed kind had a conformance suite, so broker crates about to
implement the owned kind had nothing to check their implementation against.

This adds `conformance::capabilities::owned_transactions`, built from the same synchronous
factories as the other suites. It verifies that nothing published into an open transaction is
visible before `commit`, that a commit delivers the whole buffer in publish order, that an abort
discards it, that two transactions open at once on one handle settle independently (one committed
and one aborted, then both committed), and that the handle keeps publishing directly while a
transaction is open. Reuse after settling is a compile-time property of the consuming `commit` /
`abort`, so the suite does not assert it. The suite makes no claim about the delivery order between
two transactions, only about the order inside each committed buffer.

The in-memory broker runs the new suite in-process next to the other self-tests, and the conformance
guide lists it with the rest.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
