### PR TITLE
release: 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/ruststream-macros"]
 exclude = ["templates"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -253,7 +253,7 @@ tracing = "0.1"
 # Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
 # release for release (a loose range let a partial `cargo update` pair a new core with an old
 # macros crate and fail to compile). Bumped by the same edit as [workspace.package].version.
-ruststream-macros = { version = "=0.6.0", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "=0.6.1", path = "crates/ruststream-macros", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }


### PR DESCRIPTION
# Description

Bumps the workspace version to 0.6.1 (lockstep with `ruststream-macros`, exact pin updated by the same edit). A patch release on the 0.6 line, carrying the additive changes merged since 0.6.0: the conformance suite for the owned transaction capability (`capabilities::owned_transactions`, #201) and the completed broker catalog page (#200).

The multi-package publish dry-run (`cargo publish --dry-run -p ruststream-macros -p ruststream`) packages and verifies both crates at 0.6.1.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
