### PR TITLE
refactor: drop the seeker token from the seek surface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,7 @@ pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::{DefaultPublish, PairError, PublishPolicy, Publisher};
 pub use schema::{HeadersContract, Message, MessageHeaders, NoHeaders, WithHeaders};
 pub use subscriber::Subscriber;
-pub use subscription::{
-    Name, SeekerPendingError, SeekerToken, StartAt, SubscriptionSource, WithSeeker,
-};
+pub use subscription::{Name, StartAt, SubscriptionSource};
 pub use typed_headers::{DeserializeHeadersError, SerializeHeadersError};
 
 pub mod codec;

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -10,13 +10,7 @@
 //! takes a source (a name string or a broker config value), the runtime resolves it once against
 //! the [`ConnectedBroker`] form produced by [`Broker::connect`](crate::Broker::connect).
 
-use std::{
-    borrow::Cow,
-    future::Future,
-    sync::{Arc, OnceLock},
-};
-
-use thiserror::Error;
+use std::{borrow::Cow, future::Future};
 
 use crate::{ConnectedBroker, Seekable, Seeker, Subscribe, Subscriber};
 
@@ -99,87 +93,6 @@ impl<C: Subscribe> SubscriptionSource<C> for Name {
 
     async fn subscribe(self, connected: &C) -> Result<Self::Subscriber, C::Error> {
         connected.subscribe(&self.0).await
-    }
-}
-
-/// A source decorator handing out the subscription's [`Seeker`] through a
-/// [`SeekerToken`] minted before registration.
-///
-/// The runtime owns the subscriber for the life of the service, so application code cannot call
-/// [`Seekable::seeker`] itself. `attach` wraps any [`SubscriptionSource`] whose subscriber is
-/// [`Seekable`] and returns the token alongside it: mount the wrapped source anywhere a source
-/// goes, and once the runtime opens the subscription at startup the token resolves to the live
-/// seeker. On a broker without the [`Seekable`] capability the wrapped source does not implement
-/// [`SubscriptionSource`], so the mount fails to compile instead of failing at runtime.
-///
-/// # Examples
-///
-/// ```
-/// # #[cfg(feature = "memory")]
-/// # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
-/// use ruststream::memory::{MemoryBroker, MemoryPosition, MemorySource};
-/// use ruststream::{Broker, Seeker, SubscriptionSource, WithSeeker};
-///
-/// let (source, token) = WithSeeker::attach(MemorySource::new("orders"));
-///
-/// // The runtime does this at startup; the token resolves once the subscription is open.
-/// let connected = MemoryBroker::new().connect().await?;
-/// let subscriber = source.subscribe(&connected).await?;
-///
-/// token.seeker()?.seek(MemoryPosition::start()).await?;
-/// # let _ = subscriber;
-/// # Ok(())
-/// # }
-/// ```
-pub struct WithSeeker<S, K> {
-    inner: S,
-    slot: Arc<OnceLock<K>>,
-}
-
-impl<S, K> WithSeeker<S, K> {
-    /// Wraps `source`, returning the decorated source and the token its seeker will resolve
-    /// through once the subscription opens.
-    #[must_use]
-    pub fn attach(source: S) -> (Self, SeekerToken<K>) {
-        let slot = Arc::new(OnceLock::new());
-        (
-            Self {
-                inner: source,
-                slot: Arc::clone(&slot),
-            },
-            SeekerToken { slot },
-        )
-    }
-}
-
-impl<S, K> std::fmt::Debug for WithSeeker<S, K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WithSeeker").finish_non_exhaustive()
-    }
-}
-
-impl<C, S, K> SubscriptionSource<C> for WithSeeker<S, K>
-where
-    C: ConnectedBroker,
-    // `Send` on the source and the (`Seeker`-implied) markers on `K` keep the returned future
-    // `Send`, as the trait's RPITIT promises.
-    S: SubscriptionSource<C> + Send,
-    S::Subscriber: Seekable<Seeker = K>,
-    K: Seeker,
-{
-    type Subscriber = S::Subscriber;
-
-    fn name(&self) -> &str {
-        self.inner.name()
-    }
-
-    async fn subscribe(self, connected: &C) -> Result<Self::Subscriber, C::Error> {
-        let subscriber = self.inner.subscribe(connected).await?;
-        // `subscribe` consumes the source, so the slot is filled at most once; the fill happens
-        // before the subscriber leaves this call, so a token can never observe an open
-        // subscription without its seeker.
-        let _ = self.slot.set(subscriber.seeker());
-        Ok(subscriber)
     }
 }
 
@@ -273,91 +186,10 @@ where
     }
 }
 
-/// Resolves the [`Seeker`] of a subscription mounted through [`WithSeeker::attach`].
-///
-/// Clonable and cheap: hand one copy to an admin endpoint, keep another in the application
-/// state. The token resolves once the runtime has opened the subscription (startup), so redeem
-/// it in an [`after_startup`](crate::runtime::RustStream::after_startup) hook, from
-/// [`RunningApp`](crate::runtime::RunningApp)-scoped code, or inside a handler.
-///
-/// # Examples
-///
-/// ```
-/// # #[cfg(feature = "memory")]
-/// # fn demo() {
-/// use ruststream::WithSeeker;
-/// use ruststream::memory::{MemorySeeker, MemorySource};
-///
-/// let (source, token) = WithSeeker::<_, MemorySeeker>::attach(MemorySource::new("orders"));
-/// // Not opened yet: redeeming before startup reports the pending state.
-/// assert!(token.seeker().is_err());
-/// # let _ = source;
-/// # }
-/// ```
-pub struct SeekerToken<K> {
-    slot: Arc<OnceLock<K>>,
-}
-
-impl<K> Clone for SeekerToken<K> {
-    fn clone(&self) -> Self {
-        Self {
-            slot: Arc::clone(&self.slot),
-        }
-    }
-}
-
-impl<K> std::fmt::Debug for SeekerToken<K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SeekerToken")
-            .field("resolved", &self.slot.get().is_some())
-            .finish_non_exhaustive()
-    }
-}
-
-impl<K: Seeker> SeekerToken<K> {
-    /// Returns a clone of the live seeker.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SeekerPendingError`] before the runtime has opened the subscription (the app
-    /// has not started yet, or the token's source was never mounted).
-    pub fn seeker(&self) -> Result<K, SeekerPendingError> {
-        self.slot.get().cloned().ok_or(SeekerPendingError)
-    }
-}
-
-/// The subscription behind a [`SeekerToken`] has not been opened yet.
-#[derive(Debug, Error)]
-#[error("the subscription this seeker token belongs to has not been opened yet")]
-#[non_exhaustive]
-pub struct SeekerPendingError;
-
 #[cfg(all(test, feature = "memory"))]
 mod tests {
     use super::*;
-    use crate::memory::{ConnectedMemoryBroker, MemoryPosition, MemorySeeker, MemorySource};
-
-    #[test]
-    fn a_pending_token_reports_it_is_unresolved() {
-        let (source, token) = WithSeeker::<_, MemorySeeker>::attach(MemorySource::new("orders"));
-
-        // Before startup the token names its state rather than handing out a half-built seeker.
-        let pending = token.seeker().expect_err("nothing has been opened yet");
-        assert!(pending.to_string().contains("has not been opened yet"));
-        assert!(format!("{token:?}").contains("resolved: false"));
-
-        // A clone shares the slot rather than taking it: both copies still report pending.
-        let clone = token.clone();
-        assert!(clone.seeker().is_err());
-        assert!(token.seeker().is_err());
-
-        // The decorated source keeps the inner subscription's name for the runtime and logs.
-        assert_eq!(
-            SubscriptionSource::<ConnectedMemoryBroker>::name(&source),
-            "orders"
-        );
-        assert!(format!("{source:?}").contains("WithSeeker"));
-    }
+    use crate::memory::{ConnectedMemoryBroker, MemoryPosition, MemorySource};
 
     #[test]
     fn a_start_position_decorates_the_source_it_wraps() {

--- a/tests/seek_api.rs
+++ b/tests/seek_api.rs
@@ -1,5 +1,5 @@
-//! The user-facing seek surface: a `WithSeeker` token repositioning a runtime-owned
-//! subscription from outside, and a `Seek` handler parameter repositioning it from inside.
+//! The user-facing seek surface: a `Seek` handler parameter repositioning the subscription
+//! from inside a delivery, and a `start_at(..)` clause choosing where it opens.
 #![cfg(all(
     feature = "memory",
     feature = "macros",
@@ -16,7 +16,7 @@ use tokio::sync::Notify;
 use ruststream::memory::{MemoryBroker, MemoryPosition, MemoryPublish, MemorySeeker, MemorySource};
 use ruststream::runtime::{AppInfo, HandlerResult, Out, RustStream, Seek};
 use ruststream::testing::{TestApp, expect_published};
-use ruststream::{Broker, OutgoingMessage, Publisher, Seeker, WithSeeker, subscriber};
+use ruststream::{Broker, OutgoingMessage, Publisher, Seeker, subscriber};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -26,60 +26,6 @@ struct Event {
 
 fn payload(id: u64) -> Vec<u8> {
     serde_json::to_vec(&Event { id }).expect("serializable")
-}
-
-#[subscriber("seek.audit")]
-async fn record(_event: &Event) -> HandlerResult {
-    HandlerResult::Ack
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_token_repositions_a_runtime_owned_subscription() {
-    let broker = MemoryBroker::new();
-    let ingress = broker.publisher();
-
-    let (source, token) = WithSeeker::attach(MemorySource::new("seek.audit"));
-    let app = RustStream::new(AppInfo::new("audit", "0.1.0")).with_broker(broker, |b| {
-        b.include_on(source, record);
-    });
-    let tb = TestApp::start(app).await.expect("harness start");
-
-    ingress
-        .publish(OutgoingMessage::new("seek.audit", payload(1).as_slice()))
-        .await
-        .expect("publish");
-    tb.settle().await.expect("settle");
-    tb.broker::<MemoryBroker>()
-        .subscriber("seek.audit")
-        .assert_called_once();
-
-    // Resolves once the app has started; Err before that.
-    let seeker = token.seeker().expect("the subscription is open");
-    seeker
-        .seek(MemoryPosition::start())
-        .await
-        .expect("seek back");
-
-    // The publish keeps the reaction in flight until the replay is applied, so `settle` waits
-    // for both the replayed and the new delivery.
-    ingress
-        .publish(OutgoingMessage::new("seek.audit", payload(2).as_slice()))
-        .await
-        .expect("publish");
-    tb.settle().await.expect("settle");
-
-    let received: Vec<Event> = tb
-        .broker::<MemoryBroker>()
-        .subscriber("seek.audit")
-        .received();
-    let ids: Vec<u64> = received.iter().map(|event| event.id).collect();
-    assert_eq!(
-        ids,
-        [1, 1, 2],
-        "the seek must replay the first delivery before the new publish",
-    );
-
-    tb.shutdown().await.expect("graceful shutdown");
 }
 
 /// Jumps forward when the producer marks a poison region: everything queued before the
@@ -294,16 +240,6 @@ async fn a_raw_handler_composes_with_a_seek_parameter() {
     );
 
     tb.shutdown().await.expect("graceful shutdown");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_token_is_pending_before_startup() {
-    let (_source, token) = WithSeeker::attach(MemorySource::new("seek.unopened"));
-    let token: ruststream::SeekerToken<MemorySeeker> = token;
-    assert!(
-        token.seeker().is_err(),
-        "a token must not resolve before the runtime opens the subscription",
-    );
 }
 
 // Observed through statics: batch handlers bypass the per-message instrumentation the


### PR DESCRIPTION
# Description

Removes the seeker-token path from the seek surface.

Seeking a live subscription is a per-delivery decision, and the canonical way to take it is the
`Seek(seeker): Seek<K>` handler parameter; choosing where a subscription opens is the
`start_at(..)` clause. `WithSeeker` handed the same seeker out a second way, through a
`SeekerToken` minted at the include site and resolved from a cell once the runtime opened the
subscription. That duplicate has a strictly weaker contract than the parameter it duplicates:
the token is resolved at runtime, so redeeming it before startup (or after mounting a source
that was never included) is an error value, `SeekerPendingError`, where the parameter cannot be
in that state at all. It existed to exercise the mechanism from test code, and nothing outside
this repository's own tests mounted one.

Removed:

- `WithSeeker` (the source decorator and its `SubscriptionSource` impl)
- `SeekerToken`
- `SeekerPendingError`
- their re-exports from the crate root
- the two tests in `tests/seek_api.rs` that exercised the token, plus the subscriber definition
  only they mounted

Unchanged: the `Seekable`, `Seeker` and `Positioned` capability traits, `StartAt`, the
`start_at(..)` macro clause, and the `Seek(seeker): Seek<K>` handler parameter. Every remaining
test in `tests/seek_api.rs` (in-handler seek, `start_at` replay, and the `Out` / `raw` /
`batch` / `publish` compositions) is kept as it was.

An audit of all sibling broker crates found no use of `WithSeeker`, `SeekerToken` or
`SeekerPendingError`, so nothing adopts what is being removed. No documentation prose referenced
them either; the docs already describe seeking through the parameter and the clause.

## Type of change

- [x] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
