### PR TITLE
perf: share the memory bus delivery name and headers across subscribers

### DIFF
--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -123,7 +123,7 @@ impl Publisher for MemoryRequester {
             headers: msg.headers().clone(),
         };
         self.state
-            .fanout(&outbound)
+            .fanout(outbound)
             .map_err(|_| RequestError::ShutDown)
     }
 }
@@ -150,7 +150,7 @@ impl RequestReply for MemoryRequester {
             payload: Bytes::copy_from_slice(msg.payload()),
             headers,
         };
-        if self.state.fanout(&outbound).is_err() {
+        if self.state.fanout(outbound).is_err() {
             self.state.unregister(&inbox);
             return Err(RequestError::ShutDown);
         }
@@ -267,8 +267,8 @@ impl TransactionalPublisher for MemoryPublisher {
             .expect("memory broker mutex poisoned")
             .take()
             .ok_or(MemoryError::NoTransaction)?;
-        for delivery in buffered {
-            self.state.fanout(&delivery)?;
+        for outbound in buffered {
+            self.state.fanout(outbound)?;
         }
         Ok(())
     }
@@ -356,8 +356,8 @@ impl Transaction for MemoryTransaction {
         // Settled before the flush: a failed commit has still consumed the transaction (the
         // buffer is lost per the Transaction contract), so the drop warning must not fire.
         self.settled = true;
-        for delivery in &self.buffered {
-            self.state.fanout(delivery)?;
+        for outbound in std::mem::take(&mut self.buffered) {
+            self.state.fanout(outbound)?;
         }
         Ok(())
     }
@@ -548,7 +548,7 @@ impl Seeker for MemorySeeker {
             .published
             .lock()
             .expect("memory broker mutex poisoned")
-            .get(&self.name)
+            .get(self.name.as_str())
             .map_or(0, Vec::len);
         let clamped = to.0.min(end);
         // Watermark first (Release, paired with the Acquire load in the delivery filter), then
@@ -599,7 +599,10 @@ impl MemorySubscriber {
             .lock()
             .expect("memory broker mutex poisoned");
 
-        let entries = log.get(&self.name).map(Vec::as_slice).unwrap_or_default();
+        let entries = log
+            .get(self.name.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
 
         // The replay is counted in flight BEFORE the drain releases the queued deliveries:
         // decrementing first would let the in-flight count touch zero mid-swap, and a
@@ -622,9 +625,9 @@ impl MemorySubscriber {
 
         for (seq, raw) in entries.iter().enumerate().skip(target) {
             let delivery = MemoryDelivery {
-                name: self.name.clone(),
+                name: Arc::from(self.name.as_str()),
                 payload: raw.payload_bytes(),
-                headers: raw.headers().clone(),
+                headers: Arc::new(raw.headers().clone()),
                 seq,
             };
             // The send cannot fail: this subscriber holds both ends of its own channel.

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -60,11 +60,14 @@ struct MemoryOutbound {
     headers: Headers,
 }
 
+/// A stamped message on its way to subscribers. The name and headers are shared, not owned:
+/// fanout clones one delivery per subscriber, so per-subscriber cost is reference-count bumps
+/// (plus the [`Bytes`] payload's own cheap clone), not string and map allocations.
 #[derive(Clone)]
 struct MemoryDelivery {
-    name: String,
+    name: Arc<str>,
     payload: Bytes,
-    headers: Headers,
+    headers: Arc<Headers>,
     /// Zero-based index of this message in its name's publish log. Stable across requeues, so
     /// a redelivered message reports the same [`MemoryPosition`].
     seq: usize,
@@ -89,7 +92,9 @@ impl Default for Bus {
 #[derive(Default)]
 struct MemoryState {
     subscribers: Mutex<Bus>,
-    published: Mutex<HashMap<String, Vec<RawMessage>>>,
+    // Keyed by the shared delivery name, so the per-publish log append reuses the fanout's
+    // `Arc<str>` instead of allocating a fresh key (lookups by `&str` work through `Borrow`).
+    published: Mutex<HashMap<Arc<str>, Vec<RawMessage>>>,
     notify: Notify,
     inbox_seq: AtomicU64,
     /// The harness's quiescence-and-recording coordinator, installed by a
@@ -146,7 +151,16 @@ impl MemoryState {
     // significant_drop_tightening misfires here: both guards drop at the end of the minimal
     // block right after their last use.
     #[allow(clippy::significant_drop_tightening)]
-    fn fanout(&self, outbound: &MemoryOutbound) -> Result<(), MemoryError> {
+    fn fanout(&self, outbound: MemoryOutbound) -> Result<(), MemoryError> {
+        // The outbound arrives by value: its name and headers move into shared allocations
+        // once, and every per-subscriber copy below is reference-count bumps.
+        let MemoryOutbound {
+            name,
+            payload,
+            headers,
+        } = outbound;
+        let name: Arc<str> = name.into();
+        let headers = Arc::new(headers);
         {
             let bus = self
                 .subscribers
@@ -156,17 +170,15 @@ impl MemoryState {
                 return Err(MemoryError::ShutDown);
             };
             let mut log = self.published.lock().expect("memory broker mutex poisoned");
-            let entries = log.entry(outbound.name.clone()).or_default();
+            let entries = log.entry(Arc::clone(&name)).or_default();
             let delivery = MemoryDelivery {
-                name: outbound.name.clone(),
-                payload: outbound.payload.clone(),
-                headers: outbound.headers.clone(),
+                name: Arc::clone(&name),
+                payload: payload.clone(),
+                headers: Arc::clone(&headers),
                 seq: entries.len(),
             };
-            entries.push(
-                RawMessage::new(outbound.name.clone(), outbound.payload.clone())
-                    .with_headers(outbound.headers.clone()),
-            );
+            // The log owns its copy (the one unavoidable materialization per publish).
+            entries.push(RawMessage::new(&*name, payload).with_headers((*headers).clone()));
             self.send_to(subscribers, &delivery);
         }
         self.notify.notify_waiters();
@@ -175,7 +187,7 @@ impl MemoryState {
 
     /// Enqueues `delivery` to every subscriber registered under its name.
     fn send_to(&self, subscribers: &HashMap<String, Vec<Sender>>, delivery: &MemoryDelivery) {
-        if let Some(senders) = subscribers.get(&delivery.name) {
+        if let Some(senders) = subscribers.get(&*delivery.name) {
             for tx in senders {
                 let sent = tx.send(delivery.clone());
                 // Count every live enqueue so the harness can drive to quiescence. Request inboxes
@@ -459,7 +471,7 @@ impl crate::testing::TestableBroker for ConnectedMemoryBroker {
         // Injecting into a shut-down bus is a harness bug (both run_suite and TestApp drive
         // the bus strictly before shutdown), so fail loudly instead of losing the message.
         self.state
-            .fanout(&MemoryOutbound {
+            .fanout(MemoryOutbound {
                 name: message.name().to_owned(),
                 payload: Bytes::copy_from_slice(message.payload()),
                 headers: message.headers().clone(),
@@ -694,7 +706,7 @@ impl Publisher for MemoryPublisher {
                 return Ok(());
             }
         }
-        self.state.fanout(&outbound)
+        self.state.fanout(outbound)
     }
 }
 
@@ -728,7 +740,7 @@ impl Drop for MemoryMessage {
 impl fmt::Debug for MemoryMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MemoryMessage")
-            .field("name", &self.delivery.as_ref().map(|d| d.name.as_str()))
+            .field("name", &self.delivery.as_ref().map(|d| &*d.name))
             .finish_non_exhaustive()
     }
 }
@@ -737,10 +749,7 @@ impl MemoryMessage {
     /// Returns the name the message was published to.
     #[must_use]
     pub fn name(&self) -> &str {
-        self.delivery
-            .as_ref()
-            .map(|d| d.name.as_str())
-            .unwrap_or_default()
+        self.delivery.as_ref().map(|d| &*d.name).unwrap_or_default()
     }
 
     /// Converts the delivery into a broker-agnostic [`RawMessage`]. Consumes the handle without
@@ -753,7 +762,9 @@ impl MemoryMessage {
     #[must_use]
     pub fn into_raw(mut self) -> RawMessage {
         let delivery = self.delivery.take().expect("delivery already consumed");
-        RawMessage::new(delivery.name, delivery.payload).with_headers(delivery.headers)
+        // Cold path (test assertions): materializing the shared name and headers here keeps
+        // the hot fanout free of owned copies.
+        RawMessage::new(&*delivery.name, delivery.payload).with_headers((*delivery.headers).clone())
     }
 }
 


### PR DESCRIPTION
# Description

The in-memory bus paid allocation costs on its hot path: each publish cloned the destination name three times (`String`) and the header map twice, and every subscriber then received a fully owned copy of both through the per-subscriber delivery clone.

The delivery now shares its name (`Arc<str>`) and headers (`Arc<Headers>`), and the publish log is keyed by that same shared name, so:

- a publish materializes exactly one owned copy (the log entry, which must own its data);
- each subscriber's copy is two reference-count bumps plus the payload's existing cheap `Bytes` clone;
- `fanout` takes the outbound message by value, so producers (the plain publisher, transactions draining their buffer, the requester, the harness's `inject`) hand their message over instead of being cloned out of.

Internal to the memory broker: no public API changes, and the seek/replay and requeue semantics are untouched (the replay path materializes per replayed message, a cold path). No docs changes needed - nothing user-facing moved.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)