### PR TITLE
docs: set the decode-failure policy through the subscriber clause

### DIFF
--- a/docs/guides/codecs.md
+++ b/docs/guides/codecs.md
@@ -72,16 +72,17 @@ property of the mounting, not of the type.
 ## Decode failures
 
 When decoding fails, the failure policy decides what happens to the message; by default it is
-dropped (a nack without requeue). On a macro handler the policy is set with the
-`on_failure(decode = ..)` clause; when building handlers by hand, the `Typed` wrapper returned by
-`typed(codec, handler)` takes the same policy through `on_decode_failure`:
+dropped (a nack without requeue). The policy is set per subscriber with the
+`on_failure(decode = ..)` clause:
 
 ```rust
-use ruststream::runtime::{FailurePolicy, typed};
+use ruststream::subscriber;
 
-// inside with_broker(...):
 --8<-- "examples/codecs.rs:decode_failure"
 ```
+
+When building handlers by hand, the `Typed` wrapper returned by `typed(codec, handler)` takes
+the same policy through `on_decode_failure`.
 
 The policy values (`Drop`, `Retry`, `RetryAfter(..)`, `Skip`, `FailFast`), the defaults, and the
 retry caveats live in [Failure policy](failure-policy.md). The codec examples above are

--- a/examples/codecs.rs
+++ b/examples/codecs.rs
@@ -7,9 +7,7 @@
 
 use ruststream::codec::{CborCodec, JsonCodec};
 use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{
-    AppInfo, Context, FailurePolicy, HandlerMetadata, HandlerResult, Router, RustStream, typed,
-};
+use ruststream::runtime::{AppInfo, HandlerResult, Router, RustStream};
 use ruststream::subscriber;
 use serde::Deserialize;
 
@@ -30,6 +28,15 @@ async fn audit(order: &Order) -> HandlerResult {
     HandlerResult::Ack
 }
 
+// --8<-- [start:decode_failure]
+/// A payload that fails to decode is redelivered instead of dropped.
+#[subscriber("orders", on_failure(decode = retry))]
+async fn strict(order: &Order) -> HandlerResult {
+    println!("strictly decoded order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:decode_failure]
+
 #[ruststream::app]
 fn app() -> RustStream {
     let info = AppInfo::new("codecs", "0.1.0");
@@ -45,16 +52,6 @@ fn app() -> RustStream {
             // name the codec for this one handler by mounting it through a router
             b.include_router(Router::new().with_codec(JsonCodec).include(handle));
             // --8<-- [end:per_handler]
-            // --8<-- [start:decode_failure]
-            let strict = typed(JsonCodec, |_order: &Order, _ctx: &mut Context| async {
-                HandlerResult::Ack
-            })
-            .on_decode_failure(FailurePolicy::Retry);
-            b.handle(
-                b.broker().subscribe("orders"),
-                strict,
-                HandlerMetadata::typed::<Order>("orders"),
-            );
-            // --8<-- [end:decode_failure]
+            b.include(strict);
         })
 }


### PR DESCRIPTION
The decode-failures example in the codecs guide built a handler by hand (typed(codec, ..) + on_decode_failure + b.handle) where the subscriber macro's on_failure(decode = ..) clause is the user-facing form. The snippet now shows the clause; the hand-built path stays as a one-line mention. The example compiles and runs as before.