### PR TITLE
fix: keep a receive operation per handler on a shared channel

### DIFF
--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -2,7 +2,8 @@
 
 With the `asyncapi` feature, RustStream generates an [AsyncAPI 3.0](https://www.asyncapi.com/)
 document from the application's handlers: each subscriber becomes a channel and a `receive`
-operation, and payload types contribute schemas.
+operation, and payload types contribute schemas. Handlers that share a channel each keep their own
+operation - they open separate subscriptions, so the document shows one per handler.
 
 ```toml
 ruststream = { version = "0.6", features = ["macros", "memory", "asyncapi"] }

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -482,7 +482,7 @@ fn add_receive(
         );
 
     operations.insert(
-        operation_id(name),
+        receive_operation_id(operations, name),
         Operation {
             action: "receive".to_owned(),
             channel: Reference::new(format!("#/channels/{name}")),
@@ -631,8 +631,23 @@ fn add_outgoing(
 }
 
 /// Derives a stable `receive` operation id from a subscription name.
-fn operation_id(name: &str) -> String {
-    format!("receive_{}", sanitize_id(name))
+///
+/// Several handlers may share one channel (each opens its own subscription), so the name alone
+/// does not identify an operation: a collision takes a deterministic numeric suffix instead of
+/// overwriting the operation already there, as on the send side.
+fn receive_operation_id(operations: &BTreeMap<String, Operation>, name: &str) -> String {
+    let base = format!("receive_{}", sanitize_id(name));
+    if !operations.contains_key(&base) {
+        return base;
+    }
+    let mut suffix = 2;
+    loop {
+        let candidate = format!("{base}_{suffix}");
+        if !operations.contains_key(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
 }
 
 /// Derives a stable `send` operation id from the publishing handler's subscription name and

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -96,6 +96,10 @@ fn message_components_merge_and_send_ids_stay_unique() {
     assert_eq!(spec.operations["send_shared_c1"].action, "send");
     assert_eq!(spec.operations["send_shared_c2"].action, "send");
 
+    // And one receive operation per handler, for the same reason.
+    assert_eq!(spec.operations["receive_shared"].action, "receive");
+    assert_eq!(spec.operations["receive_shared_2"].action, "receive");
+
     // The shared component filled in the payload schema from the later contributor (so the
     // coverage gate reports no false gap) and kept the first headers schema on conflict.
     let component = &spec.components.messages["u64"];
@@ -534,5 +538,57 @@ mod typed_headers_spec {
 
         // Every model here derives JsonSchema: the coverage gate reports no gaps.
         assert!(spec.messages_without_schema().is_empty());
+    }
+}
+
+/// Two handlers on one channel: each opens its own subscription, so each is its own receive
+/// operation rather than the second overwriting the first.
+#[derive(serde::Deserialize)]
+struct Audited {
+    #[allow(dead_code)]
+    id: u32,
+}
+
+/// Audits every order.
+#[ruststream::subscriber("orders.shared")]
+async fn audit_shared(order: &Audited) -> HandlerResult {
+    let _ = order;
+    HandlerResult::Ack
+}
+
+/// Bills every order.
+#[ruststream::subscriber("orders.shared")]
+async fn bill_shared(order: &Audited) -> HandlerResult {
+    let _ = order;
+    HandlerResult::Ack
+}
+
+#[test]
+fn every_handler_on_a_shared_channel_gets_its_own_receive_operation() {
+    let app = RustStream::new(AppInfo::new("svc", "1.0.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(audit_shared);
+        b.include(bill_shared);
+    });
+
+    let spec = build_spec(&app);
+
+    assert_eq!(app.handlers().len(), 2);
+    let receives: Vec<&String> = spec
+        .operations
+        .iter()
+        .filter(|(_, operation)| operation.action == "receive")
+        .map(|(id, _)| id)
+        .collect();
+    assert_eq!(
+        receives,
+        vec!["receive_orders_shared", "receive_orders_shared_2"]
+    );
+
+    // Both describe the same channel; only the operation id disambiguates them.
+    for id in receives {
+        assert_eq!(
+            spec.operations[id].channel.reference,
+            "#/channels/orders.shared"
+        );
     }
 }


### PR DESCRIPTION
# Description

Several handlers may share one channel: each opens its own subscription, and the runtime dispatches
them independently. The generated AsyncAPI document did not reflect that, because the receive
operation id was derived from the channel name alone and operations are stored by id, so a second
handler on the same channel overwrote the first. The document then described fewer handlers than the
service actually runs, silently.

The receive id now takes a deterministic numeric suffix when it would collide, which is what the
send side already does for the same reason. A service with one handler per channel gets exactly the
document it got before; only the case that previously lost an operation changes.

Based on the typed-headers branch rather than main, since the send-side handling it mirrors lives
there.

Fixes #228

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)