### PR TITLE
docs: correct the Subscribe by-name description

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -349,11 +349,12 @@ pub trait Partitioned {
 
 /// A connected broker whose subscriptions are fully determined by a name string.
 ///
-/// This is the common case (`NATS` core subjects, the in-memory broadcast broker, `Redis` pub/sub
-/// channels): no consumer group, partition, or durable-consumer configuration is needed to open a
-/// subscription, so the runtime can subscribe given just a name. Brokers whose subscriptions
-/// require richer options (`Kafka` consumer groups, `JetStream` durable consumers) do not
-/// implement `Subscribe`; callers describe those with a broker-specific
+/// A broker implements this when a name alone identifies one of its subscriptions: it maps the
+/// name onto the subscription kind it treats as its default (a `NATS` core subject, a `Redis`
+/// stream). Whatever that kind needs beyond a name, such as a consumer group or a durable
+/// subscription name, is configured once on the broker itself; a broker left without that setting
+/// rejects the subscription with an error naming the fix rather than inventing a default. Kinds
+/// outside that default are described with a broker-specific
 /// [`SubscriptionSource`](crate::SubscriptionSource) instead.
 ///
 /// Implemented on the [`ConnectedBroker`](crate::ConnectedBroker) form: a subscription needs a


### PR DESCRIPTION
# Description

The `Subscribe` trait doc described the by-name case as "no consumer group, partition, or
durable-consumer configuration is needed", and claimed that brokers needing richer options
(consumer groups, durable consumers) do not implement the trait at all. Both claims are wrong
about how brokers in the family actually work: a broker maps a name onto the subscription kind it
treats as its default and takes whatever else that kind needs (a consumer group, a durable name)
from broker-level configuration, rejecting the subscription with an error naming the fix when that
setting is missing.

This paragraph is what a broker author reads when deciding whether to implement `Subscribe`, so the
wrong rule propagates into broker crates. The replacement states the rule instead of enumerating
brokers, so it stays true as the ecosystem changes.

Documentation only: no API, behaviour, or version change. The doctest in the comment is untouched
and still compiles. Checked the docs site, README, and the rest of the rustdoc for the same claim;
it appears nowhere else.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`, plus `cargo test --workspace --doc` with and
      without default features and a rustdoc build under `-D warnings`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
