### PR TITLE
feat: unify publishing behind one builder with defaulted positions

### DIFF
--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -649,12 +649,15 @@ fn outgoing_method(
             None => quote! {
                 __rs_outgoing.extend(<#marker as ::ruststream::runtime::OutSlot>::outgoing());
             },
+            // Each listed type declares itself: a one-element set whose channel comes from the
+            // type's own #[outgoing(name = ..)], or from the marker's deprecated dictionary.
             Some(BodyDecl::List(bodies)) => {
                 let entries = bodies.iter().map(|body| {
-                    let channel = quote! {
-                        <#body as ::ruststream::runtime::OutMessage<#marker>>::CHANNEL
-                    };
-                    outgoing_entry(&channel, &quote!(#body))
+                    quote! {
+                        __rs_outgoing.extend(
+                            <#body as ::ruststream::runtime::OutMessages<#marker>>::outgoing(),
+                        );
+                    }
                 });
                 quote!(#(#entries)*)
             }
@@ -1911,7 +1914,7 @@ fn slot_bounds(outs: &[OutParam<'_>], generics: &[SlotGenerics]) -> Vec<TokenStr
         match &out.bodies {
             Some(BodyDecl::List(bodies)) => {
                 for body in bodies {
-                    out_bounds.push(quote!(#body: ::ruststream::runtime::OutMessage<#marker>));
+                    out_bounds.push(quote!(#body: ::ruststream::runtime::OutMessages<#marker>));
                 }
             }
             Some(BodyDecl::Set(set)) => {

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod expand;
 mod from_ref;
+mod outgoing;
 mod parse;
 
 use proc_macro::TokenStream;
@@ -284,6 +285,9 @@ pub fn derive_message(item: TokenStream) -> TokenStream {
         {
         }
 
+        // The set's channels come from the slot dictionary, whose name-carrying form is
+        // deprecated; the type deriving Message is not, so the warning stays at the dictionary.
+        #[allow(deprecated)]
         impl #set_impl_generics ::ruststream::runtime::OutMessages<__RsM> for #name #ty_generics
         #set_where_clause
         {
@@ -322,6 +326,49 @@ pub fn derive_message(item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+/// Derives everything a message type declares about being sent, from one `key = value`
+/// attribute: its destination
+/// ([`OutgoingDestination`](../ruststream/trait.OutgoingDestination.html)), its optional typed
+/// header contract, and the [`Message`](../ruststream/trait.Message.html) metadata the generated
+/// document reads (the type's name and doc comment).
+///
+/// The destination decides which positions the publish builder demands at the call site:
+///
+/// * `#[outgoing(name = "orders.done")]` fixes it - `publisher.message(&done).publish()` names
+///   nothing.
+/// * `#[outgoing(name = "orders.{tenant}.v1")]` declares a space of names - `to()` opens one
+///   setter per placeholder, and the publish appears once the last one is bound.
+/// * the derive alone declares nothing - the call site names it: `.to("orders.archived")`.
+///
+/// `headers = Meta` declares the typed header contract: `Meta` stays an ordinary serde struct
+/// the derive does not touch, and the publish builder then demands `with_headers(&meta)`.
+///
+/// Do not combine with `#[derive(Message)]` on the same type: this derive already provides the
+/// message metadata, and the two deliberately produce conflicting impls.
+///
+/// ```ignore
+/// /// A finished order.
+/// #[derive(Outgoing, Serialize)]
+/// #[outgoing(name = "orders.done", headers = OrderMeta)]
+/// struct OrderDone { id: u64 }
+///
+/// #[derive(Outgoing, Serialize)]
+/// #[outgoing(name = "orders.{tenant}.{region}.v1")]
+/// struct OrderPlaced { id: u64 }
+/// // out.message(&placed).to().tenant("acme").region("eu").publish().await?;
+///
+/// #[derive(Outgoing, Serialize)]
+/// struct OrderArchived { id: u64 }
+/// // out.message(&archived).to("orders.archived").publish().await?;
+/// ```
+#[proc_macro_derive(Outgoing, attributes(outgoing))]
+pub fn derive_outgoing(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    outgoing::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 /// Parses the optional `#[message(headers(Type))]` helper attribute of `#[derive(Message)]`.
@@ -383,18 +430,22 @@ pub fn derive_from_ref(item: TokenStream) -> TokenStream {
 /// [`NAME`](../ruststream/runtime/trait.OutSlot.html#associatedconstant.NAME) is the struct's
 /// identifier, used by startup errors and test assertions.
 ///
-/// The optional `#[publishes(Type = "channel", ..)]` attribute declares the slot's publish
-/// dictionary: each pair maps one message type to the channel it publishes to, enabling the
-/// typed publish path (`out.publish_typed(&value)`) and the `AsyncAPI` `send` operations.
-/// Several types may share a channel; listing one type twice is an error (its destination
-/// would be ambiguous). A marker without the attribute keeps the byte-level path only.
+/// The optional `#[publishes(Type, ..)]` attribute lists the message types the slot may
+/// publish, which is what the generated document reports for a handler leaving its `Out`
+/// parameter unrestricted. Each listed type declares its own destination with
+/// `#[derive(Outgoing)]`; listing one type twice is an error.
+///
+/// The name-carrying form `#[publishes(Type = "channel", ..)]` is deprecated: it maps the type
+/// to a channel per slot, which is what moved onto the message type. It keeps working (and keeps
+/// feeding the deprecated `out.publish_typed(&value)` path) until the deprecated surface is
+/// removed.
 ///
 /// ```ignore
 /// #[derive(OutSlot)]
 /// struct Encoded;
 ///
 /// #[derive(OutSlot)]
-/// #[publishes(ChunkDone = "chunks.done", Progress = "chunks.progress")]
+/// #[publishes(ChunkDone, Progress)]
 /// struct Events;
 ///
 /// #[subscriber("chunks", raw)]
@@ -437,50 +488,62 @@ pub fn derive_out_slot(item: TokenStream) -> TokenStream {
     let outgoing = if dictionary.is_empty() {
         quote!()
     } else {
+        // A listed type declaring its own destination contributes what it declares; one carrying
+        // the deprecated `= "channel"` form is described from the marker, as before.
         let entries = dictionary.iter().map(|entry| {
             let ty = &entry.ty;
-            let channel = &entry.channel;
+            let Some(channel) = &entry.channel else {
+                return quote! {
+                    __rs_entries.extend(
+                        <#ty as ::ruststream::runtime::OutMessages<#name>>::outgoing(),
+                    );
+                };
+            };
             quote! {
-                ::ruststream::runtime::OutgoingMessageMetadata::new(
-                    #channel,
-                    ::core::any::type_name::<#ty>(),
-                )
-                .with_message_name({
-                    #[allow(unused_imports)]
-                    use ::ruststream::__private::NoMessageProbe as _;
-                    ::ruststream::__private::Probe::<#ty>::new().message_name()
-                })
-                .with_message_description({
-                    #[allow(unused_imports)]
-                    use ::ruststream::__private::NoMessageProbe as _;
-                    ::ruststream::__private::Probe::<#ty>::new().message_description()
-                })
-                .with_payload_schema({
-                    #[allow(unused_imports)]
-                    use ::ruststream::__private::NoSchemaProbe as _;
-                    ::ruststream::__private::Probe::<#ty>::new().schema_json()
-                })
-                .with_headers_schema({
-                    #[allow(unused_imports)]
-                    use ::ruststream::__private::NoHeadersSchemaProbe as _;
-                    ::ruststream::__private::Probe::<#ty>::new().headers_schema_json()
-                })
+                __rs_entries.push(
+                    ::ruststream::runtime::OutgoingMessageMetadata::new(
+                        #channel,
+                        ::core::any::type_name::<#ty>(),
+                    )
+                    .with_message_name({
+                        #[allow(unused_imports)]
+                        use ::ruststream::__private::NoMessageProbe as _;
+                        ::ruststream::__private::Probe::<#ty>::new().message_name()
+                    })
+                    .with_message_description({
+                        #[allow(unused_imports)]
+                        use ::ruststream::__private::NoMessageProbe as _;
+                        ::ruststream::__private::Probe::<#ty>::new().message_description()
+                    })
+                    .with_payload_schema({
+                        #[allow(unused_imports)]
+                        use ::ruststream::__private::NoSchemaProbe as _;
+                        ::ruststream::__private::Probe::<#ty>::new().schema_json()
+                    })
+                    .with_headers_schema({
+                        #[allow(unused_imports)]
+                        use ::ruststream::__private::NoHeadersSchemaProbe as _;
+                        ::ruststream::__private::Probe::<#ty>::new().headers_schema_json()
+                    }),
+                );
             }
         });
         quote! {
             fn outgoing() -> ::std::vec::Vec<::ruststream::runtime::OutgoingMessageMetadata> {
-                ::std::vec![#(#entries),*]
+                let mut __rs_entries = ::std::vec::Vec::new();
+                #(#entries)*
+                __rs_entries
             }
         }
     };
-    let channels = dictionary.iter().map(|entry| {
+    let channels = dictionary.iter().filter_map(|entry| {
         let ty = &entry.ty;
-        let channel = &entry.channel;
-        quote! {
+        let channel = entry.channel.as_ref()?;
+        Some(quote! {
             impl ::ruststream::runtime::OutMessage<#name> for #ty {
                 const CHANNEL: &'static str = #channel;
             }
-        }
+        })
     });
 
     quote! {
@@ -585,6 +648,7 @@ pub fn derive_out_messages(item: TokenStream) -> TokenStream {
     quote! {
         #(#memberships)*
 
+        #[allow(deprecated)]
         impl<__RsM: ::ruststream::runtime::OutSlot> ::ruststream::runtime::OutMessages<__RsM>
             for #name
         where
@@ -634,19 +698,26 @@ fn out_messages_models(data: &syn::DataEnum) -> syn::Result<Vec<&Type>> {
     Ok(models)
 }
 
-/// One `Type = "channel"` pair of the `#[publishes(..)]` attribute.
+/// One entry of the `#[publishes(..)]` attribute: a type the slot may publish, optionally
+/// carrying the deprecated `= "channel"` destination.
 struct PublishesEntry {
     ty: Type,
-    /// The channel value: a string literal, or a const-evaluable `&'static str` expression (an
-    /// associated const initializer cannot read a `static`).
-    channel: Expr,
+    /// The channel value of the deprecated name-carrying form: a string literal, or a
+    /// const-evaluable `&'static str` expression (an associated const initializer cannot read a
+    /// `static`). `None` for the plain `#[publishes(Type, ..)]` list, where the destination
+    /// comes from the message type's own `#[derive(Outgoing)]` declaration.
+    channel: Option<Expr>,
 }
 
 impl Parse for PublishesEntry {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let ty: Type = input.parse()?;
-        input.parse::<Token![=]>()?;
-        let channel: Expr = input.parse()?;
+        let channel = if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            Some(input.parse::<Expr>()?)
+        } else {
+            None
+        };
         Ok(Self { ty, channel })
     }
 }
@@ -669,8 +740,9 @@ fn publishes_dictionary(attrs: &[Attribute]) -> syn::Result<Vec<PublishesEntry>>
             {
                 return Err(syn::Error::new_spanned(
                     &entry.ty,
-                    "this type is already in the slot's publish dictionary: one type maps to \
-                     one channel per slot (use a second slot for a second destination)",
+                    "this type is already listed on the slot: a type appears once (with the \
+                     deprecated `= \"channel\"` form, a second entry would also make its \
+                     destination ambiguous)",
                 ));
             }
             dictionary.push(entry);

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -15,7 +15,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{Attribute, DeriveInput, Expr, ItemFn, Meta, Token, Type, parse_macro_input};
+use syn::{Attribute, DeriveInput, Expr, Ident, ItemFn, Meta, Token, Type, parse_macro_input};
 
 use parse::{SubscriberArgs, doc_description};
 
@@ -432,7 +432,9 @@ pub fn derive_from_ref(item: TokenStream) -> TokenStream {
 ///
 /// The optional `#[publishes(Type, ..)]` attribute lists the message types the slot may
 /// publish, which is what the generated document reports for a handler leaving its `Out`
-/// parameter unrestricted. Each listed type declares its own destination with
+/// parameter unrestricted. The list is enforced, not only documented: publishing a type it does
+/// not name is a compile error (see `PublishedThrough` in the core crate), so the document cannot
+/// fall behind what handlers send. Each listed type declares its own destination with
 /// `#[derive(Outgoing)]`; listing one type twice is an error.
 ///
 /// The name-carrying form `#[publishes(Type = "channel", ..)]` is deprecated: it maps the type
@@ -485,57 +487,7 @@ pub fn derive_out_slot(item: TokenStream) -> TokenStream {
     let name = &input.ident;
     let name_str = name.to_string();
 
-    let outgoing = if dictionary.is_empty() {
-        quote!()
-    } else {
-        // A listed type declaring its own destination contributes what it declares; one carrying
-        // the deprecated `= "channel"` form is described from the marker, as before.
-        let entries = dictionary.iter().map(|entry| {
-            let ty = &entry.ty;
-            let Some(channel) = &entry.channel else {
-                return quote! {
-                    __rs_entries.extend(
-                        <#ty as ::ruststream::runtime::OutMessages<#name>>::outgoing(),
-                    );
-                };
-            };
-            quote! {
-                __rs_entries.push(
-                    ::ruststream::runtime::OutgoingMessageMetadata::new(
-                        #channel,
-                        ::core::any::type_name::<#ty>(),
-                    )
-                    .with_message_name({
-                        #[allow(unused_imports)]
-                        use ::ruststream::__private::NoMessageProbe as _;
-                        ::ruststream::__private::Probe::<#ty>::new().message_name()
-                    })
-                    .with_message_description({
-                        #[allow(unused_imports)]
-                        use ::ruststream::__private::NoMessageProbe as _;
-                        ::ruststream::__private::Probe::<#ty>::new().message_description()
-                    })
-                    .with_payload_schema({
-                        #[allow(unused_imports)]
-                        use ::ruststream::__private::NoSchemaProbe as _;
-                        ::ruststream::__private::Probe::<#ty>::new().schema_json()
-                    })
-                    .with_headers_schema({
-                        #[allow(unused_imports)]
-                        use ::ruststream::__private::NoHeadersSchemaProbe as _;
-                        ::ruststream::__private::Probe::<#ty>::new().headers_schema_json()
-                    }),
-                );
-            }
-        });
-        quote! {
-            fn outgoing() -> ::std::vec::Vec<::ruststream::runtime::OutgoingMessageMetadata> {
-                let mut __rs_entries = ::std::vec::Vec::new();
-                #(#entries)*
-                __rs_entries
-            }
-        }
-    };
+    let outgoing = slot_outgoing_metadata(name, &dictionary);
     let channels = dictionary.iter().filter_map(|entry| {
         let ty = &entry.ty;
         let channel = entry.channel.as_ref()?;
@@ -544,6 +496,14 @@ pub fn derive_out_slot(item: TokenStream) -> TokenStream {
                 const CHANNEL: &'static str = #channel;
             }
         })
+    });
+    // The list is the whole membership, in either form: what the document reports as leaving the
+    // slot is exactly what the publish builder admits.
+    let memberships = dictionary.iter().map(|entry| {
+        let ty = &entry.ty;
+        quote! {
+            impl ::ruststream::runtime::PublishedThrough<#name> for #ty {}
+        }
     });
 
     quote! {
@@ -554,8 +514,65 @@ pub fn derive_out_slot(item: TokenStream) -> TokenStream {
         }
 
         #(#channels)*
+
+        #(#memberships)*
     }
     .into()
+}
+
+/// The marker's `outgoing()` override, reporting its `#[publishes(..)]` dictionary as the
+/// document's outgoing messages. A listed type declaring its own destination contributes what it
+/// declares; one carrying the deprecated `= "channel"` form is described from the marker, as
+/// before. An empty dictionary keeps the trait's own default (nothing declared).
+fn slot_outgoing_metadata(name: &Ident, dictionary: &[PublishesEntry]) -> TokenStream2 {
+    if dictionary.is_empty() {
+        return quote!();
+    }
+    let entries = dictionary.iter().map(|entry| {
+        let ty = &entry.ty;
+        let Some(channel) = &entry.channel else {
+            return quote! {
+                __rs_entries.extend(
+                    <#ty as ::ruststream::runtime::OutMessages<#name>>::outgoing(),
+                );
+            };
+        };
+        quote! {
+            __rs_entries.push(
+                ::ruststream::runtime::OutgoingMessageMetadata::new(
+                    #channel,
+                    ::core::any::type_name::<#ty>(),
+                )
+                .with_message_name({
+                    #[allow(unused_imports)]
+                    use ::ruststream::__private::NoMessageProbe as _;
+                    ::ruststream::__private::Probe::<#ty>::new().message_name()
+                })
+                .with_message_description({
+                    #[allow(unused_imports)]
+                    use ::ruststream::__private::NoMessageProbe as _;
+                    ::ruststream::__private::Probe::<#ty>::new().message_description()
+                })
+                .with_payload_schema({
+                    #[allow(unused_imports)]
+                    use ::ruststream::__private::NoSchemaProbe as _;
+                    ::ruststream::__private::Probe::<#ty>::new().schema_json()
+                })
+                .with_headers_schema({
+                    #[allow(unused_imports)]
+                    use ::ruststream::__private::NoHeadersSchemaProbe as _;
+                    ::ruststream::__private::Probe::<#ty>::new().headers_schema_json()
+                }),
+            );
+        }
+    });
+    quote! {
+        fn outgoing() -> ::std::vec::Vec<::ruststream::runtime::OutgoingMessageMetadata> {
+            let mut __rs_entries = ::std::vec::Vec::new();
+            #(#entries)*
+            __rs_entries
+        }
+    }
 }
 
 /// Derives a declared message set (`OutMessages` in the core crate) from an enum whose

--- a/crates/ruststream-macros/src/outgoing.rs
+++ b/crates/ruststream-macros/src/outgoing.rs
@@ -1,0 +1,494 @@
+//! `#[derive(Outgoing)]`: everything a message type declares about being sent.
+
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{ToTokens, format_ident, quote};
+use syn::punctuated::Punctuated;
+use syn::{Attribute, DeriveInput, Expr, Ident, LitStr, Meta, Token, Type};
+
+use crate::parse::doc_description;
+
+/// The parsed `#[outgoing(..)]` attribute: the declared destination and the header contract.
+struct OutgoingArgs {
+    name: Option<LitStr>,
+    headers: Option<Type>,
+}
+
+/// The declared name, split into what the generated code needs from it.
+struct Template {
+    /// The literal parts around the placeholders, in order (one more than the placeholders).
+    literals: Vec<String>,
+    /// The placeholder names, in order.
+    placeholders: Vec<Ident>,
+}
+
+impl Template {
+    /// The `format!` string that renders the address: the literal parts with `{}` between them.
+    fn format_string(&self) -> String {
+        self.literals.join("{}")
+    }
+}
+
+pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let args = parse_args(&input.attrs)?;
+    let name = &input.ident;
+    let name_str = name.to_string();
+    let description = doc_description(&input.attrs);
+    let vis = &input.vis;
+    let contract = args.headers.as_ref().map_or_else(
+        || quote!(::ruststream::NoHeaders),
+        |headers| quote!(::ruststream::WithHeaders<#headers>),
+    );
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let template = args.name.as_ref().map(parse_template).transpose()?;
+    let address = args
+        .name
+        .as_ref()
+        .map_or_else(|| quote!(""), |literal| quote!(#literal));
+    let (form, parameters, template_items) = match &template {
+        None => (quote!(::ruststream::CallerName), quote!(&[]), quote!()),
+        Some(template) if template.placeholders.is_empty() => {
+            (quote!(::ruststream::FixedName), quote!(&[]), quote!())
+        }
+        Some(template) => {
+            let names = template
+                .placeholders
+                .iter()
+                .map(|placeholder| LitStr::new(&placeholder.to_string(), placeholder.span()));
+            let items = template_builder(name, vis, template, &input.generics);
+            (
+                quote!(::ruststream::NameTemplate),
+                quote!(&[#(#names),*]),
+                items,
+            )
+        }
+    };
+
+    let entries = declared_entries(template.is_some(), name, &ty_generics, &parameters);
+
+    // The OutMessages impl adds its own marker type parameter; pushing it onto a clone of the
+    // generics (after any lifetimes) keeps the emitted parameter order legal.
+    let mut set_generics = input.generics.clone();
+    set_generics
+        .params
+        .push(syn::parse_quote!(__RsM: ::ruststream::runtime::OutSlot));
+    let (set_impl_generics, _, set_where_clause) = set_generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::ruststream::OutgoingDestination for #name #ty_generics
+        #where_clause
+        {
+            type Form = #form;
+            const ADDRESS: &'static str = #address;
+            const PARAMETERS: &'static [&'static str] = #parameters;
+        }
+
+        impl #impl_generics ::ruststream::Message for #name #ty_generics #where_clause {
+            const NAME: &'static str = #name_str;
+            const DESCRIPTION: ::core::option::Option<&'static str> = #description;
+        }
+
+        impl #impl_generics ::ruststream::MessageHeaders for #name #ty_generics #where_clause {
+            type Contract = #contract;
+        }
+
+        // The type as a one-element declared message set: `Out<.., Marker, TheType>`.
+        impl #impl_generics
+            ::ruststream::runtime::ContainsMessage<#name #ty_generics, ::ruststream::runtime::SlotPos<0>>
+            for #name #ty_generics #where_clause
+        {
+        }
+
+        impl #set_impl_generics ::ruststream::runtime::OutMessages<__RsM> for #name #ty_generics
+        #set_where_clause
+        {
+            fn outgoing()
+                -> ::std::vec::Vec<::ruststream::runtime::OutgoingMessageMetadata>
+            {
+                #entries
+            }
+        }
+
+        #template_items
+    })
+}
+
+/// The type's own contribution to the generated document.
+///
+/// A type declaring no destination says nothing about where it goes, so it contributes no
+/// channel; the other two forms declare theirs, the templated one with its parameters.
+fn declared_entries(
+    declares: bool,
+    name: &Ident,
+    ty_generics: &syn::TypeGenerics<'_>,
+    parameters: &TokenStream2,
+) -> TokenStream2 {
+    if !declares {
+        return quote!(::std::vec::Vec::new());
+    }
+    quote! {
+        ::std::vec![
+            ::ruststream::runtime::OutgoingMessageMetadata::new(
+                <#name #ty_generics as ::ruststream::OutgoingDestination>::ADDRESS,
+                ::core::any::type_name::<#name #ty_generics>(),
+            )
+            .with_parameters(#parameters)
+            .with_message_name({
+                #[allow(unused_imports)]
+                use ::ruststream::__private::NoMessageProbe as _;
+                ::ruststream::__private::Probe::<#name #ty_generics>::new().message_name()
+            })
+            .with_message_description({
+                #[allow(unused_imports)]
+                use ::ruststream::__private::NoMessageProbe as _;
+                ::ruststream::__private::Probe::<#name #ty_generics>::new().message_description()
+            })
+            .with_payload_schema({
+                #[allow(unused_imports)]
+                use ::ruststream::__private::NoSchemaProbe as _;
+                ::ruststream::__private::Probe::<#name #ty_generics>::new().schema_json()
+            })
+            .with_headers_schema({
+                #[allow(unused_imports)]
+                use ::ruststream::__private::NoHeadersSchemaProbe as _;
+                ::ruststream::__private::Probe::<#name #ty_generics>::new().headers_schema_json()
+            }),
+        ]
+    }
+}
+
+/// Parses `#[outgoing(name = "..", headers = Type)]`, in any order, at most one of each.
+fn parse_args(attrs: &[Attribute]) -> syn::Result<OutgoingArgs> {
+    let mut args = OutgoingArgs {
+        name: None,
+        headers: None,
+    };
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("outgoing")) {
+        let metas = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+        for meta in metas {
+            let Meta::NameValue(pair) = &meta else {
+                return Err(syn::Error::new_spanned(
+                    &meta,
+                    "every #[outgoing(..)] parameter is `key = value`: `name = \"orders.done\"`, \
+                     `headers = OrderMeta`",
+                ));
+            };
+            if pair.path.is_ident("name") {
+                let literal = string_literal(&pair.value)?;
+                if args.name.replace(literal).is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &meta,
+                        "duplicate `name`: a message declares one destination",
+                    ));
+                }
+            } else if pair.path.is_ident("headers") {
+                let headers: Type = syn::parse2(pair.value.to_token_stream())?;
+                if args.headers.replace(headers).is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &meta,
+                        "duplicate `headers`: a message declares one header contract",
+                    ));
+                }
+            } else {
+                return Err(syn::Error::new_spanned(
+                    &pair.path,
+                    "unknown #[outgoing(..)] parameter: expected `name` or `headers`",
+                ));
+            }
+        }
+    }
+    Ok(args)
+}
+
+/// The `name = ..` value: a string literal, since the placeholders are read at compile time.
+fn string_literal(value: &Expr) -> syn::Result<LitStr> {
+    if let Expr::Lit(literal) = value
+        && let syn::Lit::Str(string) = &literal.lit
+    {
+        return Ok(string.clone());
+    }
+    Err(syn::Error::new_spanned(
+        value,
+        "`name` is a string literal: the destination (and its `{placeholder}` segments) is read \
+         at compile time",
+    ))
+}
+
+/// Splits a declared name into its literal parts and its `{placeholder}` segments.
+fn parse_template(literal: &LitStr) -> syn::Result<Template> {
+    let declared = literal.value();
+    let span = literal.span();
+    let mut literals = Vec::new();
+    let mut placeholders: Vec<Ident> = Vec::new();
+    let mut current = String::new();
+    let mut rest = declared.as_str();
+    while let Some(open) = rest.find('{') {
+        current.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('}') else {
+            return Err(syn::Error::new(
+                span,
+                "unclosed `{` in the declared name: every placeholder reads `{segment}`",
+            ));
+        };
+        let placeholder = &after[..close];
+        if placeholder.is_empty() {
+            return Err(syn::Error::new(
+                span,
+                "empty placeholder in the declared name: name the segment, as in `{tenant}`",
+            ));
+        }
+        let ident = syn::parse_str::<Ident>(placeholder).map_err(|_| {
+            syn::Error::new(
+                span,
+                format!(
+                    "`{placeholder}` is not a valid segment name: a placeholder becomes the \
+                     setter that binds it, so it has to be an identifier"
+                ),
+            )
+        })?;
+        if placeholders.contains(&ident) {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "`{placeholder}` appears twice in the declared name: one setter cannot bind \
+                     two segments"
+                ),
+            ));
+        }
+        placeholders.push(ident);
+        literals.push(std::mem::take(&mut current));
+        rest = &after[close + 1..];
+    }
+    if rest.contains('}') {
+        return Err(syn::Error::new(
+            span,
+            "unmatched `}` in the declared name: every placeholder reads `{segment}`",
+        ));
+    }
+    current.push_str(rest);
+    literals.push(current);
+    Ok(Template {
+        literals,
+        placeholders,
+    })
+}
+
+/// The generated address builder of a templated name: one setter per placeholder, and a publish
+/// terminal that exists only once every one of them is bound.
+fn template_builder(
+    name: &Ident,
+    vis: &syn::Visibility,
+    template: &Template,
+    generics: &syn::Generics,
+) -> TokenStream2 {
+    let module = format_ident!("__ruststream_{}_address", to_snake_case(&name.to_string()));
+    let markers: Vec<Ident> = template
+        .placeholders
+        .iter()
+        .map(|placeholder| Ident::new(&to_pascal_case(&placeholder.to_string()), Span::call_site()))
+        .collect();
+    let fields: Vec<Ident> = (0..template.placeholders.len())
+        .map(|index| format_ident!("segment_{index}"))
+        .collect();
+    let states: Vec<Ident> = (0..template.placeholders.len())
+        .map(|index| format_ident!("S{index}"))
+        .collect();
+
+    let marker_items = markers
+        .iter()
+        .zip(&template.placeholders)
+        .map(|(marker, placeholder)| {
+            let doc = format!(
+                "The `{placeholder}` segment of the declared name, named in the compile error \
+                 of a publish that never bound it."
+            );
+            quote! {
+                #[doc = #doc]
+                #[derive(Debug, Clone, Copy)]
+                pub struct #marker;
+            }
+        });
+
+    let defaults = markers
+        .iter()
+        .zip(&states)
+        .map(|(marker, state)| quote!(#state = ::ruststream::runtime::MissingSegment<#marker>));
+    let start_fields = fields
+        .iter()
+        .map(|field| quote!(#field: ::ruststream::runtime::MissingSegment::new()));
+    let struct_fields = fields
+        .iter()
+        .zip(&states)
+        .map(|(field, state)| quote!(#field: #state));
+
+    let setters = template
+        .placeholders
+        .iter()
+        .enumerate()
+        .map(|(index, placeholder)| setter(index, placeholder, &markers, &fields, &states));
+
+    let bound = fields.iter().map(|_| quote!(::std::string::String));
+    let format_string = template.format_string();
+    let format_args = fields.iter().map(|field| quote!(self.#field));
+    let (_, ty_generics, _) = generics.split_for_impl();
+    let mut template_generics = generics.clone();
+    template_generics.params.push(syn::parse_quote!(__RsCont));
+    let (template_impl_generics, _, template_where_clause) = template_generics.split_for_impl();
+    let module_doc = format!(
+        "The address builder of [`{name}`](super::{name}): one setter per placeholder of its \
+         declared name."
+    );
+
+    quote! {
+        #[doc = #module_doc]
+        #[doc(hidden)]
+        #vis mod #module {
+            #(#marker_items)*
+
+            /// One publish whose templated address is being bound, segment by segment.
+            ///
+            /// The publish terminal appears once every placeholder is bound; until then the
+            /// unbound ones ride in this type, so the compile error names them.
+            #[must_use = "an address builder does nothing until publish() is awaited"]
+            pub struct To<Cont #(, #defaults)*> {
+                pub(super) cont: Cont,
+                #(pub(super) #struct_fields,)*
+            }
+
+            impl<Cont> To<Cont> {
+                /// Opens the address builder over the publish it finishes.
+                pub(super) fn start(cont: Cont) -> Self {
+                    Self { cont #(, #start_fields)* }
+                }
+            }
+
+            #(#setters)*
+
+            impl<Cont: ::ruststream::runtime::PublishAt> To<Cont #(, #bound)*> {
+                /// Renders the declared name with the bound segments and publishes to it.
+                ///
+                /// # Errors
+                ///
+                /// Returns [`PublishError`](::ruststream::runtime::PublishError) when the
+                /// payload cannot be encoded, the typed headers cannot be serialized, or the
+                /// broker rejects the message.
+                pub async fn publish(
+                    self,
+                ) -> ::core::result::Result<
+                    (),
+                    ::ruststream::runtime::PublishError<
+                        <Cont as ::ruststream::runtime::PublishAt>::Error,
+                    >,
+                > {
+                    // A templated address is rendered per publish: that allocation is what
+                    // computing an address at run time costs, and the fixed form avoids it.
+                    let address = ::std::format!(#format_string #(, #format_args)*);
+                    ::ruststream::runtime::PublishAt::publish_at(self.cont, &address).await
+                }
+            }
+        }
+
+        impl #template_impl_generics ::ruststream::runtime::TemplateAddress<__RsCont>
+            for #name #ty_generics
+        #template_where_clause
+        {
+            type Builder = #module::To<__RsCont>;
+
+            fn begin(cont: __RsCont) -> Self::Builder {
+                #module::To::start(cont)
+            }
+        }
+    }
+}
+
+/// One placeholder's setter: it exists while that segment is unbound, and leaves the rendered
+/// value in its place.
+fn setter(
+    index: usize,
+    placeholder: &Ident,
+    markers: &[Ident],
+    fields: &[Ident],
+    states: &[Ident],
+) -> TokenStream2 {
+    let marker = &markers[index];
+    let before: Vec<TokenStream2> = states
+        .iter()
+        .enumerate()
+        .map(|(position, state)| {
+            if position == index {
+                quote!(::ruststream::runtime::MissingSegment<#marker>)
+            } else {
+                quote!(#state)
+            }
+        })
+        .collect();
+    let after: Vec<TokenStream2> = states
+        .iter()
+        .enumerate()
+        .map(|(position, state)| {
+            if position == index {
+                quote!(::std::string::String)
+            } else {
+                quote!(#state)
+            }
+        })
+        .collect();
+    let open = states
+        .iter()
+        .enumerate()
+        .filter(|(position, _)| *position != index)
+        .map(|(_, state)| quote!(#state));
+    let moved = fields.iter().enumerate().map(|(position, field)| {
+        if position == index {
+            quote!(#field: ::std::string::ToString::to_string(&value))
+        } else {
+            quote!(#field: self.#field)
+        }
+    });
+    let doc = format!("Binds the `{placeholder}` segment of the declared name.");
+    quote! {
+        impl<Cont #(, #open)*> To<Cont #(, #before)*> {
+            #[doc = #doc]
+            pub fn #placeholder(
+                self,
+                value: impl ::core::fmt::Display,
+            ) -> To<Cont #(, #after)*> {
+                To { cont: self.cont #(, #moved)* }
+            }
+        }
+    }
+}
+
+/// `OrderPlaced` -> `order_placed`, for the generated module name.
+fn to_snake_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (index, ch) in name.char_indices() {
+        if ch.is_ascii_uppercase() {
+            if index != 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// `tenant_id` -> `TenantId`, for the generated segment marker.
+fn to_pascal_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut upper = true;
+    for ch in name.chars() {
+        if ch == '_' {
+            upper = true;
+        } else if upper {
+            out.extend(ch.to_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/ruststream-macros/src/outgoing.rs
+++ b/crates/ruststream-macros/src/outgoing.rs
@@ -310,10 +310,11 @@ fn template_builder(
             }
         });
 
-    let defaults = markers
+    // The state parameters carry no defaults on purpose: rustc elides a defaulted parameter when
+    // it renders a type, and eliding the unbound segment is exactly what the error must not do.
+    let unbound = markers
         .iter()
-        .zip(&states)
-        .map(|(marker, state)| quote!(#state = ::ruststream::runtime::MissingSegment<#marker>));
+        .map(|marker| quote!(::ruststream::runtime::MissingSegment<#marker>));
     let start_fields = fields
         .iter()
         .map(|field| quote!(#field: ::ruststream::runtime::MissingSegment::new()));
@@ -351,12 +352,12 @@ fn template_builder(
             /// The publish terminal appears once every placeholder is bound; until then the
             /// unbound ones ride in this type, so the compile error names them.
             #[must_use = "an address builder does nothing until publish() is awaited"]
-            pub struct To<Cont #(, #defaults)*> {
+            pub struct To<Cont #(, #states)*> {
                 pub(super) cont: Cont,
                 #(pub(super) #struct_fields,)*
             }
 
-            impl<Cont> To<Cont> {
+            impl<Cont> To<Cont #(, #unbound)*> {
                 /// Opens the address builder over the publish it finishes.
                 pub(super) fn start(cont: Cont) -> Self {
                     Self { cont #(, #start_fields)* }
@@ -393,7 +394,7 @@ fn template_builder(
             for #name #ty_generics
         #template_where_clause
         {
-            type Builder = #module::To<__RsCont>;
+            type Builder = #module::To<__RsCont #(, ::ruststream::runtime::MissingSegment<#module::#markers>)*>;
 
             fn begin(cont: __RsCont) -> Self::Builder {
                 #module::To::start(cont)

--- a/crates/ruststream-macros/src/outgoing.rs
+++ b/crates/ruststream-macros/src/outgoing.rs
@@ -366,7 +366,7 @@ fn template_builder(
 
             #(#setters)*
 
-            impl<Cont: ::ruststream::runtime::PublishAt> To<Cont #(, #bound)*> {
+            impl<Cont> To<Cont #(, #bound)*> {
                 /// Renders the declared name with the bound segments and publishes to it.
                 ///
                 /// # Errors
@@ -374,6 +374,9 @@ fn template_builder(
                 /// Returns [`PublishError`](::ruststream::runtime::PublishError) when the
                 /// payload cannot be encoded, the typed headers cannot be serialized, or the
                 /// broker rejects the message.
+                // The bound sits on the method, not on the impl block: carried by the block it
+                // turns a publish the message's own declarations reject into "method not
+                // found", which drops the guidance those declarations come with.
                 pub async fn publish(
                     self,
                 ) -> ::core::result::Result<
@@ -381,7 +384,10 @@ fn template_builder(
                     ::ruststream::runtime::PublishError<
                         <Cont as ::ruststream::runtime::PublishAt>::Error,
                     >,
-                > {
+                >
+                where
+                    Cont: ::ruststream::runtime::PublishAt,
+                {
                     // A templated address is rendered per publish: that allocation is what
                     // computing an address at run time costs, and the fixed form avoids it.
                     let address = ::std::format!(#format_string #(, #format_args)*);

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -126,6 +126,12 @@ pub trait Publisher: Send + Sync {
 
 `OutgoingMessage` borrows its name and payload, so publishing does not force an allocation.
 
+This is the publish interface, not the one a service writes: applications publish through the
+builder (`publisher.message(&value).publish()`, `publisher.raw(&bytes).to(dest).publish()`),
+which resolves the destination, the codec and the headers and then makes exactly one call to
+this method. A broker implements `publish` and gets the whole builder for free - there is
+nothing else to provide, and nothing on the builder a broker crate has to keep in step.
+
 ### `PublishPolicy`
 
 A broker publisher is a bundle of policy (an exchange, a queue timeout, a transactional id) plus

--- a/docs/guides/asyncapi.md
+++ b/docs/guides/asyncapi.md
@@ -45,9 +45,15 @@ raw-bytes messages are not reported), and `Spec::messages_without_schema()` list
 message components - assert it empty in a test to gate schema coverage in CI.
 
 Beyond payloads, the document also carries **headers schemas** (from a handler's
-`FromHeaders<T>` parameter or a type's `#[message(headers(..))]` contract) and **`send`
+`FromHeaders<T>` parameter or a type's declared `headers = ..` contract) and **`send`
 operations** for every declared outgoing message - the reply of a `publish(..)` form and every
-entry of an `Out` slot's `#[publishes(..)]` dictionary. See [typed headers](headers.md).
+message type an `Out` slot declares. See [typed headers](headers.md).
+
+A message type whose declared name is a template (`#[outgoing(name = "orders.{tenant}.v1")]`)
+is declared on that templated address, with the channel's **parameters** block filled from its
+placeholders, so the declaration and the call site cannot drift apart. A type that declares no
+destination contributes no channel, which is what it says about itself. See
+[publishing](publishing.md#declaring-where-a-message-goes).
 
 ## Message names and descriptions
 

--- a/docs/guides/headers.md
+++ b/docs/guides/headers.md
@@ -2,8 +2,8 @@
 
 Message headers travel as an untyped `name -> bytes` map. When an application carries a real
 contract in them (ids, sequence numbers, totals), one struct can declare that contract and
-drive all three surfaces at once: runtime extraction on the consume side, the typed publish
-path on the produce side, and the headers schema in the generated AsyncAPI document.
+drive all three surfaces at once: runtime extraction on the consume side, the publish builder
+on the produce side, and the headers schema in the generated AsyncAPI document.
 
 ## The contract
 
@@ -54,54 +54,47 @@ the document still shows the full contract.
 
 ## Declaring a contract on a message type
 
-`#[derive(Message)]` accepts `#[message(headers(Meta))]`: the contract becomes part of the
-type. The typed publish path then demands exactly those headers, and the AsyncAPI document
-renders the schema next to the payload wherever the type appears.
+`#[derive(Outgoing)]` accepts `headers = Meta` next to the destination: the contract becomes
+part of the type. The publish builder then demands exactly those headers, and the AsyncAPI
+document renders the schema next to the payload wherever the type appears. See
+[publishing](publishing.md#declaring-where-a-message-goes) for the destination half.
 
 --8<-- "examples/typed_headers.rs:messages"
 
-## Publishing: the slot dictionary
+## Publishing: the contract at the call site
 
-An `Out` slot's marker can declare what it publishes and where, with
-`#[publishes(Type = "channel", ..)]`:
+An `Out` slot's marker lists the message types the slot may publish:
 
 --8<-- "examples/typed_headers.rs:dictionary"
 
-The `Out` parameter's optional third position declares the message set the handler publishes:
+The `Out` parameter's optional third position declares the message set this handler publishes:
 
-- `Out<impl Publisher, Events>` (or an explicit `()`) - unrestricted: `publish_typed` accepts
-  any type in the marker's dictionary;
+- `Out<impl Publisher, Events>` (or an explicit `()`) - unrestricted: any declared message;
 - `Out<impl Publisher, Events, (ChunkDone, Progress)>` - an inline list;
-- `Out<impl Publisher, Events, ChunkDone>` - one declared type (a `#[derive(Message)]` type
+- `Out<impl Publisher, Events, ChunkDone>` - one declared type (a `#[derive(Outgoing)]` type
   declares itself);
 - `Out<impl Publisher, Events, ConvertSends>` - a `#[derive(OutMessages)]` enum whose variants
   each wrap one model: a reusable, named set (the enum is a type-level declaration and is
   never constructed).
 
-The body then publishes by value alone: the destination comes from the dictionary, the payload
-encodes with the include site's scope codec, and the compiler enforces the whole declaration.
+The body then publishes through the builder (the handler above), and the compiler enforces the
+whole declaration:
 
-- a declared message type outside the marker's dictionary does not compile (the error names
-  the type and the slot);
-- a `publish_typed` of a type outside the declared set does not compile - the handler
-  publishes what it declared, nothing else;
-- a type declaring `#[message(headers(..))]` publishes only through
-  `.with_headers(&meta).publish_typed(&value)` - forgetting the headers, or passing the wrong
-  headers type, does not compile;
+- a `message(..)` of a type outside the declared set does not compile - the handler publishes
+  what it declared, nothing else;
+- a type declaring `headers = Meta` publishes only through
+  `.message(&value).with_headers(&meta)` - forgetting the headers, or passing the wrong headers
+  type, does not compile;
+- the destination comes from the type's own declaration, so a fixed name needs nothing at the
+  call site and a templated one demands its placeholders;
 - the capability position is checked against the include-site policy statically, as always:
   `Out<impl TransactionalPublisher, Events, (ChunkDone, Progress)>` demands a policy whose
-  live publisher is transactional, and the declared publishes ride inside its transactions;
-- several types may share one channel; one type maps to one channel per slot.
+  live publisher is transactional, and the declared publishes ride inside its transactions.
 
-A bare collection works as a model - `#[publishes(Vec<Frame> = "chunks.frames")]`, declared in
-a list or a set enum, published with `publish_typed(&frames)`; its header contract is none by
-definition (wrap it in a `#[derive(Message)]` newtype to declare one).
-
-The typed path needs a named marker (the dictionary lives on it), and destinations are fixed
-by the declaration. The value derefs to the slot's publisher, so the declared capability's
-whole surface stays reachable - including the byte-level
-`out.publish(OutgoingMessage::new(dest, ..))` for a destination computed per message, which is
-inherently undocumentable in a static AsyncAPI document.
+A payload the service already holds encoded, or a foreign type that cannot carry a declaration
+(a bare `Vec<Frame>`), goes out through the byte entry point:
+`out.raw(&bytes).to(dest).publish()`. It takes the same headers positions and no codec; wrap
+the payload in a `#[derive(Outgoing)]` newtype when it deserves a declaration of its own.
 
 ## The reply form
 
@@ -124,7 +117,7 @@ With the `asyncapi` feature, `build_spec` renders:
   or from the input type's `#[message(headers(..))]` contract when the handler extracts by
   hand;
 - a `send` operation per declared outgoing message - the reply of every `publish(..)` form and
-  every entry of every slot dictionary - each with its payload and headers schemas.
+  every message type a slot declares - each with its payload and headers schemas.
 
 Schemas describe the logical field types (`task_id: integer`), while wire values are
 string-encoded headers; that convention matches how header contracts are documented across the

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -5,6 +5,13 @@ publisher injected into the handler with the `Out` parameter. Either way the han
 sees an unconnected publisher: registrations carry publish *policies* (pure declarations), and
 the runtime pairs them with the connected broker at startup.
 
+An explicit publish is always the same builder, entered with `message(..)` for a value and
+`raw(..)` for bytes and finished with `publish()`. Which positions the call site has to fill -
+the destination, the typed headers, the codec - is decided by what the message type declares, so
+an under-specified publish is a compile error rather than a run-time surprise. `Publisher::publish`
+still exists underneath, but as the interface a broker crate implements (see
+[broker authors](../broker-authors/index.md)); a service writes the builder.
+
 ## Replying from a handler
 
 Name a reply destination with `publish(..)` and return the reply value. The runtime encodes it and
@@ -66,6 +73,11 @@ use ruststream::runtime::Out;
 --8<-- "examples/publishing.rs:forward"
 ```
 
+`message(&value)` encodes with the scope's codec (name another one for a single call with
+`.with_codec(..)`), `raw(&bytes)` sends a payload the service already holds encoded and has no
+codec position at all. Both take the typed headers with `.with_headers(&meta)` and an
+already-built map with `.with_header_map(headers)`, and both end in `publish()`.
+
 The include site names the source; for the scope's own broker it is the publish policy:
 
 ```rust
@@ -102,12 +114,45 @@ against a policy whose live publisher supports owned transactions, checked at th
 with a diagnostic naming the missing capability. The slot marker is also the identity the
 [test harness](testing.md#asserting-on-out-slots) records publishes against.
 
-A named marker can go further and declare a **publish dictionary** - which message types it
-publishes and to which channels. The `Out` parameter's optional third position then declares
-what this handler sends (`Out<impl Publisher, Marker, (A, B)>`, a single type, or a
-`#[derive(OutMessages)]` set enum), and the handler publishes by value with compile-checked
-destinations and header contracts, feeding the `send` operations of the generated AsyncAPI
-document. See [typed headers](headers.md).
+The `Out` parameter's optional third position declares what this handler sends
+(`Out<impl Publisher, Marker, (A, B)>`, a single type, or a `#[derive(OutMessages)]` set enum);
+a marker's own `#[publishes(A, B)]` list says what the slot may publish, which is what the
+generated document reports for a handler that leaves the position unrestricted. See
+[typed headers](headers.md).
+
+### Declaring where a message goes
+
+A message type declares everything about being sent through one derive, with every parameter in
+the same `key = value` form. `name` is the destination and `headers` names the contract type
+(which stays an ordinary serde struct the derive does not touch):
+
+```rust
+use ruststream::Outgoing;
+
+--8<-- "examples/publishing.rs:declared"
+```
+
+The declaration decides which destination position the call site has:
+
+- **A fixed name** resolves the destination, so there is no `to(..)` to write - and no way to
+  send that type somewhere the document does not mention.
+- **A name template** (`"orders.{tenant}.placed"`) opens `to()`, which returns a builder with one
+  setter per placeholder. `publish()` appears only once every placeholder is bound, and an
+  unbound one rides in the builder's type, so the compile error names the segment. The address is
+  rendered per publish, which is what computing a destination at run time costs; a fixed name
+  keeps publishing from a `&'static str`.
+- **No `name` at all** means the call site names it: `.to("orders.archived")`, taking a `&str` or
+  a computed `String`.
+
+A message declaring `headers = Meta` publishes only with `.with_headers(&meta)` - forgetting it,
+or passing another type, does not compile. In the generated document a fixed name becomes its
+channel, a template becomes a templated address whose parameters block is filled from its
+placeholders, and a type declaring no destination contributes nothing, which is what it says
+about itself.
+
+```rust
+--8<-- "examples/publishing.rs:declared_mount"
+```
 
 The parameter composes with every subscriber form: next to a `Seek` parameter, on a byte-input
 handler, and on batch handlers (`b.include(f).publisher(..)` - the whole page in,
@@ -236,7 +281,9 @@ after settling are compile errors, not runtime surprises:
 --8<-- "examples/publishing.rs:manual_transaction"
 ```
 
-The scope encodes values with the publisher's codec and sends them directly: per-publisher
+The scope carries the same builder as every other surface (`scope.message(&value).publish()`,
+`scope.raw(&bytes).to("audit").publish()`), sending into the open transaction instead of straight
+to the broker. It encodes values with the publisher's codec and sends them directly: per-publisher
 transforms and the app-wide `publish_layer` middleware belong to the dispatch path (they read the
 originating delivery) and do not run here. Dropping an unsettled scope logs a warning and leaves
 the broker transaction open on that handle - always settle explicitly.
@@ -254,7 +301,7 @@ holds exactly one transaction per producer, implement only the borrowed kind.
 The owned kind has typed sugar too: on a `TypedPublisher` whose publisher implements
 `OwnedTransactions`, `transaction()` opens a `TypedTransaction` that owns the broker transaction
 and encodes with the publisher's codec - `let mut txn = typed.transaction().await?;`, then
-`txn.publish("orders", &value).await?;` and `txn.commit().await?;`. Where `.transactional()` +
+`txn.message(&value).publish().await?;` and `txn.commit().await?;`. Where `.transactional()` +
 `begin()` gives the borrowed scope (one per handle), any number of `TypedTransaction`s can be
 open on one `TypedPublisher` at a time.
 

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -155,6 +155,13 @@ channel, a template becomes a templated address whose parameters block is filled
 placeholders, and a type declaring no destination contributes nothing, which is what it says
 about itself.
 
+The derive is what makes a value publishable this way, the third case included, so a `Serialize`
+type owned by another crate stays outside the builder: the orphan rule forbids deriving on it,
+and there is no way to default the destination for types that declare nothing (a blanket
+implementation would collide with every derived one, and preferring the derived one is
+specialization, which stable Rust does not have). Wrap such a value in a newtype that derives
+`Outgoing`, or, inside a transaction, keep the scope's `publish(name, &value)`.
+
 ```rust
 --8<-- "examples/publishing.rs:declared_mount"
 ```

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -117,8 +117,13 @@ with a diagnostic naming the missing capability. The slot marker is also the ide
 The `Out` parameter's optional third position declares what this handler sends
 (`Out<impl Publisher, Marker, (A, B)>`, a single type, or a `#[derive(OutMessages)]` set enum);
 a marker's own `#[publishes(A, B)]` list says what the slot may publish, which is what the
-generated document reports for a handler that leaves the position unrestricted. See
-[typed headers](headers.md).
+generated document reports for a handler that leaves the position unrestricted. The list is
+enforced rather than only documented: a typed publish of a type the marker does not name is a
+compile error naming the missing membership, so the document cannot fall behind what handlers
+send. A marker listing nothing therefore publishes nothing typed, and byte publishes through
+`raw(..)` are unaffected - they carry no message type to list. The implicit `DefaultSlot` of a
+single unnamed `Out<impl Publisher>` has no declaration site to list types on, so it admits
+every declared message. See [typed headers](headers.md).
 
 ### Declaring where a message goes
 

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -77,11 +77,14 @@ async fn forward(event: &Event, Out(out): Out<impl Publisher>) -> HandlerResult 
 // A handler with several injected publishers names a slot marker per parameter; the include
 // site binds each marker to its own policy, in any order. No broker publisher type appears in
 // the signature, so the same handler mounts on a production broker and on its in-process test
-// transport unchanged.
+// transport unchanged. Each marker lists what may leave through it, which is both what the
+// generated document reports and what the publish builder admits.
 #[derive(OutSlot)]
+#[publishes(Event)]
 struct Primary;
 
 #[derive(OutSlot)]
+#[publishes(Event)]
 struct Shadow;
 
 #[subscriber("mirror")]

--- a/examples/publishing.rs
+++ b/examples/publishing.rs
@@ -9,13 +9,16 @@
 
 use std::error::Error;
 
-use ruststream::codec::{Codec, JsonCodec};
+use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::runtime::{
     App, AppInfo, DefaultSlot, HandlerResult, Out, Outgoing, PublishContext, PublishLayer,
     PublishNext, PublishPipeline, PublishTransform, RustStream, Transactional, TypedPublisher,
 };
-use ruststream::{OutSlot, OutgoingMessage, Publisher, TransactionalPublisher, subscriber};
+// The derive and the pipeline's message type share the name in different namespaces: the derive
+// is the macro `ruststream::Outgoing`, the value flowing through a publish transform is the type
+// `ruststream::runtime::Outgoing`.
+use ruststream::{OutSlot, Outgoing, Publisher, TransactionalPublisher, subscriber};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
@@ -28,7 +31,8 @@ struct Response {
     ok: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+// The derive with no `name`: an event this service sends wherever the call site says.
+#[derive(Debug, Deserialize, Serialize, Outgoing)]
 struct Event {
     id: u64,
 }
@@ -58,12 +62,11 @@ async fn validate(req: &Request) -> Result<Response, HandlerResult> {
 // --8<-- [start:forward]
 // The publisher arrives as a parameter (the Out marker): the source is attached at the include
 // site, the runtime pairs it with the connected broker at startup, and the handler always holds
-// a live publisher - no registry, no erased lookup, no state plumbing.
+// a live publisher - no registry, no erased lookup, no state plumbing. `Event` declares no
+// destination of its own, so the call site names one.
 #[subscriber("ingress")]
 async fn forward(event: &Event, Out(out): Out<impl Publisher>) -> HandlerResult {
-    let payload = JsonCodec.encode(event).expect("serializable");
-    let msg = OutgoingMessage::new("egress", payload.as_ref());
-    if out.publish(msg).await.is_err() {
+    if out.message(event).to("egress").publish().await.is_err() {
         return HandlerResult::retry();
     }
     HandlerResult::Ack
@@ -87,13 +90,16 @@ async fn mirror(
     Out(primary): Out<impl Publisher, Primary>,
     Out(shadow): Out<impl Publisher, Shadow>,
 ) -> HandlerResult {
-    let payload = JsonCodec.encode(event).expect("serializable");
     if primary
-        .publish(OutgoingMessage::new("mirror-primary", payload.as_ref()))
+        .message(event)
+        .to("mirror-primary")
+        .publish()
         .await
         .is_err()
         || shadow
-            .publish(OutgoingMessage::new("mirror-shadow", payload.as_ref()))
+            .message(event)
+            .to("mirror-shadow")
+            .publish()
             .await
             .is_err()
     {
@@ -108,11 +114,10 @@ async fn mirror(
 // destination while an audit copy fans out through the Out parameter.
 #[subscriber("gateway-requests", publish("gateway-responses"))]
 async fn gateway(req: &Request, Out(out): Out<impl Publisher>) -> Result<Response, HandlerResult> {
-    let audit = JsonCodec
-        .encode(&Event { id: req.id })
-        .expect("serializable");
     if out
-        .publish(OutgoingMessage::new("gateway-audit", audit.as_ref()))
+        .message(&Event { id: req.id })
+        .to("gateway-audit")
+        .publish()
         .await
         .is_err()
     {
@@ -121,6 +126,57 @@ async fn gateway(req: &Request, Out(out): Out<impl Publisher>) -> Result<Respons
     Ok(Response { ok: true })
 }
 // --8<-- [end:publish_out]
+
+// --8<-- [start:declared]
+// What a message says about being sent lives on the type. A fixed name resolves the destination
+// for every call site; a name template turns each `{placeholder}` into a setter, so a service
+// routing per tenant still declares where the type goes; and the derive alone (like `Event`
+// above) leaves the name to the call.
+#[derive(Debug, Serialize, Outgoing)]
+#[outgoing(name = "orders.confirmed")]
+struct OrderConfirmed {
+    id: u64,
+}
+
+#[derive(Debug, Serialize, Outgoing)]
+#[outgoing(name = "orders.{tenant}.placed")]
+struct OrderPlaced {
+    id: u64,
+}
+
+#[derive(OutSlot)]
+#[publishes(OrderConfirmed, OrderPlaced)]
+struct Orders;
+
+#[subscriber("orders.incoming")]
+async fn route(
+    event: &Event,
+    Out(orders): Out<impl Publisher, Orders, (OrderConfirmed, OrderPlaced)>,
+) -> HandlerResult {
+    // Bound to one name: the destination is already resolved.
+    if orders
+        .message(&OrderConfirmed { id: event.id })
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    // Bound to a space of names: one setter per placeholder, and no publish until the last one
+    // is bound.
+    if orders
+        .message(&OrderPlaced { id: event.id })
+        .to()
+        .tenant("acme")
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    HandlerResult::Ack
+}
+// --8<-- [end:declared]
 
 // --8<-- [start:static_transform]
 /// A static, per-publisher transform: stamps an envelope header on every outgoing message.
@@ -220,6 +276,10 @@ fn app() -> impl App {
             // with .out(<marker>, ..) - DefaultSlot for a single unnamed slot
             b.include(gateway).out(DefaultSlot, MemoryPublish).mount();
             // --8<-- [end:publish_out_mount]
+            // --8<-- [start:declared_mount]
+            // the slot lists what it may publish; where each message goes is its own declaration
+            b.include(route).out(Orders, MemoryPublish).mount();
+            // --8<-- [end:declared_mount]
             // --8<-- [start:batch_publishing_mount]
             // .transactional() marks the wiring; the pairing checks that the policy's live
             // publisher implements TransactionalPublisher. Without it, each reply publishes

--- a/examples/typed_headers.rs
+++ b/examples/typed_headers.rs
@@ -12,7 +12,7 @@ use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::runtime::{AppInfo, FromHeaders, HandlerResult, Out, RustStream};
 use ruststream::schemars::JsonSchema;
 use ruststream::testing::TestApp;
-use ruststream::{Message, OutSlot, Publisher, subscriber};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
 use serde::{Deserialize, Serialize};
 
 // The header contracts: flat structs whose fields name headers. On the wire every value is a
@@ -32,33 +32,34 @@ struct DoneMeta {
 }
 // --8<-- [end:contracts]
 
-// The outgoing messages: `#[message(headers(..))]` ties a header contract to the type, so the
-// typed publish path demands the right headers and the AsyncAPI document shows them.
+// The outgoing messages: one derive declares everything about being sent - the destination, and
+// the header contract that comes with it - so the publish builder demands the right headers and
+// the AsyncAPI document shows them next to the payload.
 // --8<-- [start:messages]
-#[derive(Message, Serialize, Deserialize, JsonSchema)]
-#[message(headers(DoneMeta))]
+#[derive(Outgoing, Serialize, Deserialize, JsonSchema)]
+#[outgoing(name = "chunks.done", headers = DoneMeta)]
 struct ChunkDone {
     output_key: String,
 }
 
-#[derive(Message, Serialize, Deserialize, JsonSchema)]
+#[derive(Outgoing, Serialize, Deserialize, JsonSchema)]
+#[outgoing(name = "chunks.progress")]
 struct Progress {
     percent: u8,
 }
 // --8<-- [end:messages]
 
-// The slot's publish dictionary: each type maps to the channel it publishes to. The destination
-// never appears in handler code, and an undeclared type does not compile.
+// The slot lists what it may publish; where each type goes is the type's own declaration.
 // --8<-- [start:dictionary]
 #[derive(OutSlot)]
-#[publishes(ChunkDone = "chunks.done", Progress = "chunks.progress")]
+#[publishes(ChunkDone, Progress)]
 struct Events;
 // --8<-- [end:dictionary]
 
 // FromHeaders parses the delivery headers into the contract before the body runs; a missing or
 // unparsable header settles the delivery by `on_failure(decode = ..)` (drop by default). The
 // Out parameter's optional third position declares the message types this handler publishes:
-// destinations come from the dictionary, headers from each message's contract - `Progress`
+// destinations come from each type's declaration, headers from its contract - `Progress`
 // publishes bare, `ChunkDone` does not compile without `.with_headers(&meta)`.
 // --8<-- [start:handler]
 #[subscriber("chunks.raw", raw)]
@@ -68,7 +69,12 @@ async fn convert(
     Out(events): Out<impl Publisher, Events, (ChunkDone, Progress)>,
 ) -> HandlerResult {
     let percent = u8::try_from(meta.chunk_no * 100 / meta.chunks_total.max(1)).unwrap_or(100);
-    if events.publish_typed(&Progress { percent }).await.is_err() {
+    if events
+        .message(&Progress { percent })
+        .publish()
+        .await
+        .is_err()
+    {
         return HandlerResult::retry();
     }
 
@@ -80,8 +86,9 @@ async fn convert(
         duration_ms: chunk.len() as u64,
     };
     if events
+        .message(&done)
         .with_headers(&done_meta)
-        .publish_typed(&done)
+        .publish()
         .await
         .is_err()
     {
@@ -101,8 +108,10 @@ struct StatusRequest {
     task_id: u64,
 }
 
-#[derive(Message, Serialize, JsonSchema)]
-#[message(headers(DoneMeta))]
+// The reply is sent where the `publish(..)` clause says, so the type declares no name of its
+// own - only the contract that travels with it.
+#[derive(Outgoing, Serialize, JsonSchema)]
+#[outgoing(headers = DoneMeta)]
 struct StatusReply {
     done: bool,
 }

--- a/src/asyncapi.rs
+++ b/src/asyncapi.rs
@@ -126,10 +126,28 @@ pub struct Info {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct Channel {
-    /// The channel address (the broker name / subject).
+    /// The channel address (the broker name / subject). A templated address keeps its
+    /// `{placeholder}` segments, and every one of them is declared in
+    /// [`parameters`](Self::parameters).
     pub address: String,
     /// Messages on this channel, keyed by message name, referencing component definitions.
     pub messages: BTreeMap<String, Reference>,
+    /// The address's parameters, one per `{placeholder}` segment; empty (and omitted) for a
+    /// fixed address.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub parameters: BTreeMap<String, Parameter>,
+}
+
+/// An `AsyncAPI` channel parameter: one `{placeholder}` segment of a templated address.
+///
+/// The declaration names the segments; what a service puts in them is a run-time value, so the
+/// object carries no enumeration.
+#[derive(Debug, Clone, Default, Serialize)]
+#[non_exhaustive]
+pub struct Parameter {
+    /// Optional human description of the segment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// An `AsyncAPI` operation: an action on a channel.
@@ -474,6 +492,7 @@ fn add_receive(
         .or_insert_with(|| Channel {
             address: name.to_owned(),
             messages: BTreeMap::new(),
+            parameters: BTreeMap::new(),
         })
         .messages
         .insert(
@@ -608,6 +627,13 @@ fn add_outgoing(
         .or_insert_with(|| Channel {
             address: channel.to_owned(),
             messages: BTreeMap::new(),
+            // A templated address declares its placeholders, so the document says what the
+            // segments are instead of showing an address nothing describes.
+            parameters: outgoing
+                .parameters
+                .iter()
+                .map(|segment| ((*segment).to_owned(), Parameter::default()))
+                .collect(),
         })
         .messages
         .insert(

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -182,6 +182,8 @@ impl<S: Subscriber> BatchSubscriber for BufferedSubscriber<S> {
 
 #[cfg(all(test, feature = "memory"))]
 mod tests {
+    use std::future::ready;
+
     use futures::StreamExt;
 
     use super::*;
@@ -223,12 +225,12 @@ mod tests {
             &EMPTY
         }
 
-        async fn ack(self) -> Result<(), crate::AckError> {
-            Ok(())
+        fn ack(self) -> impl Future<Output = Result<(), crate::AckError>> {
+            ready(Ok(()))
         }
 
-        async fn nack(self, _requeue: bool) -> Result<(), crate::AckError> {
-            Ok(())
+        fn nack(self, _requeue: bool) -> impl Future<Output = Result<(), crate::AckError>> {
+            ready(Ok(()))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ pub use field::{BuildContext, ContextField, Field, FieldMut};
 pub use headers::Headers;
 pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::{DefaultPublish, PairError, PublishPolicy, Publisher};
-pub use schema::{HeadersContract, Message, MessageHeaders, NoHeaders, WithHeaders};
+pub use schema::{
+    CallerName, DestinationForm, FixedName, HeadersContract, Message, MessageHeaders, NameTemplate,
+    NoHeaders, OutgoingDestination, WithHeaders,
+};
 pub use subscriber::Subscriber;
 pub use subscription::{FromName, Name, StartAt, SubscriptionSource, Unnamed};
 pub use typed_headers::{DeserializeHeadersError, SerializeHeadersError};
@@ -104,6 +107,14 @@ pub use ruststream_macros::app;
 /// Available with the `macros` feature.
 #[cfg(feature = "macros")]
 pub use ruststream_macros::Message;
+
+/// Derive macro declaring everything a message type says about being sent: its destination
+/// ([`OutgoingDestination`]) and its optional header contract ([`MessageHeaders`]), plus the
+/// [`Message`] metadata the generated document reads.
+///
+/// Available with the `macros` feature.
+#[cfg(feature = "macros")]
+pub use ruststream_macros::Outgoing;
 
 /// Derive macro that implements [`FromRef`](runtime::FromRef) for each field of an application
 /// state, so handlers can inject any field with [`State<T>`](runtime::State).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //! * `cbor`: [`codec::CborCodec`].
 //! * `memory`: [`memory::MemoryBroker`], an in-process broker usable in applications, prototypes
 //!   and tests.
-//! * `macros`: the `#[subscriber]`, [`#[ruststream::app]`](macro@app), and
-//!   [`#[derive(Message)]`](macro@Message) macros.
+//! * `macros`: the `#[subscriber]`, [`#[ruststream::app]`](macro@app),
+//!   [`#[derive(Outgoing)]`](macro@Outgoing) and [`#[derive(Message)]`](macro@Message) macros.
 //! * `asyncapi`: `AsyncAPI` document generation and the HTML viewer.
 //! * `metrics`: Prometheus metrics middleware and exporter.
 //! * `logging`: colored, `RUST_LOG`-driven console logging via `tracing-subscriber`

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -8,6 +8,7 @@
 
 use std::{
     fmt,
+    future::{Future, ready},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -113,20 +114,20 @@ impl fmt::Debug for MemoryRequester {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Publisher for MemoryRequester {
     type Error = RequestError;
 
-    async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
+    fn publish(&self, msg: OutgoingMessage<'_>) -> impl Future<Output = Result<(), Self::Error>> {
         let outbound = MemoryOutbound {
             name: msg.name().to_owned(),
             payload: Bytes::copy_from_slice(msg.payload()),
             headers: msg.headers().clone(),
         };
-        self.state
-            .fanout(outbound)
-            .map_err(|_| RequestError::ShutDown)
+        ready(
+            self.state
+                .fanout(outbound)
+                .map_err(|_| RequestError::ShutDown),
+        )
     }
 }
 
@@ -251,39 +252,43 @@ impl BatchSubscriber for MemorySubscriber {
 /// [`MemoryError::TransactionBusy`] (leaving the open transaction untouched), and `commit` /
 /// `abort` without an open transaction return [`MemoryError::NoTransaction`]. Clones of the
 /// handle do not share the transaction (see [`MemoryPublisher`]).
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl TransactionalPublisher for MemoryPublisher {
-    async fn begin_transaction(&self) -> Result<(), MemoryError> {
+    fn begin_transaction(&self) -> impl Future<Output = Result<(), MemoryError>> {
         let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
         if txn.is_some() {
-            return Err(MemoryError::TransactionBusy);
+            return ready(Err(MemoryError::TransactionBusy));
         }
         *txn = Some(Vec::new());
         drop(txn);
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn commit(&self) -> Result<(), MemoryError> {
+    fn commit(&self) -> impl Future<Output = Result<(), MemoryError>> {
         let buffered = self
             .txn
             .lock()
             .expect("memory broker mutex poisoned")
-            .take()
-            .ok_or(MemoryError::NoTransaction)?;
+            .take();
+        let Some(buffered) = buffered else {
+            return ready(Err(MemoryError::NoTransaction));
+        };
         for outbound in buffered {
-            self.state.fanout(outbound)?;
+            if let Err(err) = self.state.fanout(outbound) {
+                return ready(Err(err));
+            }
         }
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn abort(&self) -> Result<(), MemoryError> {
-        self.txn
-            .lock()
-            .expect("memory broker mutex poisoned")
-            .take()
-            .map(|_| ())
-            .ok_or(MemoryError::NoTransaction)
+    fn abort(&self) -> impl Future<Output = Result<(), MemoryError>> {
+        ready(
+            self.txn
+                .lock()
+                .expect("memory broker mutex poisoned")
+                .take()
+                .map(|_| ())
+                .ok_or(MemoryError::NoTransaction),
+        )
     }
 }
 
@@ -342,12 +347,13 @@ impl Drop for MemoryTransaction {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Transaction for MemoryTransaction {
     type Error = MemoryError;
 
-    async fn publish(&mut self, msg: OutgoingMessage<'_>) -> Result<(), MemoryError> {
+    fn publish(
+        &mut self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), MemoryError>> {
         // Buffering is local to this value and never touches the bus; a commit against a
         // shut-down bus is what reports the error.
         self.buffered.push(MemoryOutbound {
@@ -355,41 +361,41 @@ impl Transaction for MemoryTransaction {
             payload: Bytes::copy_from_slice(msg.payload()),
             headers: msg.headers().clone(),
         });
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn commit(mut self) -> Result<(), MemoryError> {
+    fn commit(mut self) -> impl Future<Output = Result<(), MemoryError>> {
         // Settled before the flush: a failed commit has still consumed the transaction (the
         // buffer is lost per the Transaction contract), so the drop warning must not fire.
         self.settled = true;
         for outbound in std::mem::take(&mut self.buffered) {
-            self.state.fanout(outbound)?;
+            if let Err(err) = self.state.fanout(outbound) {
+                return ready(Err(err));
+            }
         }
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn abort(mut self) -> Result<(), MemoryError> {
+    fn abort(mut self) -> impl Future<Output = Result<(), MemoryError>> {
         self.settled = true;
-        Ok(())
+        ready(Ok(()))
     }
 }
 
 /// Owned transactions: every [`transaction`](OwnedTransactions::transaction) call opens an
 /// independent buffer-owning `MemoryTransaction`, so any number can be open concurrently on one
 /// handle, next to (and unaffected by) the handle-level [`TransactionalPublisher`] transaction.
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl OwnedTransactions for MemoryPublisher {
     type Transaction = MemoryTransaction;
 
-    async fn transaction(&self) -> Result<MemoryTransaction, MemoryError> {
+    fn transaction(&self) -> impl Future<Output = Result<MemoryTransaction, MemoryError>> {
         // Opening allocates a buffer and never touches the bus; a shut-down bus surfaces at
         // commit, the visibility point, like the handle-level begin.
-        Ok(MemoryTransaction {
+        ready(Ok(MemoryTransaction {
             state: Arc::clone(&self.state),
             buffered: Vec::new(),
             settled: false,
-        })
+        }))
     }
 }
 
@@ -529,8 +535,6 @@ impl Seekable for MemorySubscriber {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Seeker for MemorySeeker {
     type Position = MemoryPosition;
     type Error = MemoryError;
@@ -541,7 +545,7 @@ impl Seeker for MemorySeeker {
     /// # Errors
     ///
     /// Returns [`MemoryError::ShutDown`] through a handle aliasing a shut-down bus.
-    async fn seek(&self, to: MemoryPosition) -> Result<(), MemoryError> {
+    fn seek(&self, to: MemoryPosition) -> impl Future<Output = Result<(), MemoryError>> {
         // The liveness check and the handoff happen under the bus lock (then the log lock,
         // fanout's order): a seek that returns Ok happened strictly before any shutdown, and
         // the end-clamp is consistent with the log length at that instant.
@@ -551,7 +555,7 @@ impl Seeker for MemorySeeker {
             .lock()
             .expect("memory broker mutex poisoned");
         if !matches!(&*bus, Bus::Live(_)) {
-            return Err(MemoryError::ShutDown);
+            return ready(Err(MemoryError::ShutDown));
         }
         let end = self
             .state
@@ -571,7 +575,7 @@ impl Seeker for MemorySeeker {
             .expect("memory broker mutex poisoned") = Some(clamped);
         drop(bus);
         self.control.waker.wake();
-        Ok(())
+        ready(Ok(()))
     }
 }
 

--- a/src/memory/capability.rs
+++ b/src/memory/capability.rs
@@ -113,6 +113,8 @@ impl fmt::Debug for MemoryRequester {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Publisher for MemoryRequester {
     type Error = RequestError;
 
@@ -249,6 +251,8 @@ impl BatchSubscriber for MemorySubscriber {
 /// [`MemoryError::TransactionBusy`] (leaving the open transaction untouched), and `commit` /
 /// `abort` without an open transaction return [`MemoryError::NoTransaction`]. Clones of the
 /// handle do not share the transaction (see [`MemoryPublisher`]).
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl TransactionalPublisher for MemoryPublisher {
     async fn begin_transaction(&self) -> Result<(), MemoryError> {
         let mut txn = self.txn.lock().expect("memory broker mutex poisoned");
@@ -338,6 +342,8 @@ impl Drop for MemoryTransaction {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Transaction for MemoryTransaction {
     type Error = MemoryError;
 
@@ -371,6 +377,8 @@ impl Transaction for MemoryTransaction {
 /// Owned transactions: every [`transaction`](OwnedTransactions::transaction) call opens an
 /// independent buffer-owning `MemoryTransaction`, so any number can be open concurrently on one
 /// handle, next to (and unaffected by) the handle-level [`TransactionalPublisher`] transaction.
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl OwnedTransactions for MemoryPublisher {
     type Transaction = MemoryTransaction;
 
@@ -521,6 +529,8 @@ impl Seekable for MemorySubscriber {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Seeker for MemorySeeker {
     type Position = MemoryPosition;
     type Error = MemoryError;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -284,6 +284,8 @@ impl fmt::Debug for MemoryBroker {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Broker for MemoryBroker {
     type Error = MemoryError;
     type Connected = ConnectedMemoryBroker;
@@ -343,6 +345,8 @@ impl ConnectedMemoryBroker {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl ConnectedBroker for ConnectedMemoryBroker {
     type Error = MemoryError;
     type Closed = ClosedMemoryBroker;
@@ -393,6 +397,8 @@ impl ConnectedBroker for ConnectedMemoryBroker {
 #[must_use]
 pub struct MemoryPublish;
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl PublishPolicy<ConnectedMemoryBroker> for MemoryPublish {
     type Live = MemoryPublisher;
 
@@ -424,6 +430,8 @@ impl DefaultPublish for ConnectedMemoryBroker {
 #[must_use]
 pub struct MemoryRequest;
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl PublishPolicy<ConnectedMemoryBroker> for MemoryRequest {
     type Live = MemoryRequester;
 
@@ -495,6 +503,8 @@ impl crate::testing::TestableBroker for ConnectedMemoryBroker {
 crate::register_testable_broker!(ConnectedMemoryBroker);
 // --8<-- [end:testable]
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Subscribe for ConnectedMemoryBroker {
     type Subscriber = MemorySubscriber;
 
@@ -697,6 +707,8 @@ pub enum MemoryError {
     ShutDown,
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl Publisher for MemoryPublisher {
     type Error = MemoryError;
 
@@ -777,6 +789,8 @@ impl MemoryMessage {
     }
 }
 
+// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
+#[allow(clippy::unused_async_trait_impl)]
 impl IncomingMessage for MemoryMessage {
     fn payload(&self) -> &[u8] {
         self.delivery

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -29,6 +29,7 @@ use std::{
     collections::HashMap,
     convert::Infallible,
     fmt,
+    future::{Future, ready},
     sync::{Arc, Mutex, OnceLock, atomic::AtomicU64},
     task::Poll,
     time::Duration,
@@ -284,8 +285,6 @@ impl fmt::Debug for MemoryBroker {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Broker for MemoryBroker {
     type Error = MemoryError;
     type Connected = ConnectedMemoryBroker;
@@ -293,7 +292,7 @@ impl Broker for MemoryBroker {
     /// Connecting is free for an in-process bus. A shut-down bus (a clone lineage may have shut
     /// the shared state down) is revived with a fresh, empty registration map, so the connected
     /// form always starts live; a live bus keeps its registrations.
-    async fn connect(self) -> Result<Self::Connected, Self::Error> {
+    fn connect(self) -> impl Future<Output = Result<Self::Connected, Self::Error>> {
         {
             let mut bus = self
                 .state
@@ -304,7 +303,7 @@ impl Broker for MemoryBroker {
                 *bus = Bus::Live(HashMap::new());
             }
         }
-        Ok(ConnectedMemoryBroker { state: self.state })
+        ready(Ok(ConnectedMemoryBroker { state: self.state }))
     }
 }
 
@@ -345,8 +344,6 @@ impl ConnectedMemoryBroker {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl ConnectedBroker for ConnectedMemoryBroker {
     type Error = MemoryError;
     type Closed = ClosedMemoryBroker;
@@ -356,7 +353,7 @@ impl ConnectedBroker for ConnectedMemoryBroker {
     /// request) errors with [`MemoryError::ShutDown`]. Consuming `self` makes any further use
     /// of this handle a compile error; the returned witness reports how many subscriber
     /// registrations the teardown dropped.
-    async fn shutdown(self) -> Result<Self::Closed, Self::Error> {
+    fn shutdown(self) -> impl Future<Output = Result<Self::Closed, Self::Error>> {
         let dropped = {
             let mut bus = self
                 .state
@@ -368,9 +365,9 @@ impl ConnectedBroker for ConnectedMemoryBroker {
                 Bus::ShutDown => 0,
             }
         };
-        Ok(ClosedMemoryBroker {
+        ready(Ok(ClosedMemoryBroker {
             subscribers_dropped: dropped,
-        })
+        }))
     }
 }
 
@@ -397,13 +394,14 @@ impl ConnectedBroker for ConnectedMemoryBroker {
 #[must_use]
 pub struct MemoryPublish;
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl PublishPolicy<ConnectedMemoryBroker> for MemoryPublish {
     type Live = MemoryPublisher;
 
-    async fn pair(self, connected: &ConnectedMemoryBroker) -> Result<Self::Live, PairError> {
-        Ok(connected.publisher())
+    fn pair(
+        self,
+        connected: &ConnectedMemoryBroker,
+    ) -> impl Future<Output = Result<Self::Live, PairError>> {
+        ready(Ok(connected.publisher()))
     }
 }
 
@@ -430,13 +428,14 @@ impl DefaultPublish for ConnectedMemoryBroker {
 #[must_use]
 pub struct MemoryRequest;
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl PublishPolicy<ConnectedMemoryBroker> for MemoryRequest {
     type Live = MemoryRequester;
 
-    async fn pair(self, connected: &ConnectedMemoryBroker) -> Result<Self::Live, PairError> {
-        Ok(connected.requester())
+    fn pair(
+        self,
+        connected: &ConnectedMemoryBroker,
+    ) -> impl Future<Output = Result<Self::Live, PairError>> {
+        ready(Ok(connected.requester()))
     }
 }
 
@@ -503,16 +502,16 @@ impl crate::testing::TestableBroker for ConnectedMemoryBroker {
 crate::register_testable_broker!(ConnectedMemoryBroker);
 // --8<-- [end:testable]
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Subscribe for ConnectedMemoryBroker {
     type Subscriber = MemorySubscriber;
 
-    async fn subscribe(&self, name: &str) -> Result<Self::Subscriber, Self::Error> {
+    fn subscribe(&self, name: &str) -> impl Future<Output = Result<Self::Subscriber, Self::Error>> {
         let (tx, rx) = mpsc::unbounded_channel();
         let name = name.to_owned();
-        self.state.register(name.clone(), tx.clone())?;
-        Ok(MemorySubscriber {
+        if let Err(err) = self.state.register(name.clone(), tx.clone()) {
+            return ready(Err(err));
+        }
+        ready(Ok(MemorySubscriber {
             name,
             rx,
             requeue: tx,
@@ -521,7 +520,7 @@ impl Subscribe for ConnectedMemoryBroker {
             seek: Arc::new(SeekControl::default()),
             #[cfg(feature = "testing")]
             coordinator: self.state.coordinator(),
-        })
+        }))
     }
 }
 
@@ -707,12 +706,10 @@ pub enum MemoryError {
     ShutDown,
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl Publisher for MemoryPublisher {
     type Error = MemoryError;
 
-    async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
+    fn publish(&self, msg: OutgoingMessage<'_>) -> impl Future<Output = Result<(), Self::Error>> {
         let outbound = MemoryOutbound {
             name: msg.name().to_owned(),
             payload: Bytes::copy_from_slice(msg.payload()),
@@ -724,10 +721,10 @@ impl Publisher for MemoryPublisher {
                 // Buffering is local to this handle and never touches the bus; a commit against
                 // a shut-down bus is what reports the error.
                 buffered.push(outbound);
-                return Ok(());
+                return ready(Ok(()));
             }
         }
-        self.state.fanout(outbound)
+        ready(self.state.fanout(outbound))
     }
 }
 
@@ -789,8 +786,6 @@ impl MemoryMessage {
     }
 }
 
-// Reference implementation: keeps the contract's `async fn` shape, the one a real broker needs.
-#[allow(clippy::unused_async_trait_impl)]
 impl IncomingMessage for MemoryMessage {
     fn payload(&self) -> &[u8] {
         self.delivery
@@ -810,12 +805,12 @@ impl IncomingMessage for MemoryMessage {
             .map_or_else(|| EMPTY.get_or_init(Headers::new), |d| &d.headers)
     }
 
-    async fn ack(mut self) -> Result<(), AckError> {
+    fn ack(mut self) -> impl Future<Output = Result<(), AckError>> {
         self.delivery.take();
-        Ok(())
+        ready(Ok(()))
     }
 
-    async fn nack(mut self, requeue: bool) -> Result<(), AckError> {
+    fn nack(mut self, requeue: bool) -> impl Future<Output = Result<(), AckError>> {
         let delivery = self.delivery.take().expect("delivery already consumed");
         if requeue {
             let sent = self.requeue.send(delivery);
@@ -830,7 +825,7 @@ impl IncomingMessage for MemoryMessage {
             #[cfg(not(feature = "testing"))]
             let _ = sent;
         }
-        Ok(())
+        ready(Ok(()))
     }
 
     fn supports_nack_after(&self) -> bool {
@@ -839,7 +834,7 @@ impl IncomingMessage for MemoryMessage {
 
     /// Native delayed redelivery: the message returns to the same subscriber's queue once
     /// `delay` has elapsed, not immediately.
-    async fn nack_after(mut self, delay: Duration) -> Result<(), AckError> {
+    fn nack_after(mut self, delay: Duration) -> impl Future<Output = Result<(), AckError>> {
         let delivery = self.delivery.take().expect("delivery already consumed");
         let requeue = self.requeue.clone();
         // Under the harness, register the redelivery with the coordinator so the in-flight count is
@@ -854,14 +849,14 @@ impl IncomingMessage for MemoryMessage {
                     counter.enqueued();
                 }
             });
-            return Ok(());
+            return ready(Ok(()));
         }
         tokio::spawn(async move {
             sleep(delay).await;
             // The subscriber may be gone by then; a dropped receiver is not an error.
             let _ = requeue.send(delivery);
         });
-        Ok(())
+        ready(Ok(()))
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -323,6 +323,8 @@ mod tests {
 
     #[tokio::test]
     async fn incoming_message_defaults_apply_without_override() {
+        use std::future::ready;
+
         use crate::AckError;
 
         // A minimal IncomingMessage that overrides nothing optional, pinning the trait defaults
@@ -341,12 +343,12 @@ mod tests {
                 &self.headers
             }
 
-            async fn ack(self) -> Result<(), AckError> {
-                Ok(())
+            fn ack(self) -> impl Future<Output = Result<(), AckError>> {
+                ready(Ok(()))
             }
 
-            async fn nack(self, _requeue: bool) -> Result<(), AckError> {
-                Ok(())
+            fn nack(self, _requeue: bool) -> impl Future<Output = Result<(), AckError>> {
+                ready(Ok(()))
             }
         }
 

--- a/src/otel/export.rs
+++ b/src/otel/export.rs
@@ -642,6 +642,8 @@ mod tests {
     #[cfg(feature = "json")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn publish_layer_splits_failures_by_error_type() {
+        use std::future::ready;
+
         use opentelemetry_sdk::metrics::InMemoryMetricExporter;
 
         use crate::codec::JsonCodec;
@@ -651,8 +653,11 @@ mod tests {
         struct Failing;
         impl crate::Publisher for Failing {
             type Error = std::io::Error;
-            async fn publish(&self, _msg: crate::OutgoingMessage<'_>) -> Result<(), Self::Error> {
-                Err(std::io::Error::other("no broker"))
+            fn publish(
+                &self,
+                _msg: crate::OutgoingMessage<'_>,
+            ) -> impl Future<Output = Result<(), Self::Error>> {
+                ready(Err(std::io::Error::other("no broker")))
             }
         }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,8 +21,8 @@
 //! ```
 
 pub use crate::runtime::{
-    App, AppInfo, Context, Ctx, FromHeaders, FromRef, HandlerResult, Out, Router, RunningApp,
-    RustStream, Seek, State, SubscriberSettings, TypedPublisher,
+    App, AppInfo, Context, Ctx, FromHeaders, FromRef, HandlerResult, Out, PublishExt, Router,
+    RunningApp, RustStream, Seek, State, SubscriberSettings, TypedPublisher,
 };
 pub use crate::{
     Broker, Headers, IncomingMessage, Message, Name, OutSlot, OutgoingMessage, PublishPolicy,
@@ -31,6 +31,8 @@ pub use crate::{
 
 // The attribute macros and the derives share their names with the traits they implement (the
 // `Message` trait and its derive, `OutSlot`, `FromRef`), which is why the re-exports above
-// already carry the derive where the trait lives at the crate root.
+// already carry the derive where the trait lives at the crate root. `Outgoing` is the exception:
+// the derive lives at the root while the publish pipeline's message type of the same name lives
+// in `runtime`, so a service that writes a publish transform imports that one explicitly.
 #[cfg(feature = "macros")]
-pub use crate::{FromRef, app, subscriber};
+pub use crate::{FromRef, Outgoing, app, subscriber};

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -570,7 +570,7 @@ mod tests {
     use crate::memory::MemoryBroker;
     use crate::runtime::publisher_registry::ErasedPublisher;
     use crate::runtime::{AppInfo, RustStream};
-    use crate::{IncomingMessage, Subscriber};
+    use crate::{IncomingMessage, OutgoingMessage, Subscriber};
 
     use super::Arc;
 
@@ -595,7 +595,7 @@ mod tests {
 
         let fallback = fallback.expect("retry_via must wire the deferred-retry publisher");
         fallback
-            .publish_bytes("retry.fallback", b"deferred")
+            .publish_erased(OutgoingMessage::new("retry.fallback", b"deferred"))
             .await
             .expect("the erased fallback publish failed");
 

--- a/src/runtime/batch/tests.rs
+++ b/src/runtime/batch/tests.rs
@@ -1,3 +1,4 @@
+use std::future::ready;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -369,14 +370,14 @@ impl IncomingMessage for UnsettleableMessage {
         EMPTY.get_or_init(Headers::new)
     }
 
-    async fn ack(self) -> Result<(), AckError> {
+    fn ack(self) -> impl Future<Output = Result<(), AckError>> {
         self.0.fetch_add(1, Ordering::SeqCst);
-        Err(AckError::Timeout)
+        ready(Err(AckError::Timeout))
     }
 
-    async fn nack(self, _requeue: bool) -> Result<(), AckError> {
+    fn nack(self, _requeue: bool) -> impl Future<Output = Result<(), AckError>> {
         self.0.fetch_add(1, Ordering::SeqCst);
-        Err(AckError::Timeout)
+        ready(Err(AckError::Timeout))
     }
 }
 
@@ -550,12 +551,16 @@ async fn decode_and_ack_failures_are_logged_with_their_subscription() {
 struct Frames(Arc<Mutex<Vec<Vec<u8>>>>);
 
 impl RawSliceHandler for Frames {
-    async fn handle_slice(&self, batch: &[&[u8]], _ctx: &mut Context<'_>) -> BatchResult {
+    fn handle_slice(
+        &self,
+        batch: &[&[u8]],
+        _ctx: &mut Context<'_>,
+    ) -> impl Future<Output = BatchResult> {
         self.0
             .lock()
             .unwrap()
             .extend(batch.iter().map(|frame| frame.to_vec()));
-        BatchResult::Uniform(HandlerResult::Ack)
+        ready(BatchResult::Uniform(HandlerResult::Ack))
     }
 }
 

--- a/src/runtime/batch_inject.rs
+++ b/src/runtime/batch_inject.rs
@@ -154,6 +154,7 @@ where
 
 #[cfg(all(test, feature = "memory", feature = "json"))]
 mod tests {
+    use std::future::ready;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -197,18 +198,18 @@ mod tests {
 
     // Ignores the app state, so it is generic over it (mounts on any app).
     impl<S: Send + Sync> BatchInjectCall<S> for Scale {
-        async fn call(
+        fn call(
             &self,
             batch: &[u32],
             factor: &u32,
             _ctx: &mut Context<'_, (), S>,
-        ) -> BatchResult {
+        ) -> impl Future<Output = BatchResult> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.seen
                 .lock()
                 .unwrap()
                 .extend(batch.iter().map(|n| n * factor));
-            BatchResult::Uniform(HandlerResult::Ack)
+            ready(BatchResult::Uniform(HandlerResult::Ack))
         }
     }
 

--- a/src/runtime/batch_publishing/tests.rs
+++ b/src/runtime/batch_publishing/tests.rs
@@ -1,3 +1,4 @@
+use std::future::ready;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -60,17 +61,17 @@ impl BatchPublishingDef for Confirm {
 
 // Ignores the app state, so it is generic over it (mounts on any app).
 impl<S: Send + Sync> BatchPublishingCall<S> for Confirm {
-    async fn call(
+    fn call(
         &self,
         batch: &[u32],
         (): &(),
         _ctx: &mut Context<'_, (), S>,
-    ) -> Result<Vec<u32>, HandlerResult> {
+    ) -> impl Future<Output = Result<Vec<u32>, HandlerResult>> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        if let Some(result) = self.fail_with {
-            return Err(result);
-        }
-        Ok(batch.iter().map(|n| n * 10).collect())
+        let result = self
+            .fail_with
+            .map_or_else(|| Ok(batch.iter().map(|n| n * 10).collect()), Err);
+        ready(result)
     }
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -23,7 +23,8 @@ use super::batch::BatchHandler;
 use super::context::Context;
 use super::failure::{DispatchFailure, FailurePolicy, panic_reason};
 use super::handler::{Handler, HandlerResult};
-use super::publisher_registry::ErasedPublisher;
+use super::publish::raw_of;
+use super::publisher_registry::{ErasedPublisher, ErasedSink};
 #[cfg(feature = "testing")]
 use crate::testing::coordinator::{Record, TestHooks, in_slot_scope};
 
@@ -796,10 +797,10 @@ where
 
     tokio::spawn(async move {
         tokio::time::sleep(delay).await;
-        if let Err(err) = publisher
-            .publish_message(&subject, &payload, &headers)
-            .await
-        {
+        let deferred = raw_of(ErasedSink(publisher.as_ref()), &payload)
+            .with_header_map(headers)
+            .to(subject.as_str());
+        if let Err(err) = deferred.publish().await {
             warn!(
                 target: "ruststream::dispatch",
                 subscription = %subject,

--- a/src/runtime/dispatch/tests.rs
+++ b/src/runtime/dispatch/tests.rs
@@ -1,3 +1,4 @@
+use std::future::ready;
 use std::sync::{
     Arc,
     atomic::{AtomicU8, Ordering},
@@ -30,14 +31,14 @@ impl IncomingMessage for PlainMessage {
         &self.headers
     }
 
-    async fn ack(self) -> Result<(), AckError> {
-        Ok(())
+    fn ack(self) -> impl Future<Output = Result<(), AckError>> {
+        ready(Ok(()))
     }
 
-    async fn nack(self, requeue: bool) -> Result<(), AckError> {
+    fn nack(self, requeue: bool) -> impl Future<Output = Result<(), AckError>> {
         self.settled
             .store(if requeue { 2 } else { 1 }, Ordering::SeqCst);
-        Ok(())
+        ready(Ok(()))
     }
 }
 
@@ -54,12 +55,12 @@ impl IncomingMessage for UnsettleableMessage {
         &EMPTY
     }
 
-    async fn ack(self) -> Result<(), AckError> {
-        Err(AckError::Timeout)
+    fn ack(self) -> impl Future<Output = Result<(), AckError>> {
+        ready(Err(AckError::Timeout))
     }
 
-    async fn nack(self, _requeue: bool) -> Result<(), AckError> {
-        Err(AckError::Unsupported)
+    fn nack(self, _requeue: bool) -> impl Future<Output = Result<(), AckError>> {
+        ready(Err(AckError::Unsupported))
     }
 }
 
@@ -70,8 +71,8 @@ struct RejectingPublisher;
 impl Publisher for RejectingPublisher {
     type Error = std::io::Error;
 
-    async fn publish(&self, _msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
-        Err(std::io::Error::other("connection closed"))
+    fn publish(&self, _msg: OutgoingMessage<'_>) -> impl Future<Output = Result<(), Self::Error>> {
+        ready(Err(std::io::Error::other("connection closed")))
     }
 }
 

--- a/src/runtime/inject.rs
+++ b/src/runtime/inject.rs
@@ -37,13 +37,13 @@ use super::slot::{DefaultSlot, OutSlot, SlotPublisher, TypedSlot};
 /// (`Out<impl Publisher, MySlot>`, see [`OutSlot`](super::OutSlot)) and the include site binds
 /// each with `.out(marker, policy)`, in any order.
 ///
-/// An optional third position declares the message set the handler publishes, enabling the
-/// typed publish path ([`publish_typed`](super::TypedSlot::publish_typed), destinations from
-/// the marker's `#[publishes(..)]` dictionary):
+/// An optional third position declares the message set the handler publishes, which the publish
+/// builder ([`message`](super::TypedSlot::message), destinations from each type's
+/// `#[derive(Outgoing)]` declaration) is checked against:
 ///
 /// - `Out<impl Publisher>` / `Out<impl Publisher, Events>` / `Out<impl Publisher, Events, ()>`
-///   - unrestricted: `publish_typed` accepts any type in the marker's dictionary;
-/// - `Out<impl Publisher, Events, ChunkDone>` - one declared type (a `#[derive(Message)]` type
+///   - unrestricted: any declared message the handler names;
+/// - `Out<impl Publisher, Events, ChunkDone>` - one declared type (a `#[derive(Outgoing)]` type
 ///   declares itself);
 /// - `Out<impl Publisher, Events, (ChunkDone, Progress)>` - a list of declared types;
 /// - `Out<impl Publisher, Events, SendSet>` - a `#[derive(OutMessages)]` enum whose variants'
@@ -143,7 +143,7 @@ pub trait FromStartup<B: Broker, Sub, Extra>: Sized {
 
 /// The injected publisher: pairs the slot's attached policy against the connected broker and
 /// wraps it with the slot identity, the include site's scope codec (what
-/// [`publish_typed`](super::TypedSlot::publish_typed) encodes with), and the declared message
+/// [`message`](super::TypedSlot::message) encodes with), and the declared message
 /// set. A failing pair surfaces at startup with the slot's name (an unbound slot never gets
 /// this far: the include site does not compile without a policy per slot).
 impl<B, Sub, Policy, EncodeCodec, Body, M> FromStartup<B, Sub, (Policy, EncodeCodec)>

--- a/src/runtime/inject.rs
+++ b/src/runtime/inject.rs
@@ -11,7 +11,7 @@
 //! new injected parameter kind is one `FromStartup` impl, not a new definition form.
 
 use std::fmt;
-use std::future::Future;
+use std::future::{Future, ready};
 
 use tracing::warn;
 
@@ -177,23 +177,23 @@ where
     Sub: Seekable + Sync,
     Extra: Send,
 {
-    async fn resolve(
+    fn resolve(
         _extra: Extra,
         _connected: &Connected<B>,
         subscriber: &Sub,
-    ) -> Result<Self, PairError> {
-        Ok(Self(subscriber.seeker()))
+    ) -> impl Future<Output = Result<Self, PairError>> {
+        ready(Ok(Self(subscriber.seeker())))
     }
 }
 
 /// A definition with no injected parameters still resolves: to nothing.
 impl<B: Broker, Sub: Sync, Extra: Send> FromStartup<B, Sub, Extra> for () {
-    async fn resolve(
+    fn resolve(
         _extra: Extra,
         _connected: &Connected<B>,
         _subscriber: &Sub,
-    ) -> Result<Self, PairError> {
-        Ok(())
+    ) -> impl Future<Output = Result<Self, PairError>> {
+        ready(Ok(()))
     }
 }
 

--- a/src/runtime/metadata.rs
+++ b/src/runtime/metadata.rs
@@ -23,6 +23,11 @@ pub struct OutgoingMessageMetadata {
     /// The serialized JSON Schema of the type's `#[message(headers(..))]` contract, when it
     /// declares one.
     pub headers_schema: Option<String>,
+    /// The placeholder names of a templated destination (`orders.{tenant}.v1`), in the order
+    /// they appear in [`channel`](Self::channel). Empty for a fixed one; the generated document
+    /// turns them into the channel's parameters block, so the declaration and the call site
+    /// cannot drift apart.
+    pub parameters: &'static [&'static str],
 }
 
 impl OutgoingMessageMetadata {
@@ -36,7 +41,15 @@ impl OutgoingMessageMetadata {
             message_description: None,
             payload_schema: None,
             headers_schema: None,
+            parameters: &[],
         }
+    }
+
+    /// Builder-style setter for a templated destination's placeholder names.
+    #[must_use]
+    pub fn with_parameters(mut self, parameters: &'static [&'static str]) -> Self {
+        self.parameters = parameters;
+        self
     }
 
     /// Builder-style setter for the [`Message`](crate::Message) name.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -65,12 +65,14 @@ pub use lifecycle::ConnectedSlot;
 pub use metadata::{HandlerMetadata, OutgoingMessageMetadata};
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, ForBatch, Outgoing,
-    PublishContext, PublishDynLayer, PublishDynNext, PublishDynStack, PublishIdentity,
-    PublishLayer, PublishNext, PublishPipeline, PublishStack, PublishTransform,
-    PublishTransformIdentity, PublishTransformStack, ReplyPublisher, ReplyWiring,
-    TransactionPublishError, TransactionScope, Transactional, TypedPublisher, TypedTransaction,
-    for_batch,
+    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, CallCodec, ForBatch,
+    HeadersUnset, MapHeaders, MessageBody, MissingSegment, Outgoing, Publish, PublishAt,
+    PublishCodec, PublishContext, PublishDynLayer, PublishDynNext, PublishDynStack, PublishError,
+    PublishExt, PublishHeaders, PublishIdentity, PublishLayer, PublishNext, PublishPipeline,
+    PublishSink, PublishStack, PublishTransform, PublishTransformIdentity, PublishTransformStack,
+    RawBody, ReplyPublisher, ReplyWiring, ResolvedName, SatisfiesContract, SuppliedName,
+    TemplateAddress, TransactionPublishError, TransactionScope, Transactional, TypedHeaders,
+    TypedPublisher, TypedTransaction, for_batch,
 };
 pub use publish_source::{Bindable, Bound, BrokerRegistration};
 pub use publisher_registry::ErasedPublisher;
@@ -86,11 +88,13 @@ pub use settings::{
     AllOpen, BufferedStep, Declared, FailureStep, Fixed, MapSourceStep, NameStep, Open,
     StartAtStep, SubscriberBuilder, SubscriberSettings, WorkersStep,
 };
+#[allow(deprecated)]
+pub use slot::OutMessage;
 #[doc(hidden)]
 pub use slot::{BindSlot, InitSlots, IntoSlotSource, MissingSlot, SlotPos, WithSource};
 pub use slot::{
-    BindSlots, ContainsMessage, DefaultSlot, HasSlots, OutMessage, OutMessages, OutSlot,
-    PublishTypedError, SlotPublisher, TypedSlot, TypedSlotWithHeaders, Unrestricted,
+    BindSlots, ContainsMessage, DefaultSlot, HasSlots, OutMessages, OutSlot, PublishTypedError,
+    SlotPublisher, TypedSlot, TypedSlotWithHeaders, Unrestricted,
 };
 pub use subscriber_def::SubscriberDef;
 pub use typed::{Typed, typed};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -94,7 +94,7 @@ pub use slot::OutMessage;
 pub use slot::{BindSlot, InitSlots, IntoSlotSource, MissingSlot, SlotPos, WithSource};
 pub use slot::{
     BindSlots, ContainsMessage, DefaultSlot, HasSlots, OutMessages, OutSlot, PublishTypedError,
-    SlotPublisher, TypedSlot, TypedSlotWithHeaders, Unrestricted,
+    PublishedThrough, SlotPublisher, TypedSlot, TypedSlotWithHeaders, Unrestricted,
 };
 pub use subscriber_def::SubscriberDef;
 pub use typed::{Typed, typed};

--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -403,8 +403,7 @@ where
     Sink: PublishSink,
     T: OutgoingDestination + MessageHeaders + Serialize + Sync,
     Enc: PublishCodec,
-    Hdrs: PublishHeaders + SatisfiesContract<T::Contract>,
-    Dest: ResolvedName,
+    Hdrs: PublishHeaders,
 {
     /// Encodes the value with the resolved codec and publishes it to the resolved destination.
     ///
@@ -417,7 +416,14 @@ where
     ///
     /// As cancel-safe as the sink's own send: dropping the future mid-flight may leave the
     /// message in an indeterminate state.
-    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>> {
+    // The two position bounds sit on the method, not on the impl block: a bound the impl block
+    // carries makes an under-specified publish "method not found", which drops the guidance
+    // these traits declare, while a bound the method carries reports it.
+    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+    where
+        Hdrs: SatisfiesContract<T::Contract>,
+        Dest: ResolvedName,
+    {
         let Self {
             sink,
             body,
@@ -450,7 +456,6 @@ impl<Sink, Hdrs, Dest> Publish<Sink, RawBody<'_>, (), Hdrs, Dest>
 where
     Sink: PublishSink,
     Hdrs: PublishHeaders,
-    Dest: ResolvedName,
 {
     /// Publishes the bytes as they are, to the destination named at the call site.
     ///
@@ -463,7 +468,12 @@ where
     ///
     /// As cancel-safe as the sink's own send: dropping the future mid-flight may leave the
     /// message in an indeterminate state.
-    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>> {
+    // On the method for the same reason as on the typed terminal: a bytes publish that never
+    // named its destination has to read as the missing `to(..)`, not as a missing method.
+    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+    where
+        Dest: ResolvedName,
+    {
         let Self {
             sink,
             body,

--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -27,7 +27,8 @@ use super::sink::{CallCodec, PublishCodec, PublishSink};
 ///
 /// Built by the `message(..)` and `raw(..)` entry points of every publish surface (an
 /// [`Out`](crate::runtime::Out) slot, a [`TypedPublisher`](super::TypedPublisher), a transaction
-/// scope, any [`Publisher`](crate::Publisher) through [`PublishExt`]), and finished by
+/// scope, any [`Publisher`](crate::Publisher) through [`PublishExt`](super::PublishExt)), and
+/// finished by
 /// [`publish`](Self::publish). The type parameters are the positions:
 ///
 /// * `Sink` - where the bytes go, a [`PublishSink`].

--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -1,0 +1,477 @@
+//! The publish builder: one call shape for every publish, with the positions a message type
+//! leaves open.
+//!
+//! A publish is a value (or bytes), a destination, optionally typed headers, and - for a value -
+//! a codec. The builder carries one position per piece and resolves each at the most specific
+//! level that names it, so the surfaces differ in what they *declare*, never in which method to
+//! call. Which positions exist at a call site is decided by the message type's
+//! [`OutgoingDestination`] declaration, so an under-specified publish does not compile.
+
+use std::borrow::Cow;
+use std::fmt;
+use std::future::Future;
+use std::marker::PhantomData;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::codec::{Codec, CodecError};
+use crate::{
+    CallerName, FixedName, Headers, HeadersContract, MessageHeaders, NameTemplate, NoHeaders,
+    OutgoingDestination, OutgoingMessage, SerializeHeadersError, WithHeaders,
+};
+
+use super::sink::{CallCodec, PublishCodec, PublishSink};
+
+/// A publish under construction: the entry point's payload plus the positions still open.
+///
+/// Built by the `message(..)` and `raw(..)` entry points of every publish surface (an
+/// [`Out`](crate::runtime::Out) slot, a [`TypedPublisher`](super::TypedPublisher), a transaction
+/// scope, any [`Publisher`](crate::Publisher) through [`PublishExt`]), and finished by
+/// [`publish`](Self::publish). The type parameters are the positions:
+///
+/// * `Sink` - where the bytes go, a [`PublishSink`].
+/// * `Body` - [`MessageBody`] (a value to encode) or [`RawBody`] (bytes as they are).
+/// * `Enc` - the codec position ([`PublishCodec`]); `()` on the byte entry point, which has none.
+/// * `Hdrs` - [`HeadersUnset`], [`TypedHeaders`] or [`MapHeaders`].
+/// * `Dest` - the destination: [`FixedName`] and [`SuppliedName`] are resolved, [`CallerName`]
+///   and [`NameTemplate`] are still waiting for the call site.
+///
+/// You never name this type; the entry points return it and the compiler carries it.
+#[must_use = "a publish builder does nothing until publish() is awaited"]
+pub struct Publish<Sink, Body, Enc, Hdrs, Dest> {
+    sink: Sink,
+    body: Body,
+    codec: Enc,
+    headers: Hdrs,
+    dest: Dest,
+}
+
+impl<Sink, Body, Enc, Hdrs, Dest> fmt::Debug for Publish<Sink, Body, Enc, Hdrs, Dest> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Publish").finish_non_exhaustive()
+    }
+}
+
+/// The payload of a typed publish: the value to encode with the resolved codec.
+#[derive(Debug, Clone, Copy)]
+pub struct MessageBody<'a, T>(&'a T);
+
+/// The payload of a byte publish: the bytes to send as they are.
+#[derive(Debug, Clone, Copy)]
+pub struct RawBody<'a>(&'a [u8]);
+
+/// The headers position before anything fills it: the message travels with no headers of its own.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct HeadersUnset;
+
+/// The headers position filled with a typed contract value, serialized into the header map one
+/// entry per field when the publish runs.
+#[derive(Debug, Clone, Copy)]
+pub struct TypedHeaders<'a, H: ?Sized>(&'a H);
+
+/// The headers position filled with an already-built [`Headers`] map, sent as it is.
+#[derive(Debug, Clone, Default)]
+pub struct MapHeaders(Headers);
+
+/// A destination named at the call site, the resolved form of [`CallerName`].
+#[derive(Debug, Clone)]
+pub struct SuppliedName<'a>(Cow<'a, str>);
+
+/// A destination that the publish can be sent to: fixed by the declaration, or named at the call.
+///
+/// This is what separates a publish that is ready to run from one whose call site has not said
+/// where the message goes. [`CallerName`] and [`NameTemplate`] deliberately do not implement it.
+#[diagnostic::on_unimplemented(
+    message = "this publish has no destination yet",
+    note = "a message type declaring no name takes one at the call: `.to(\"orders.archived\")`; \
+            one declaring a name template opens its placeholder setters with `.to()`, and the \
+            publish appears once every placeholder is bound"
+)]
+pub trait ResolvedName {
+    /// The destination this publish goes to, given the type's declared address (used by the
+    /// fixed form, ignored by the supplied one).
+    fn resolve<'n>(&'n self, declared: &'n str) -> &'n str;
+}
+
+impl ResolvedName for FixedName {
+    fn resolve<'n>(&'n self, declared: &'n str) -> &'n str {
+        declared
+    }
+}
+
+impl ResolvedName for SuppliedName<'_> {
+    fn resolve<'n>(&'n self, _declared: &'n str) -> &'n str {
+        &self.0
+    }
+}
+
+/// What a headers position contributes to the outgoing message.
+///
+/// Implemented by the three header states; the publish calls it once, just before the message
+/// leaves.
+pub trait PublishHeaders {
+    /// Writes this position's headers into the outgoing message's map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SerializeHeadersError`] when a typed contract value is not a flat struct or
+    /// string-keyed map.
+    fn write(self, headers: &mut Headers) -> Result<(), SerializeHeadersError>;
+}
+
+impl PublishHeaders for HeadersUnset {
+    fn write(self, _headers: &mut Headers) -> Result<(), SerializeHeadersError> {
+        Ok(())
+    }
+}
+
+impl<H: Serialize + ?Sized> PublishHeaders for TypedHeaders<'_, H> {
+    fn write(self, headers: &mut Headers) -> Result<(), SerializeHeadersError> {
+        headers.insert_typed(self.0)
+    }
+}
+
+impl PublishHeaders for MapHeaders {
+    fn write(self, headers: &mut Headers) -> Result<(), SerializeHeadersError> {
+        *headers = self.0;
+        Ok(())
+    }
+}
+
+/// A headers position that satisfies a message's declared header contract.
+///
+/// The contract comes from the message type ([`MessageHeaders`]): a type declaring
+/// `#[outgoing(headers = Meta)]` publishes only with `with_headers(&meta)`, and a type declaring
+/// none publishes without typed headers. The byte entry point has no contract, so every position
+/// is admissible there.
+#[diagnostic::on_unimplemented(
+    message = "the headers of this publish do not match the message's `{C}` contract",
+    note = "a message declaring `#[outgoing(headers = Meta)]` is published as \
+            `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed \
+            headers (an arbitrary map still travels through `.with_header_map(..)`)"
+)]
+pub trait SatisfiesContract<C: HeadersContract> {}
+
+impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+
+// A contract-less message may still carry arbitrary transport headers; that map says nothing
+// about the message's declared shape, so it does not stand in for a contract.
+impl SatisfiesContract<NoHeaders> for MapHeaders {}
+
+impl<H> SatisfiesContract<WithHeaders<H>> for TypedHeaders<'_, H> {}
+
+/// The error of the publish builder: encoding the payload, serializing the typed headers, or the
+/// sink itself.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PublishError<E> {
+    /// The codec failed to encode the message payload.
+    #[error("encoding the message failed: {0}")]
+    Encode(#[source] CodecError),
+    /// The typed headers did not serialize into a header map.
+    #[error("serializing the typed headers failed: {0}")]
+    Headers(#[source] SerializeHeadersError),
+    /// The sink (the broker publisher, or the transaction) rejected the message.
+    #[error("publishing the message failed: {0}")]
+    Publish(#[source] E),
+}
+
+impl<Sink, Body, Enc, Hdrs, Dest> Publish<Sink, Body, Enc, Hdrs, Dest> {
+    /// The whole-tuple constructor the entry points share.
+    pub(crate) const fn new(sink: Sink, body: Body, codec: Enc, headers: Hdrs, dest: Dest) -> Self {
+        Self {
+            sink,
+            body,
+            codec,
+            headers,
+            dest,
+        }
+    }
+}
+
+/// Starts a typed publish: `value` is encoded with `codec`, and the destination position is the
+/// one the type declares.
+pub(crate) fn message_of<Sink, T, Enc>(
+    sink: Sink,
+    value: &T,
+    codec: Enc,
+) -> Publish<Sink, MessageBody<'_, T>, Enc, HeadersUnset, T::Form>
+where
+    T: OutgoingDestination,
+{
+    Publish::new(
+        sink,
+        MessageBody(value),
+        codec,
+        HeadersUnset,
+        <T::Form as Default>::default(),
+    )
+}
+
+/// Starts a byte publish: the payload travels as it is, and the destination is named at the call.
+pub(crate) fn raw_of<Sink, B>(
+    sink: Sink,
+    payload: &B,
+) -> Publish<Sink, RawBody<'_>, (), HeadersUnset, CallerName>
+where
+    B: AsRef<[u8]> + ?Sized,
+{
+    Publish::new(
+        sink,
+        RawBody(payload.as_ref()),
+        (),
+        HeadersUnset,
+        CallerName,
+    )
+}
+
+impl<'a, Sink, T, Enc, Hdrs, Dest> Publish<Sink, MessageBody<'a, T>, Enc, Hdrs, Dest> {
+    /// Names the codec for this publish, the most specific level of the codec ladder: it wins
+    /// over the surface's codec, which in turn won over the application's and the crate default.
+    ///
+    /// Only the typed entry point has this position; bytes are sent as they are.
+    pub fn with_codec<C: Codec>(
+        self,
+        codec: C,
+    ) -> Publish<Sink, MessageBody<'a, T>, CallCodec<C>, Hdrs, Dest> {
+        Publish::new(
+            self.sink,
+            self.body,
+            CallCodec(codec),
+            self.headers,
+            self.dest,
+        )
+    }
+}
+
+impl<Sink, Body, Enc, Dest> Publish<Sink, Body, Enc, HeadersUnset, Dest> {
+    /// Supplies the typed headers of this publish.
+    ///
+    /// On the typed entry point the value is checked against the message's declared contract, so
+    /// a missing, extra or mismatched headers value is a compile error. On the byte entry point
+    /// any serializable value is accepted: bytes declare no contract.
+    ///
+    /// The borrow is cheap; nothing is serialized until the publish runs.
+    pub fn with_headers<H: ?Sized>(
+        self,
+        headers: &H,
+    ) -> Publish<Sink, Body, Enc, TypedHeaders<'_, H>, Dest> {
+        Publish::new(
+            self.sink,
+            self.body,
+            self.codec,
+            TypedHeaders(headers),
+            self.dest,
+        )
+    }
+
+    /// Attaches an already-built header map, sent as it is.
+    ///
+    /// This is the transport-level position: a map carries whatever the caller put in it and
+    /// stands for no declared contract, so a message type that declares one still demands
+    /// [`with_headers`](Self::with_headers).
+    pub fn with_header_map(self, headers: Headers) -> Publish<Sink, Body, Enc, MapHeaders, Dest> {
+        Publish::new(
+            self.sink,
+            self.body,
+            self.codec,
+            MapHeaders(headers),
+            self.dest,
+        )
+    }
+}
+
+impl<Sink, Body, Enc, Hdrs> Publish<Sink, Body, Enc, Hdrs, CallerName> {
+    /// Names the destination of this publish.
+    ///
+    /// Present when the message type declares no name of its own, and on the byte entry point.
+    /// Pass a `&str` (the borrowed, no-allocation case) or a `String` (a computed one).
+    pub fn to<'n>(
+        self,
+        name: impl Into<Cow<'n, str>>,
+    ) -> Publish<Sink, Body, Enc, Hdrs, SuppliedName<'n>> {
+        Publish::new(
+            self.sink,
+            self.body,
+            self.codec,
+            self.headers,
+            SuppliedName(name.into()),
+        )
+    }
+}
+
+impl<Sink, T, Enc, Hdrs> Publish<Sink, MessageBody<'_, T>, Enc, Hdrs, NameTemplate>
+where
+    T: TemplateAddress<Self>,
+{
+    /// Opens the placeholder setters of a templated destination: one per `{placeholder}` of the
+    /// type's declared name, in any order, with the publish terminal appearing once the last one
+    /// is bound.
+    ///
+    /// An unbound placeholder rides in the returned builder's type, so the compile error names
+    /// the segment that is missing.
+    pub fn to(self) -> T::Builder {
+        T::begin(self)
+    }
+}
+
+/// A destination template's binding builder: what `to()` opens for a type whose declared name
+/// carries placeholders.
+///
+/// Implemented by `#[derive(Outgoing)]` on a type with a templated `name`; the associated
+/// [`Builder`](Self::Builder) is the generated value carrying one setter per placeholder. You
+/// never implement it by hand.
+pub trait TemplateAddress<Cont> {
+    /// The generated builder, with every placeholder still unbound.
+    type Builder;
+
+    /// Opens the builder over the publish it will finish.
+    fn begin(cont: Cont) -> Self::Builder;
+}
+
+/// The unbound state of one address placeholder.
+///
+/// The segment marker rides in the type so the compile error of an unfinished address names the
+/// placeholder that was forgotten, the way an unbound [`Out`](crate::runtime::Out) slot names
+/// itself. `#[derive(Outgoing)]` generates one marker per placeholder of the declared name.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MissingSegment<S>(PhantomData<fn() -> S>);
+
+impl<S> MissingSegment<S> {
+    /// The unbound placeholder, as the generated builder starts it.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+/// A publish whose destination is rendered by a generated address builder.
+///
+/// The terminal a templated `to()` chain calls once every placeholder is bound; the rendered
+/// address is the only thing the generated code adds to the publish the builder already carries.
+pub trait PublishAt {
+    /// The sink's error, as reported through [`PublishError`].
+    type Error;
+
+    /// Runs the publish against the rendered address.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PublishError`] when the payload cannot be encoded, the typed headers cannot be
+    /// serialized, or the sink rejects the message.
+    fn publish_at(
+        self,
+        name: &str,
+    ) -> impl Future<Output = Result<(), PublishError<Self::Error>>> + Send;
+}
+
+/// Sends one message, applying the headers position and the sink.
+async fn deliver<Sink: PublishSink, Hdrs: PublishHeaders>(
+    mut sink: Sink,
+    name: &str,
+    payload: &[u8],
+    headers: Hdrs,
+) -> Result<(), PublishError<Sink::Error>> {
+    let mut map = Headers::new();
+    headers.write(&mut map).map_err(PublishError::Headers)?;
+    let msg = OutgoingMessage::new(name, payload).with_headers(map);
+    sink.send(msg).await.map_err(PublishError::Publish)
+}
+
+/// Encodes `value` and sends it, shared by the resolved and the rendered terminals.
+async fn encode_and_send<Sink, T, Enc, Hdrs>(
+    sink: Sink,
+    codec: Enc,
+    value: &T,
+    headers: Hdrs,
+    name: &str,
+) -> Result<(), PublishError<Sink::Error>>
+where
+    Sink: PublishSink,
+    T: Serialize + Sync,
+    Enc: PublishCodec,
+    Hdrs: PublishHeaders,
+{
+    let payload = codec.codec().encode(value).map_err(PublishError::Encode)?;
+    deliver(sink, name, &payload, headers).await
+}
+
+impl<Sink, T, Enc, Hdrs, Dest> Publish<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>
+where
+    Sink: PublishSink,
+    T: OutgoingDestination + MessageHeaders + Serialize + Sync,
+    Enc: PublishCodec,
+    Hdrs: PublishHeaders + SatisfiesContract<T::Contract>,
+    Dest: ResolvedName,
+{
+    /// Encodes the value with the resolved codec and publishes it to the resolved destination.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PublishError`] when the codec rejects the value, the typed headers do not
+    /// serialize, or the sink rejects the message.
+    ///
+    /// # Cancel safety
+    ///
+    /// As cancel-safe as the sink's own send: dropping the future mid-flight may leave the
+    /// message in an indeterminate state.
+    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>> {
+        let Self {
+            sink,
+            body,
+            codec,
+            headers,
+            dest,
+        } = self;
+        // The declared address is the fixed form's name, borrowed straight from the declaration;
+        // the supplied form ignores it and lends its own.
+        let name = dest.resolve(T::ADDRESS);
+        encode_and_send(sink, codec, body.0, headers, name).await
+    }
+}
+
+impl<Sink, T, Enc, Hdrs> PublishAt for Publish<Sink, MessageBody<'_, T>, Enc, Hdrs, NameTemplate>
+where
+    Sink: PublishSink,
+    T: OutgoingDestination + MessageHeaders + Serialize + Sync,
+    Enc: PublishCodec + Send,
+    Hdrs: PublishHeaders + SatisfiesContract<T::Contract> + Send,
+{
+    type Error = Sink::Error;
+
+    async fn publish_at(self, name: &str) -> Result<(), PublishError<Sink::Error>> {
+        encode_and_send(self.sink, self.codec, self.body.0, self.headers, name).await
+    }
+}
+
+impl<Sink, Hdrs, Dest> Publish<Sink, RawBody<'_>, (), Hdrs, Dest>
+where
+    Sink: PublishSink,
+    Hdrs: PublishHeaders,
+    Dest: ResolvedName,
+{
+    /// Publishes the bytes as they are, to the destination named at the call site.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PublishError`] when the typed headers do not serialize, or the sink rejects the
+    /// message.
+    ///
+    /// # Cancel safety
+    ///
+    /// As cancel-safe as the sink's own send: dropping the future mid-flight may leave the
+    /// message in an indeterminate state.
+    pub async fn publish(self) -> Result<(), PublishError<Sink::Error>> {
+        let Self {
+            sink,
+            body,
+            headers,
+            dest,
+            ..
+        } = self;
+        // Bytes declare no address of their own, so the destination is always the supplied one.
+        let name = dest.resolve("");
+        deliver(sink, name, body.0, headers).await
+    }
+}

--- a/src/runtime/publish/ext.rs
+++ b/src/runtime/publish/ext.rs
@@ -1,0 +1,78 @@
+//! The publish builder's entry points on a bare [`Publisher`].
+
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+use crate::OutgoingDestination;
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+use crate::codec::DefaultCodec;
+use crate::{CallerName, Publisher};
+
+use super::builder::{HeadersUnset, Publish, RawBody, raw_of};
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+use super::builder::{MessageBody, message_of};
+#[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+use super::sink::CallCodec;
+
+/// The publish builder on any [`Publisher`]: `message(..)` for a value, `raw(..)` for bytes.
+///
+/// Blanket-implemented for every publisher, so a broker publisher held in the application state
+/// publishes through the same builder as an [`Out`](crate::runtime::Out) slot. The difference is
+/// the codec ladder: a bare publisher carries no codec of its own, so `message(..)` encodes with
+/// the crate's [`DefaultCodec`](crate::codec::DefaultCodec) unless the call names one with
+/// `with_codec(..)`. A surface that has a codec (an `Out` slot, a
+/// [`TypedPublisher`](super::TypedPublisher), a transaction scope) shadows these with its own
+/// entry points and uses that codec instead.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+/// # async fn demo() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::runtime::PublishExt;
+/// use ruststream::Outgoing;
+/// use serde::Serialize;
+///
+/// #[derive(Outgoing, Serialize)]
+/// #[outgoing(name = "orders.done")]
+/// struct OrderDone {
+///     id: u64,
+/// }
+///
+/// let publisher = MemoryBroker::new().publisher();
+/// publisher.message(&OrderDone { id: 7 }).publish().await?;
+/// publisher.raw(b"{}").to("orders.audit").publish().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub trait PublishExt: Publisher {
+    /// Starts a byte publish: the payload travels as it is, to the destination named with
+    /// `to(..)`.
+    fn raw<'a, B>(
+        &'a self,
+        payload: &'a B,
+    ) -> Publish<&'a Self, RawBody<'a>, (), HeadersUnset, CallerName>
+    where
+        B: AsRef<[u8]> + ?Sized,
+    {
+        raw_of(self, payload)
+    }
+
+    /// Starts a typed publish of a `#[derive(Outgoing)]` value, encoded with the crate's
+    /// default codec (name another one with `with_codec(..)`).
+    ///
+    /// Available when a codec feature is enabled; with none, every publish names its codec.
+    #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
+    fn message<'a, T>(
+        &'a self,
+        value: &'a T,
+    ) -> Publish<&'a Self, MessageBody<'a, T>, CallCodec<DefaultCodec>, HeadersUnset, T::Form>
+    where
+        T: OutgoingDestination,
+    {
+        // A bare publisher has no codec of its own, so the bottom of the ladder (the crate
+        // default) rides in the call position - the only one this surface has.
+        message_of(self, value, CallCodec(DefaultCodec::default()))
+    }
+}
+
+impl<P: Publisher + ?Sized> PublishExt for P {}

--- a/src/runtime/publish/mod.rs
+++ b/src/runtime/publish/mod.rs
@@ -96,18 +96,29 @@ mod sealed {
     impl<P, C, PL, BL> Sealed for super::Transactional<P, C, PL, BL> {}
 }
 
+mod builder;
+mod ext;
 mod pipeline;
 mod publisher;
 mod reply;
+mod sink;
 mod transaction;
 mod transform;
 
+pub use builder::{
+    HeadersUnset, MapHeaders, MessageBody, MissingSegment, Publish, PublishAt, PublishError,
+    PublishHeaders, RawBody, ResolvedName, SatisfiesContract, SuppliedName, TemplateAddress,
+    TypedHeaders,
+};
+pub(crate) use builder::{message_of, raw_of};
+pub use ext::PublishExt;
 pub use pipeline::{
     PublishDynLayer, PublishDynNext, PublishDynStack, PublishIdentity, PublishLayer, PublishNext,
     PublishPipeline, PublishStack,
 };
 pub use publisher::{Transactional, TypedPublisher};
 pub use reply::{ReplyPublisher, ReplyWiring};
+pub use sink::{CallCodec, PublishCodec, PublishSink};
 pub use transaction::{TransactionPublishError, TransactionScope, TypedTransaction};
 pub use transform::{
     BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, ForBatch,

--- a/src/runtime/publish/publisher.rs
+++ b/src/runtime/publish/publisher.rs
@@ -9,12 +9,13 @@ use crate::runtime::lifecycle::BoxError;
 // `DefaultCodec` only exists when a codec feature is on; the impl that names it is gated the same
 // way, so an ungated import would break `--no-default-features`.
 use super::{
-    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, Outgoing,
-    PublishContext, PublishPipeline, PublishTransform, PublishTransformIdentity,
-    PublishTransformStack,
+    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, HeadersUnset,
+    MessageBody, Outgoing, Publish, PublishContext, PublishPipeline, PublishTransform,
+    PublishTransformIdentity, PublishTransformStack, RawBody, message_of, raw_of,
 };
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::codec::DefaultCodec;
+use crate::{CallerName, OutgoingDestination};
 use crate::{ConnectedBroker, PairError, PublishPolicy, Publisher, TransactionalPublisher};
 
 /// A byte [`Publisher`] paired with a [`Codec`] and a static [`PublishTransform`] stack, ready to send
@@ -136,6 +137,59 @@ impl<P, C, PL, BL> TypedPublisher<P, C, PL, BL> {
     #[must_use]
     pub fn transactional(self) -> Transactional<P, C, PL, BL> {
         Transactional { inner: self }
+    }
+}
+
+impl<P, C, PL, BL> TypedPublisher<P, C, PL, BL> {
+    /// Starts a typed publish of a `#[derive(Outgoing)]` value, encoded with this publisher's
+    /// codec: `publisher.message(&done).publish().await?`.
+    ///
+    /// Which positions the call site still has to fill comes from the message type's
+    /// declaration; see [`Publish`]. The static [`PublishTransform`](super::PublishTransform)
+    /// stack and the application's publish middleware do not run here - both belong to the
+    /// dispatch path, where a delivery context exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+    /// # async fn demo() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// use ruststream::memory::MemoryBroker;
+    /// use ruststream::runtime::TypedPublisher;
+    /// use ruststream::Outgoing;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Outgoing, Serialize)]
+    /// #[outgoing(name = "orders.done")]
+    /// struct OrderDone {
+    ///     id: u64,
+    /// }
+    ///
+    /// let publisher = TypedPublisher::new(MemoryBroker::new().publisher());
+    /// publisher.message(&OrderDone { id: 7 }).publish().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn message<'a, T>(
+        &'a self,
+        value: &'a T,
+    ) -> Publish<&'a P, MessageBody<'a, T>, &'a C, HeadersUnset, T::Form>
+    where
+        T: OutgoingDestination,
+    {
+        message_of(&self.publisher, value, &self.codec)
+    }
+
+    /// Starts a byte publish through this publisher: the payload travels as it is, to the
+    /// destination named with `to(..)`. No codec position, by construction.
+    pub fn raw<'a, B>(
+        &'a self,
+        payload: &'a B,
+    ) -> Publish<&'a P, RawBody<'a>, (), HeadersUnset, CallerName>
+    where
+        B: AsRef<[u8]> + ?Sized,
+    {
+        raw_of(&self.publisher, payload)
     }
 }
 

--- a/src/runtime/publish/sink.rs
+++ b/src/runtime/publish/sink.rs
@@ -1,0 +1,120 @@
+//! The two positions a publish builder resolves against the surface it started from: the byte
+//! sink that finally takes the message, and the codec that encodes a value into it.
+
+use std::error::Error as StdError;
+use std::future::Future;
+
+use crate::codec::Codec;
+use crate::{OutgoingMessage, Publisher, Transaction};
+
+/// The byte sink a publish builder resolves down to.
+///
+/// Every publish surface ends in one call carrying an [`OutgoingMessage`]: a live
+/// [`Publisher`] for the ordinary path, a [`Transaction`] for a buffered one. The builder is
+/// generic over this trait so both paths share one set of positions instead of growing a
+/// parallel method each.
+///
+/// You never implement it: it is blanket-implemented for `&P` of every [`Publisher`] and for
+/// `&mut T` of every [`Transaction`]. A broker crate implements [`Publisher`], which is what
+/// makes its publisher a sink.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "memory")]
+/// # async fn demo() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// use ruststream::memory::MemoryBroker;
+/// use ruststream::runtime::PublishSink;
+/// use ruststream::OutgoingMessage;
+///
+/// let broker = MemoryBroker::new();
+/// let publisher = broker.publisher();
+/// let mut sink = &publisher; // any &Publisher is a sink
+/// sink.send(OutgoingMessage::new("orders", b"{}".as_slice()))
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub trait PublishSink: Send {
+    /// The error the sink reports when the message cannot be sent.
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Sends one message into the sink.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] when the broker (or the transaction buffer) rejects the message.
+    ///
+    /// # Cancel safety
+    ///
+    /// Inherited from the underlying publisher or transaction: dropping the future mid-flight
+    /// may leave the message in an indeterminate state.
+    fn send(
+        &mut self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+// A shared publisher reference is the ordinary sink: publishing takes `&self`, so the builder
+// only ever borrows it.
+impl<P: Publisher + ?Sized> PublishSink for &P {
+    type Error = P::Error;
+
+    fn send(
+        &mut self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        (**self).publish(msg)
+    }
+}
+
+// A transaction buffers into itself, so its sink is the unique borrow the builder holds for the
+// duration of one publish.
+impl<T: Transaction> PublishSink for &mut T {
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        (**self).publish(msg)
+    }
+}
+
+/// The codec position of a publish builder: the surface's own codec, or one named at the call
+/// with [`with_codec`](super::Publish::with_codec).
+///
+/// The two forms are `&C` (the surface's codec, borrowed - the scope, router or application
+/// level of the codec ladder) and [`CallCodec<C>`] (a codec named at the call, the most specific
+/// level). Like [`PublishSink`], it exists so the builder carries one codec position rather than
+/// one method per level.
+pub trait PublishCodec {
+    /// The resolved codec.
+    type Codec: Codec;
+
+    /// Borrows the resolved codec.
+    fn codec(&self) -> &Self::Codec;
+}
+
+impl<C: Codec> PublishCodec for &C {
+    type Codec = C;
+
+    fn codec(&self) -> &C {
+        self
+    }
+}
+
+/// A codec named at the call site, the most specific level of the codec ladder.
+///
+/// Produced by [`Publish::with_codec`](super::Publish::with_codec); you never construct it
+/// directly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct CallCodec<C>(pub(super) C);
+
+impl<C: Codec> PublishCodec for CallCodec<C> {
+    type Codec = C;
+
+    fn codec(&self) -> &C {
+        &self.0
+    }
+}

--- a/src/runtime/publish/tests.rs
+++ b/src/runtime/publish/tests.rs
@@ -12,6 +12,7 @@ use super::*;
 #[cfg(feature = "json")]
 mod fixtures {
     use std::collections::HashMap;
+    use std::future::ready;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use thiserror::Error;
@@ -54,24 +55,27 @@ mod fixtures {
     impl Publisher for Rigged {
         type Error = RiggedError;
 
-        async fn publish(&self, _msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
+        fn publish(
+            &self,
+            _msg: OutgoingMessage<'_>,
+        ) -> impl Future<Output = Result<(), Self::Error>> {
             self.published.fetch_add(1, Ordering::SeqCst);
-            Ok(())
+            ready(Ok(()))
         }
     }
 
     impl TransactionalPublisher for Rigged {
-        async fn begin_transaction(&self) -> Result<(), Self::Error> {
-            Self::step(self.fail_begin)
+        fn begin_transaction(&self) -> impl Future<Output = Result<(), Self::Error>> {
+            ready(Self::step(self.fail_begin))
         }
 
-        async fn commit(&self) -> Result<(), Self::Error> {
-            Self::step(self.fail_commit)
+        fn commit(&self) -> impl Future<Output = Result<(), Self::Error>> {
+            ready(Self::step(self.fail_commit))
         }
 
-        async fn abort(&self) -> Result<(), Self::Error> {
+        fn abort(&self) -> impl Future<Output = Result<(), Self::Error>> {
             self.aborted.fetch_add(1, Ordering::SeqCst);
-            Self::step(self.fail_abort)
+            ready(Self::step(self.fail_abort))
         }
     }
 
@@ -81,8 +85,8 @@ mod fixtures {
     impl OwnedTransactions for Rigged {
         type Transaction = MemoryTransaction;
 
-        async fn transaction(&self) -> Result<Self::Transaction, Self::Error> {
-            Err(RiggedError)
+        fn transaction(&self) -> impl Future<Output = Result<Self::Transaction, Self::Error>> {
+            ready(Err(RiggedError))
         }
     }
 
@@ -95,10 +99,13 @@ mod fixtures {
     impl PublishPolicy<ConnectedMemoryBroker> for RefusePairing {
         type Live = Rigged;
 
-        async fn pair(self, _connected: &ConnectedMemoryBroker) -> Result<Self::Live, PairError> {
-            Err(PairError::from_boxed(Box::from(
+        fn pair(
+            self,
+            _connected: &ConnectedMemoryBroker,
+        ) -> impl Future<Output = Result<Self::Live, PairError>> {
+            ready(Err(PairError::from_boxed(Box::from(
                 "the policy refused to pair",
-            )))
+            ))))
         }
     }
 }
@@ -144,6 +151,8 @@ fn capture_events() -> (
 #[cfg(all(feature = "json", feature = "logging"))]
 #[tokio::test]
 async fn cancelled_commit_keeps_the_unsettled_drop_warning() {
+    use std::future::{pending, ready};
+
     use crate::{OutgoingMessage, Publisher, TransactionalPublisher};
 
     struct PendingCommit;
@@ -151,22 +160,25 @@ async fn cancelled_commit_keeps_the_unsettled_drop_warning() {
     impl Publisher for PendingCommit {
         type Error = std::convert::Infallible;
 
-        async fn publish(&self, _msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
-            Ok(())
+        fn publish(
+            &self,
+            _msg: OutgoingMessage<'_>,
+        ) -> impl Future<Output = Result<(), Self::Error>> {
+            ready(Ok(()))
         }
     }
 
     impl TransactionalPublisher for PendingCommit {
-        async fn begin_transaction(&self) -> Result<(), Self::Error> {
-            Ok(())
+        fn begin_transaction(&self) -> impl Future<Output = Result<(), Self::Error>> {
+            ready(Ok(()))
         }
 
         async fn commit(&self) -> Result<(), Self::Error> {
-            std::future::pending().await
+            pending().await
         }
 
-        async fn abort(&self) -> Result<(), Self::Error> {
-            Ok(())
+        fn abort(&self) -> impl Future<Output = Result<(), Self::Error>> {
+            ready(Ok(()))
         }
     }
 

--- a/src/runtime/publish/transaction.rs
+++ b/src/runtime/publish/transaction.rs
@@ -9,8 +9,11 @@ use tracing::warn;
 use crate::codec::{Codec, CodecError};
 // `DefaultCodec` only exists when a codec feature is on; the impl that names it is gated the same
 // way, so an ungated import would break `--no-default-features`.
-use super::TypedPublisher;
-use crate::{OutgoingMessage, OwnedTransactions, Transaction, TransactionalPublisher};
+use super::{HeadersUnset, MessageBody, Publish, RawBody, TypedPublisher, message_of, raw_of};
+use crate::{
+    CallerName, OutgoingDestination, OutgoingMessage, OwnedTransactions, Transaction,
+    TransactionalPublisher,
+};
 
 /// A live broker transaction, opened by [`Transactional::begin`](crate::runtime::Transactional::begin).
 ///
@@ -32,6 +35,35 @@ pub struct TransactionScope<'a, P, C> {
     pub(super) publisher: &'a P,
     pub(super) codec: &'a C,
     pub(super) open: bool,
+}
+
+impl<'s, P, C> TransactionScope<'s, P, C> {
+    /// Starts a typed publish inside the transaction, encoded with the wrapper's codec: the same
+    /// builder as everywhere else, sending into the open transaction instead of straight to the
+    /// broker.
+    ///
+    /// Nothing published this way is visible before [`commit`](Self::commit).
+    pub fn message<'a, T>(
+        &'a self,
+        value: &'a T,
+    ) -> Publish<&'s P, MessageBody<'a, T>, &'s C, HeadersUnset, T::Form>
+    where
+        T: OutgoingDestination,
+    {
+        message_of(self.publisher, value, self.codec)
+    }
+
+    /// Starts a byte publish inside the transaction: the payload travels as it is, to the
+    /// destination named with `to(..)`.
+    pub fn raw<'a, B>(
+        &'a self,
+        payload: &'a B,
+    ) -> Publish<&'s P, RawBody<'a>, (), HeadersUnset, CallerName>
+    where
+        B: AsRef<[u8]> + ?Sized,
+    {
+        raw_of(self.publisher, payload)
+    }
 }
 
 impl<P, C> TransactionScope<'_, P, C>
@@ -198,6 +230,34 @@ where
 pub struct TypedTransaction<'a, Txn, C> {
     txn: Txn,
     codec: &'a C,
+}
+
+impl<'c, Txn, C> TypedTransaction<'c, Txn, C> {
+    /// Starts a typed publish into the transaction's buffer, encoded with the publisher's codec.
+    ///
+    /// The unique borrow is what the buffer needs, so one publish is built and awaited at a
+    /// time; nothing is visible before [`commit`](Self::commit).
+    pub fn message<'a, T>(
+        &'a mut self,
+        value: &'a T,
+    ) -> Publish<&'a mut Txn, MessageBody<'a, T>, &'c C, HeadersUnset, T::Form>
+    where
+        T: OutgoingDestination,
+    {
+        message_of(&mut self.txn, value, self.codec)
+    }
+
+    /// Starts a byte publish into the transaction's buffer: the payload travels as it is, to the
+    /// destination named with `to(..)`.
+    pub fn raw<'a, B>(
+        &'a mut self,
+        payload: &'a B,
+    ) -> Publish<&'a mut Txn, RawBody<'a>, (), HeadersUnset, CallerName>
+    where
+        B: AsRef<[u8]> + ?Sized,
+    {
+        raw_of(&mut self.txn, payload)
+    }
 }
 
 impl<Txn, C> TypedTransaction<'_, Txn, C>

--- a/src/runtime/publish/transaction.rs
+++ b/src/runtime/publish/transaction.rs
@@ -78,6 +78,16 @@ where
     /// [`abort`](Self::abort). Aborting is the safe default - after an error the broker-side
     /// transaction state is implementation-defined.
     ///
+    /// Unlike the rest of the pre-builder surface this is not deprecated, because the builder
+    /// does not cover it. [`message`](Self::message) reads the destination form off the value's
+    /// type through [`OutgoingDestination`], which `#[derive(Outgoing)]` implements - so a
+    /// `Serialize` type the service does not own is out of reach: the orphan rule forbids both
+    /// the derive and a hand-written impl on a foreign type. Defaulting the form for types that
+    /// declare nothing would need a blanket impl, which collides with every derived one, and
+    /// picking the derived impl over the blanket is specialization, unavailable on stable. Own
+    /// the type, derive `Outgoing` on it and publish it through the builder wherever that is
+    /// possible; this method stays for the case where it is not.
+    ///
     /// # Errors
     ///
     /// Returns [`TransactionPublishError::Encode`] when the codec rejects the value, and
@@ -270,6 +280,11 @@ where
     ///
     /// A failed publish does not settle the transaction; the caller decides between retrying
     /// and [`abort`](Self::abort).
+    ///
+    /// Not deprecated, for the reason spelled out on
+    /// [`TransactionScope::publish`](TransactionScope::publish): a `Serialize` type the service
+    /// does not own cannot declare an [`OutgoingDestination`], so the builder's
+    /// [`message`](Self::message) entry point does not reach it.
     ///
     /// # Errors
     ///

--- a/src/runtime/publisher_registry.rs
+++ b/src/runtime/publisher_registry.rs
@@ -20,7 +20,12 @@ use super::publish::PublishSink;
 ///
 /// Blanket-implemented for every [`Publisher`], so any broker's publisher can be held as
 /// `Arc<dyn ErasedPublisher>` for the `retry_after` fallback.
-pub trait ErasedPublisher: Send + Sync {
+///
+/// Sealed: erasure is the runtime's own machinery and the blanket impl already covers every
+/// publisher, so there is nothing outside this crate to implement it for. That is what keeps
+/// the method list free to follow the publish builder - growing or retiring a method here
+/// reaches no downstream implementor.
+pub trait ErasedPublisher: sealed::Sealed + Send + Sync {
     /// Publishes one message, with whatever destination, payload and headers it carries.
     ///
     /// # Errors
@@ -63,6 +68,15 @@ pub trait ErasedPublisher: Send + Sync {
         payload: &'a [u8],
         headers: &'a Headers,
     ) -> BoxFuture<'a, Result<(), BoxError>>;
+}
+
+mod sealed {
+    use crate::Publisher;
+
+    /// Seals [`ErasedPublisher`](super::ErasedPublisher).
+    pub trait Sealed {}
+
+    impl<P: Publisher> Sealed for P {}
 }
 
 #[allow(deprecated)]

--- a/src/runtime/publisher_registry.rs
+++ b/src/runtime/publisher_registry.rs
@@ -166,7 +166,7 @@ mod tests {
     #[tokio::test]
     async fn the_erased_error_carries_the_broker_message() {
         let error = ErasedPublishError(Box::new(std::io::Error::other("broker refused")));
-        assert!(error.to_string().contains("broker refused"), "got: {error}",);
+        assert!(error.to_string().contains("broker refused"), "got: {error}");
         assert!(
             format!("{:?}", ErasedSink(&MemoryBroker::new().publisher())).starts_with("ErasedSink")
         );

--- a/src/runtime/publisher_registry.rs
+++ b/src/runtime/publisher_registry.rs
@@ -6,20 +6,41 @@
 //! with handlers, put it in the typed application state instead and read it with
 //! [`Context::state`](super::Context::state).
 
+use std::fmt;
+use std::future::Future;
+
+use thiserror::Error;
+
 use crate::{Headers, OutgoingMessage, Publisher};
 
 use super::lifecycle::{BoxError, BoxFuture};
+use super::publish::PublishSink;
 
 /// A publisher with its concrete type and error erased.
 ///
 /// Blanket-implemented for every [`Publisher`], so any broker's publisher can be held as
 /// `Arc<dyn ErasedPublisher>` for the `retry_after` fallback.
 pub trait ErasedPublisher: Send + Sync {
+    /// Publishes one message, with whatever destination, payload and headers it carries.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying publisher's error, boxed, if the broker rejects the publish.
+    fn publish_erased<'a>(
+        &'a self,
+        msg: OutgoingMessage<'a>,
+    ) -> BoxFuture<'a, Result<(), BoxError>>;
+
     /// Publishes `payload` to `name`, with no headers.
     ///
     /// # Errors
     ///
     /// Returns the underlying publisher's error, boxed, if the broker rejects the publish.
+    #[deprecated(
+        since = "0.6.4",
+        note = "headers are a position on the publish builder, not a second method: use \
+                publisher.raw(payload).to(name).publish()"
+    )]
     fn publish_bytes<'a>(
         &'a self,
         name: &'a str,
@@ -31,6 +52,11 @@ pub trait ErasedPublisher: Send + Sync {
     /// # Errors
     ///
     /// Returns the underlying publisher's error, boxed, if the broker rejects the publish.
+    #[deprecated(
+        since = "0.6.4",
+        note = "headers are a position on the publish builder, not a second method: use \
+                publisher.raw(payload).with_header_map(headers).to(name).publish()"
+    )]
     fn publish_message<'a>(
         &'a self,
         name: &'a str,
@@ -39,17 +65,21 @@ pub trait ErasedPublisher: Send + Sync {
     ) -> BoxFuture<'a, Result<(), BoxError>>;
 }
 
+#[allow(deprecated)]
 impl<P: Publisher> ErasedPublisher for P {
+    fn publish_erased<'a>(
+        &'a self,
+        msg: OutgoingMessage<'a>,
+    ) -> BoxFuture<'a, Result<(), BoxError>> {
+        Box::pin(async move { self.publish(msg).await.map_err(|e| Box::new(e) as BoxError) })
+    }
+
     fn publish_bytes<'a>(
         &'a self,
         name: &'a str,
         payload: &'a [u8],
     ) -> BoxFuture<'a, Result<(), BoxError>> {
-        Box::pin(async move {
-            self.publish(OutgoingMessage::new(name, payload))
-                .await
-                .map_err(|e| Box::new(e) as BoxError)
-        })
+        self.publish_erased(OutgoingMessage::new(name, payload))
     }
 
     fn publish_message<'a>(
@@ -58,11 +88,42 @@ impl<P: Publisher> ErasedPublisher for P {
         payload: &'a [u8],
         headers: &'a Headers,
     ) -> BoxFuture<'a, Result<(), BoxError>> {
-        Box::pin(async move {
-            self.publish(OutgoingMessage::new(name, payload).with_headers(headers.clone()))
+        self.publish_erased(OutgoingMessage::new(name, payload).with_headers(headers.clone()))
+    }
+}
+
+/// The publish builder's sink over an erased publisher.
+///
+/// The blanket [`PublishSink`] impl covers `&P` of a concrete [`Publisher`]; the runtime's
+/// deferred-redelivery fallback holds a `dyn ErasedPublisher` instead, which no broker type
+/// names, so it reaches the same builder through this wrapper.
+pub(crate) struct ErasedSink<'a>(pub(crate) &'a dyn ErasedPublisher);
+
+impl PublishSink for ErasedSink<'_> {
+    type Error = ErasedPublishError;
+
+    fn send(
+        &mut self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let publisher = self.0;
+        async move {
+            publisher
+                .publish_erased(msg)
                 .await
-                .map_err(|e| Box::new(e) as BoxError)
-        })
+                .map_err(ErasedPublishError)
+        }
+    }
+}
+
+/// The error of a publish through an erased publisher: the broker's own, boxed.
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub(crate) struct ErasedPublishError(BoxError);
+
+impl fmt::Debug for ErasedSink<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ErasedSink").finish_non_exhaustive()
     }
 }
 
@@ -72,8 +133,47 @@ mod tests {
 
     use super::*;
     use crate::memory::MemoryBroker;
+    use crate::runtime::publish::raw_of;
     use crate::{IncomingMessage, Subscriber};
 
+    /// The erased sink reaches the publish builder, which is how the deferred-retry fallback
+    /// republishes: one message, headers included, through the same positions as everywhere.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_erased_sink_publishes_through_the_builder() {
+        let broker = MemoryBroker::new();
+        let mut subscriber = broker.subscribe("erased.builder");
+        let publisher = broker.publisher();
+        let erased: &dyn ErasedPublisher = &publisher;
+
+        let mut headers = Headers::new();
+        headers.insert("k", "v");
+        raw_of(ErasedSink(erased), b"deferred")
+            .with_header_map(headers)
+            .to("erased.builder")
+            .publish()
+            .await
+            .expect("the erased builder publish failed");
+
+        let mut stream = std::pin::pin!(subscriber.stream());
+        let delivery = stream.next().await.unwrap().expect("delivery");
+        assert_eq!(delivery.payload(), b"deferred");
+        assert_eq!(delivery.headers().get_str("k"), Some("v"));
+        delivery.ack().await.expect("ack failed");
+    }
+
+    /// The rendered error of an erased publish carries the broker's own message, so a failed
+    /// deferred republish is diagnosable from the log line alone.
+    #[tokio::test]
+    async fn the_erased_error_carries_the_broker_message() {
+        let error = ErasedPublishError(Box::new(std::io::Error::other("broker refused")));
+        assert!(error.to_string().contains("broker refused"), "got: {error}",);
+        assert!(
+            format!("{:?}", ErasedSink(&MemoryBroker::new().publisher())).starts_with("ErasedSink")
+        );
+    }
+
+    // The deprecated pair keeps working until it is removed, so it keeps its coverage.
+    #[allow(deprecated)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn blanket_erasure_publishes_bytes_and_messages() {
         let broker = MemoryBroker::new();

--- a/src/runtime/publishing.rs
+++ b/src/runtime/publishing.rs
@@ -310,6 +310,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::future::ready;
+
     use super::{PublishingCall, PublishingDef, publishing_metadata};
     use crate::Headers;
     use crate::Name;
@@ -342,13 +344,13 @@ mod tests {
 
     // Ignores the app state, so it is generic over it (mounts on any app).
     impl<S: Send + Sync> PublishingCall<S> for ManualPub {
-        async fn call(
+        fn call(
             &self,
             input: &u32,
             (): &(),
             _ctx: &mut Context<'_, (), S>,
-        ) -> Result<u32, HandlerResult> {
-            Ok(*input)
+        ) -> impl Future<Output = Result<u32, HandlerResult>> {
+            ready(Ok(*input))
         }
     }
 
@@ -379,6 +381,7 @@ mod tests {
     #[cfg(all(feature = "memory", feature = "json", feature = "logging"))]
     mod diagnostics {
         use std::collections::HashMap;
+        use std::future::ready;
         use std::sync::{Arc, Mutex};
 
         use futures::StreamExt;
@@ -465,8 +468,11 @@ mod tests {
         impl Publisher for Rejecting {
             type Error = MemoryError;
 
-            async fn publish(&self, _msg: OutgoingMessage<'_>) -> Result<(), Self::Error> {
-                Err(MemoryError::ShutDown)
+            fn publish(
+                &self,
+                _msg: OutgoingMessage<'_>,
+            ) -> impl Future<Output = Result<(), Self::Error>> {
+                ready(Err(MemoryError::ShutDown))
             }
         }
 

--- a/src/runtime/slot.rs
+++ b/src/runtime/slot.rs
@@ -354,7 +354,9 @@ impl_contains_message! {
     message = "`{Self}` does not define a message set for the `{M}` slot",
     note = "the third Out argument is a tuple of types, `()` (unrestricted), a \
             #[derive(Outgoing)] type (declares itself and where it goes), or a \
-            #[derive(OutMessages)] enum (declares its variants' models)"
+            #[derive(OutMessages)] enum (declares its variants' models); a \
+            #[derive(Message)] type declares itself only while the marker still names its \
+            channel in the deprecated #[publishes({Self} = \"<channel>\")] form"
 )]
 pub trait OutMessages<M: OutSlot> {
     /// The set's declared outgoing messages, for the generated document. Called once at

--- a/src/runtime/slot.rs
+++ b/src/runtime/slot.rs
@@ -353,9 +353,8 @@ impl_contains_message! {
 #[diagnostic::on_unimplemented(
     message = "`{Self}` does not define a message set for the `{M}` slot",
     note = "the third Out argument is a tuple of types, `()` (unrestricted), a \
-            #[derive(Message)] type (declares itself), or a #[derive(OutMessages)] enum \
-            (declares its variants' models); every member must be in the marker's \
-            #[publishes(..)] dictionary"
+            #[derive(Outgoing)] type (declares itself and where it goes), or a \
+            #[derive(OutMessages)] enum (declares its variants' models)"
 )]
 pub trait OutMessages<M: OutSlot> {
     /// The set's declared outgoing messages, for the generated document. Called once at

--- a/src/runtime/slot.rs
+++ b/src/runtime/slot.rs
@@ -24,11 +24,13 @@ use thiserror::Error;
 
 use crate::codec::{Codec, CodecError};
 use crate::runtime::metadata::OutgoingMessageMetadata;
+use crate::runtime::publish::{HeadersUnset, MessageBody, Publish, RawBody, message_of, raw_of};
 #[cfg(feature = "testing")]
 use crate::testing::coordinator::record_slot_publish;
 use crate::{
-    ConnectedBroker, MessageHeaders, NoHeaders, OutgoingMessage, OwnedTransactions, Publisher,
-    RequestReply, SerializeHeadersError, TransactionalPublisher, WithHeaders,
+    CallerName, ConnectedBroker, MessageHeaders, NoHeaders, OutgoingDestination, OutgoingMessage,
+    OwnedTransactions, Publisher, RequestReply, SerializeHeadersError, TransactionalPublisher,
+    WithHeaders,
 };
 
 /// A slot marker: the identity of one [`Out`](super::Out) injection.
@@ -207,9 +209,14 @@ impl<P: RequestReply, M: OutSlot> RequestReply for SlotPublisher<P, M> {
 /// share one channel; one type maps to exactly one channel per slot (the derive rejects a
 /// duplicate).
 ///
+/// Deprecated: a message type now declares its own destination with `#[derive(Outgoing)]`, so
+/// the marker's dictionary is a list of types (`#[publishes(ChunkDone, Progress)]`) and the
+/// destination no longer depends on which slot the message leaves through.
+///
 /// # Examples
 ///
 /// ```
+/// # #![allow(deprecated)]
 /// use ruststream::runtime::{OutMessage, OutSlot};
 ///
 /// struct Progress {
@@ -231,8 +238,14 @@ impl<P: RequestReply, M: OutSlot> RequestReply for SlotPublisher<P, M> {
 /// ```
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not in the publish dictionary of the `{M}` slot",
-    note = "declare it on the marker: #[publishes({Self} = \"<channel>\")] (the #[derive(OutSlot)] \
-            attribute); only declared types publish through publish_typed"
+    note = "declare the destination on the message type instead: #[derive(Outgoing)] with \
+            #[outgoing(name = \"<channel>\")], and list the type on the marker as \
+            #[publishes({Self})]"
+)]
+#[deprecated(
+    since = "0.6.4",
+    note = "the destination moved onto the message type: #[derive(Outgoing)] with \
+            #[outgoing(name = \"..\")], and #[publishes(Type, ..)] on the marker"
 )]
 pub trait OutMessage<M: OutSlot> {
     /// The channel / subject the message type publishes to through this slot.
@@ -361,12 +374,11 @@ impl<M: OutSlot> OutMessages<M> for () {
 /// The live value behind an [`Out`](super::Out) parameter: the slot's publisher plus the scope
 /// codec, pinned to the parameter's declared message set.
 ///
-/// The handler receives it destructured (`Out(out)`) and publishes dictionary messages
-/// with [`publish_typed`](Self::publish_typed) / [`with_headers`](Self::with_headers); the
-/// declared publisher capability stays reachable through `Deref` (the byte-level
-/// [`publish`](Publisher::publish) for a computed destination, transactions, broker-defined
-/// capability traits). You never name this type: the `#[subscriber]` macro wires it from the
-/// parameter declaration.
+/// The handler receives it destructured (`Out(out)`) and publishes declared messages with the
+/// builder ([`message`](Self::message) for a value, [`raw`](Self::raw) for bytes); the declared
+/// publisher capability stays reachable through `Deref` (transactions, broker-defined capability
+/// traits). You never name this type: the `#[subscriber]` macro wires it from the parameter
+/// declaration.
 ///
 /// # Examples
 ///
@@ -374,7 +386,7 @@ impl<M: OutSlot> OutMessages<M> for () {
 /// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
 /// # mod demo {
 /// use ruststream::runtime::{HandlerResult, Out};
-/// use ruststream::{Message, OutSlot, Publisher, subscriber};
+/// use ruststream::{Outgoing, OutSlot, Publisher, subscriber};
 /// use serde::{Deserialize, Serialize};
 /// # #[derive(serde::Deserialize)]
 /// # struct Event { id: u64 }
@@ -384,19 +396,20 @@ impl<M: OutSlot> OutMessages<M> for () {
 ///     task_id: u64,
 /// }
 ///
-/// #[derive(Message, Serialize)]
+/// #[derive(Outgoing, Serialize)]
+/// #[outgoing(name = "chunks.progress")]
 /// struct Progress {
 ///     percent: u8,
 /// }
 ///
-/// #[derive(Message, Serialize)]
-/// #[message(headers(DoneMeta))]
+/// #[derive(Outgoing, Serialize)]
+/// #[outgoing(name = "chunks.done", headers = DoneMeta)]
 /// struct ChunkDone {
 ///     output_key: String,
 /// }
 ///
 /// #[derive(OutSlot)]
-/// #[publishes(ChunkDone = "chunks.done", Progress = "chunks.progress")]
+/// #[publishes(ChunkDone, Progress)]
 /// struct Events;
 ///
 /// #[subscriber("chunks.raw")]
@@ -404,14 +417,14 @@ impl<M: OutSlot> OutMessages<M> for () {
 ///     event: &Event,
 ///     Out(out): Out<impl Publisher, Events, (ChunkDone, Progress)>,
 /// ) -> HandlerResult {
-///     // No headers contract on Progress: publish directly.
-///     if out.publish_typed(&Progress { percent: 100 }).await.is_err() {
+///     // No headers contract on Progress: publish straight away.
+///     if out.message(&Progress { percent: 100 }).publish().await.is_err() {
 ///         return HandlerResult::retry();
 ///     }
 ///     // ChunkDone declares DoneMeta: with_headers is demanded by the contract.
 ///     let done = ChunkDone { output_key: format!("out/{}", event.id) };
 ///     let meta = DoneMeta { task_id: event.id };
-///     if out.with_headers(&meta).publish_typed(&done).await.is_err() {
+///     if out.message(&done).with_headers(&meta).publish().await.is_err() {
 ///         return HandlerResult::retry();
 ///     }
 ///     HandlerResult::Ack
@@ -511,6 +524,75 @@ where
     }
 }
 
+impl<P, Body, M, EncodeCodec> TypedSlot<P, Body, M, EncodeCodec> {
+    /// Starts a typed publish through the slot, encoded with the include site's scope codec.
+    ///
+    /// The message type has to be in the parameter's declared message set; everything else -
+    /// the destination and the header contract - comes from the type's `#[derive(Outgoing)]`
+    /// declaration, so the builder demands exactly the positions that declaration leaves open
+    /// (see [`Publish`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+    /// # mod demo {
+    /// use ruststream::runtime::{HandlerResult, Out};
+    /// use ruststream::{Outgoing, OutSlot, Publisher, subscriber};
+    /// use serde::Serialize;
+    /// # #[derive(serde::Deserialize)]
+    /// # struct Event { id: u64 }
+    ///
+    /// #[derive(Outgoing, Serialize)]
+    /// #[outgoing(name = "chunks.progress")]
+    /// struct Progress {
+    ///     percent: u8,
+    /// }
+    ///
+    /// #[derive(OutSlot)]
+    /// #[publishes(Progress)]
+    /// struct Events;
+    ///
+    /// #[subscriber("chunks.raw")]
+    /// async fn convert(
+    ///     event: &Event,
+    ///     Out(out): Out<impl Publisher, Events, Progress>,
+    /// ) -> HandlerResult {
+    ///     if out.message(&Progress { percent: 100 }).publish().await.is_err() {
+    ///         return HandlerResult::retry();
+    ///     }
+    ///     HandlerResult::Ack
+    /// }
+    /// # }
+    /// ```
+    pub fn message<'a, T, Index>(
+        &'a self,
+        value: &'a T,
+    ) -> Publish<&'a P, MessageBody<'a, T>, &'a EncodeCodec, HeadersUnset, T::Form>
+    where
+        Body: ContainsMessage<T, Index>,
+        T: OutgoingDestination,
+    {
+        message_of(&self.slot, value, &self.codec)
+    }
+
+    /// Starts a byte publish through the slot: the payload travels as it is, to the destination
+    /// named with `to(..)`.
+    ///
+    /// The declared message set does not restrict this path - bytes carry no message type - so
+    /// it stays the escape hatch for a payload the service already holds encoded.
+    pub fn raw<'a, B>(
+        &'a self,
+        payload: &'a B,
+    ) -> Publish<&'a P, RawBody<'a>, (), HeadersUnset, CallerName>
+    where
+        B: AsRef<[u8]> + ?Sized,
+    {
+        raw_of(&self.slot, payload)
+    }
+}
+
+#[allow(deprecated)]
 impl<P, Body, M, EncodeCodec> TypedSlot<P, Body, M, EncodeCodec>
 where
     P: Publisher,
@@ -565,6 +647,10 @@ where
     /// }
     /// # }
     /// ```
+    #[deprecated(
+        since = "0.6.4",
+        note = "use the publish builder: out.message(&value).publish()"
+    )]
     pub async fn publish_typed<T, Index>(
         &self,
         value: &T,
@@ -598,6 +684,10 @@ where
     /// out.with_headers(&DoneMeta { task_id: 7 }).publish_typed(&done).await?;
     /// ```
     #[must_use]
+    #[deprecated(
+        since = "0.6.4",
+        note = "use the publish builder: out.message(&value).with_headers(&meta).publish()"
+    )]
     pub fn with_headers<'a, H>(
         &'a self,
         headers: &'a H,
@@ -620,6 +710,7 @@ pub struct TypedSlotWithHeaders<'a, P, Body, M, EncodeCodec, H> {
     headers: &'a H,
 }
 
+#[allow(deprecated)]
 impl<P, Body, M, EncodeCodec, H> TypedSlotWithHeaders<'_, P, Body, M, EncodeCodec, H>
 where
     P: Publisher,
@@ -641,6 +732,10 @@ where
     ///
     /// As cancel-safe as the underlying publisher's [`publish`](Publisher::publish): dropping
     /// the future mid-flight may leave the message in an indeterminate state.
+    #[deprecated(
+        since = "0.6.4",
+        note = "use the publish builder: out.message(&value).with_headers(&meta).publish()"
+    )]
     pub async fn publish_typed<T, Index>(
         &self,
         value: &T,

--- a/src/runtime/slot.rs
+++ b/src/runtime/slot.rs
@@ -6,6 +6,8 @@
 //! from the attachment's [`PublishPolicy::Live`](crate::PublishPolicy::Live) - fully monomorphized, no erasure. The pieces:
 //!
 //! - [`OutSlot`] / [`DefaultSlot`]: the marker vocabulary (`#[derive(OutSlot)]` for named ones).
+//! - [`PublishedThrough`]: membership in a marker's `#[publishes(..)]` dictionary, so what the
+//!   document reports as leaving a slot is exactly what the publish builder admits.
 //! - [`SlotPublisher`]: the transparent wrapper the handler actually receives; it delegates the
 //!   publisher capabilities and, under the `testing` feature, attributes publishes to the slot.
 //! - [`HasSlots`] / [`BindSlots`]: the macro-implemented contract on a definition (the marker
@@ -87,6 +89,53 @@ pub struct DefaultSlot;
 impl OutSlot for DefaultSlot {
     const NAME: &'static str = "default";
 }
+
+/// Membership of a message type in a slot marker's `#[publishes(..)]` dictionary: the type may
+/// leave through a slot identified by `Slot`.
+///
+/// `#[derive(OutSlot)]` emits one impl per listed type, in either dictionary form, and the
+/// publish builder's typed entry point ([`TypedSlot::message`]) requires it. That is what keeps
+/// the generated document honest: an unrestricted `Out<impl Publisher, Marker>` reports the
+/// marker's dictionary as what the handler sends, so a message outside it would be a publish the
+/// document never declared.
+///
+/// The membership is declared on the message type rather than on the marker, matching
+/// [`OutMessage`] and keeping the compile error about the message: with the marker as `Self`
+/// and the message as the parameter, a single-entry dictionary would leave the message type to
+/// be inferred from the one impl, and the call site would report a type mismatch against the
+/// listed type instead of the missing membership.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::runtime::{OutSlot, PublishedThrough};
+///
+/// struct Progress;
+///
+/// struct Events;
+///
+/// impl OutSlot for Events {
+///     const NAME: &'static str = "Events";
+/// }
+///
+/// // What `#[derive(OutSlot)]` + `#[publishes(Progress)]` generates:
+/// impl PublishedThrough<Events> for Progress {}
+///
+/// fn admits<T: PublishedThrough<Slot>, Slot>() {}
+/// admits::<Progress, Events>();
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "the `{Slot}` slot does not publish `{Self}`",
+    note = "the marker lists what leaves through the slot, and the generated document reports \
+            that list: add the type to it (`#[derive(OutSlot)] #[publishes({Self}, ..)]`), or \
+            publish through a slot that lists it"
+)]
+pub trait PublishedThrough<Slot> {}
+
+// The implicit slot is the one a handler gets without naming a marker, so there is no
+// declaration site to list types on and nothing for the document to report; narrowing it would
+// leave `Out<impl Publisher>` with no typed publish at all.
+impl<T> PublishedThrough<DefaultSlot> for T {}
 
 /// The live publisher an [`Out`](super::Out) slot injects: the attachment's paired publisher,
 /// wrapped with the slot identity.
@@ -528,8 +577,9 @@ where
 impl<P, Body, M, EncodeCodec> TypedSlot<P, Body, M, EncodeCodec> {
     /// Starts a typed publish through the slot, encoded with the include site's scope codec.
     ///
-    /// The message type has to be in the parameter's declared message set; everything else -
-    /// the destination and the header contract - comes from the type's `#[derive(Outgoing)]`
+    /// The message type has to be in the marker's `#[publishes(..)]` dictionary (see
+    /// [`PublishedThrough`]) and in the parameter's declared message set; everything else - the
+    /// destination and the header contract - comes from the type's `#[derive(Outgoing)]`
     /// declaration, so the builder demands exactly the positions that declaration leaves open
     /// (see [`Publish`]).
     ///
@@ -572,7 +622,7 @@ impl<P, Body, M, EncodeCodec> TypedSlot<P, Body, M, EncodeCodec> {
     ) -> Publish<&'a P, MessageBody<'a, T>, &'a EncodeCodec, HeadersUnset, T::Form>
     where
         Body: ContainsMessage<T, Index>,
-        T: OutgoingDestination,
+        T: OutgoingDestination + PublishedThrough<M>,
     {
         message_of(&self.slot, value, &self.codec)
     }

--- a/src/runtime/slot/tests.rs
+++ b/src/runtime/slot/tests.rs
@@ -73,6 +73,8 @@ impl OutgoingDestination for Progress {
     const ADDRESS: &'static str = "events.progress";
 }
 
+impl PublishedThrough<Events> for Progress {}
+
 /// Headers a header map can carry: one scalar field.
 #[derive(Serialize)]
 struct Meta {
@@ -117,6 +119,8 @@ impl OutgoingDestination for Done {
     type Form = FixedName;
     const ADDRESS: &'static str = "events.done";
 }
+
+impl PublishedThrough<Events> for Done {}
 
 /// The unrestricted declaration documents whatever the marker declares, so a handler that
 /// pins no message set still contributes the slot's dictionary to the document.

--- a/src/runtime/slot/tests.rs
+++ b/src/runtime/slot/tests.rs
@@ -1,6 +1,11 @@
+// The dictionary and the typed publish methods are deprecated in place: they keep working, so
+// they keep their regression coverage here alongside the builder's.
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 
 use super::*;
+use crate::{FixedName, OutgoingDestination};
 
 #[derive(Debug)]
 struct A;
@@ -61,6 +66,13 @@ impl MessageHeaders for Progress {
     type Contract = NoHeaders;
 }
 
+// What `#[derive(Outgoing)]` with `#[outgoing(name = "events.progress")]` declares, so the same
+// fixture drives the builder's error arms.
+impl OutgoingDestination for Progress {
+    type Form = FixedName;
+    const ADDRESS: &'static str = "events.progress";
+}
+
 /// Headers a header map can carry: one scalar field.
 #[derive(Serialize)]
 struct Meta {
@@ -99,6 +111,11 @@ impl OutMessage<Events> for Done {
 
 impl MessageHeaders for Done {
     type Contract = WithHeaders<NestedMeta>;
+}
+
+impl OutgoingDestination for Done {
+    type Form = FixedName;
+    const ADDRESS: &'static str = "events.done";
 }
 
 /// The unrestricted declaration documents whatever the marker declares, so a handler that
@@ -295,5 +312,61 @@ async fn unrepresentable_headers_fail_the_typed_publish() {
     assert!(
         futures::poll!(stream.next()).is_pending(),
         "nothing may be published once the headers are rejected",
+    );
+}
+
+/// The builder reports the same two failures on its own error, each in its own arm, and stops
+/// before the broker sees anything.
+#[cfg(all(feature = "memory", feature = "json"))]
+#[tokio::test]
+async fn the_builder_separates_the_encode_and_the_headers_failure() {
+    use futures::StreamExt;
+
+    use crate::Subscriber;
+    use crate::codec::JsonCodec;
+    use crate::memory::MemoryBroker;
+    use crate::runtime::PublishError;
+
+    let broker = MemoryBroker::new();
+    let mut subscriber = broker.subscribe("events.done");
+    let slot = TypedSlot::<_, (), Events, _>::new(
+        SlotPublisher::<_, Events>::new(broker.publisher()),
+        JsonCodec,
+    );
+
+    let encode = slot
+        .message(&Progress::new())
+        .publish()
+        .await
+        .expect_err("the codec cannot encode this payload");
+    assert!(
+        matches!(encode, PublishError::Encode(_)),
+        "the encode arm must be distinguishable from a broker rejection: {encode:?}",
+    );
+
+    let headers = NestedMeta {
+        inner: Meta { task_id: 7 },
+    };
+    let rejected = slot
+        .message(&Done { key: "out/1" })
+        .with_headers(&headers)
+        .publish()
+        .await
+        .expect_err("a nested struct is not a header value");
+    assert!(
+        matches!(rejected, PublishError::Headers(_)),
+        "the headers arm names what failed: {rejected:?}",
+    );
+    assert!(
+        rejected
+            .to_string()
+            .contains("serializing the typed headers"),
+        "the message must point at the headers: {rejected}",
+    );
+
+    let mut stream = std::pin::pin!(subscriber.stream());
+    assert!(
+        futures::poll!(stream.next()).is_pending(),
+        "nothing may be published once a position fails",
     );
 }

--- a/src/runtime/subscriber_def.rs
+++ b/src/runtime/subscriber_def.rs
@@ -106,6 +106,8 @@ pub(crate) fn subscriber_metadata<D: SubscriberDef>(name: String, def: &D) -> Ha
 
 #[cfg(test)]
 mod tests {
+    use std::future::ready;
+
     use super::{SubscriberDef, subscriber_metadata};
     use crate::Headers;
     use crate::Name;
@@ -117,8 +119,8 @@ mod tests {
     struct Noop;
 
     impl Handler<u32> for Noop {
-        async fn handle(&self, _msg: &u32, _ctx: &mut Context<'_>) -> Settle {
-            HandlerResult::Ack.into()
+        fn handle(&self, _msg: &u32, _ctx: &mut Context<'_>) -> impl Future<Output = Settle> {
+            ready(HandlerResult::Ack.into())
         }
     }
 

--- a/src/runtime/typed.rs
+++ b/src/runtime/typed.rs
@@ -121,6 +121,7 @@ where
 
 #[cfg(all(test, feature = "json"))]
 mod tests {
+    use std::future::ready;
     use std::sync::{
         Arc,
         atomic::{AtomicU32, Ordering},
@@ -145,12 +146,12 @@ mod tests {
             &self.1
         }
 
-        async fn ack(self) -> Result<(), AckError> {
-            Ok(())
+        fn ack(self) -> impl Future<Output = Result<(), AckError>> {
+            ready(Ok(()))
         }
 
-        async fn nack(self, _requeue: bool) -> Result<(), AckError> {
-            Ok(())
+        fn nack(self, _requeue: bool) -> impl Future<Output = Result<(), AckError>> {
+            ready(Ok(()))
         }
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -27,11 +27,11 @@ pub trait Message {
 
 /// Declares a message type's typed header contract.
 ///
-/// `#[derive(Message)]` implements it: `#[message(headers(Meta))]` on the type sets the
-/// contract to [`WithHeaders<Meta>`], and a derive without the attribute sets [`NoHeaders`].
-/// The contract types both message documentation (the `AsyncAPI` headers schema of the
-/// message) and the typed publish path: a slot's
-/// [`publish_typed`](crate::runtime::TypedSlot::publish_typed) compiles only with the
+/// `#[derive(Outgoing)]` implements it: `#[outgoing(headers = Meta)]` on the type sets the
+/// contract to [`WithHeaders<Meta>`], and a declaration without it sets [`NoHeaders`]
+/// (`#[derive(Message)]` with `#[message(headers(Meta))]` does the same for a type that
+/// declares no destination). The contract types both message documentation (the `AsyncAPI`
+/// headers schema of the message) and the publish builder: `publish()` compiles only with the
 /// headers the contract declares (none for [`NoHeaders`]).
 ///
 /// The two contract shapes are a closed vocabulary ([`HeadersContract`] is sealed), so the
@@ -48,7 +48,7 @@ pub trait Message {
 ///
 /// struct ChunkDone;
 ///
-/// // What `#[derive(Message)]` + `#[message(headers(ChunkMeta))]` generates:
+/// // What `#[derive(Outgoing)]` + `#[outgoing(headers = ChunkMeta)]` generates:
 /// impl MessageHeaders for ChunkDone {
 ///     type Contract = WithHeaders<ChunkMeta>;
 /// }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -100,11 +100,90 @@ pub trait HeadersContract: sealed::Sealed {}
 impl HeadersContract for NoHeaders {}
 impl<H> HeadersContract for WithHeaders<H> {}
 
+/// Declares where a message type is sent.
+///
+/// `#[derive(Outgoing)]` implements it from the type's `#[outgoing(name = ..)]` attribute, and
+/// [`Form`](Self::Form) is what the publish builder reads to decide which destination position
+/// the call site has to fill:
+///
+/// * `#[outgoing(name = "orders.done")]` declares [`FixedName`]: the destination is resolved by
+///   the declaration, and the builder offers no `to(..)` at all.
+/// * `#[outgoing(name = "orders.{tenant}.v1")]` declares [`NameTemplate`]: the builder's `to()`
+///   opens one setter per placeholder, and the publish terminal appears once every one of them
+///   is bound.
+/// * a derive with no `name` declares [`CallerName`]: the builder takes the destination as
+///   `to("orders.archived")`.
+///
+/// In every case the destination exists before the publish does, so an under-specified call site
+/// is a compile error rather than a runtime surprise.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::{FixedName, OutgoingDestination};
+///
+/// struct OrderDone;
+///
+/// // What `#[derive(Outgoing)]` + `#[outgoing(name = "orders.done")]` generates:
+/// impl OutgoingDestination for OrderDone {
+///     type Form = FixedName;
+///     const ADDRESS: &'static str = "orders.done";
+/// }
+///
+/// assert_eq!(OrderDone::ADDRESS, "orders.done");
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not declare how it is sent",
+    note = "derive it on the message type: `#[derive(Outgoing)]` alone lets the call site name \
+            the destination, `#[outgoing(name = \"orders.done\")]` fixes it, and \
+            `#[outgoing(name = \"orders.{{tenant}}.v1\")]` opens one setter per placeholder"
+)]
+pub trait OutgoingDestination {
+    /// The declared form: [`FixedName`], [`NameTemplate`] or [`CallerName`].
+    type Form: DestinationForm;
+
+    /// The declared address: the literal name, the template with its placeholders in braces, or
+    /// the empty string when the type declares none.
+    const ADDRESS: &'static str = "";
+
+    /// The template's placeholder names, in the order they appear in [`ADDRESS`](Self::ADDRESS).
+    /// Empty for the other two forms; the generated document turns it into the channel's
+    /// parameters block.
+    const PARAMETERS: &'static [&'static str] = &[];
+}
+
+/// The destination form of a type declaring one literal name: the address is fixed, so the
+/// publish builder resolves it without asking the call site.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct FixedName;
+
+/// The destination form of a type declaring a name template: the call site binds every
+/// placeholder through the setters generated from it, and the address is rendered per publish.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct NameTemplate;
+
+/// The destination form of a type declaring no name: the call site names the destination.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct CallerName;
+
+/// The closed set of destination forms: [`FixedName`], [`NameTemplate`] and [`CallerName`].
+///
+/// Sealed, like [`HeadersContract`]: the publish builder branches on exactly these three shapes
+/// at compile time, so the vocabulary cannot grow outside the crate.
+pub trait DestinationForm: sealed::Sealed + Default {}
+
+impl DestinationForm for FixedName {}
+impl DestinationForm for NameTemplate {}
+impl DestinationForm for CallerName {}
+
 mod sealed {
-    /// Seals [`HeadersContract`](super::HeadersContract): the two shapes are the whole
-    /// vocabulary.
+    /// Seals [`HeadersContract`](super::HeadersContract) and
+    /// [`DestinationForm`](super::DestinationForm): each vocabulary is closed.
     pub trait Sealed {}
 
     impl Sealed for super::NoHeaders {}
     impl<H> Sealed for super::WithHeaders<H> {}
+    impl Sealed for super::FixedName {}
+    impl Sealed for super::NameTemplate {}
+    impl Sealed for super::CallerName {}
 }

--- a/tests/app_cli_coverage.rs
+++ b/tests/app_cli_coverage.rs
@@ -13,7 +13,7 @@
     feature = "logging"
 ))]
 
-use std::future::pending;
+use std::future::{pending, ready};
 use std::io;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -283,11 +283,11 @@ impl SubscriptionSource<ConnectedMemoryBroker> for RefusedSubscription {
         "cov.refused"
     }
 
-    async fn subscribe(
+    fn subscribe(
         self,
         _connected: &ConnectedMemoryBroker,
-    ) -> Result<Self::Subscriber, MemoryError> {
-        Err(MemoryError::ShutDown)
+    ) -> impl Future<Output = Result<Self::Subscriber, MemoryError>> {
+        ready(Err(MemoryError::ShutDown))
     }
 }
 
@@ -341,8 +341,8 @@ impl Broker for StubbornBroker {
     type Error = io::Error;
     type Connected = ConnectedStubborn;
 
-    async fn connect(self) -> Result<Self::Connected, Self::Error> {
-        Ok(ConnectedStubborn)
+    fn connect(self) -> impl Future<Output = Result<Self::Connected, Self::Error>> {
+        ready(Ok(ConnectedStubborn))
     }
 }
 
@@ -350,8 +350,8 @@ impl ConnectedBroker for ConnectedStubborn {
     type Error = io::Error;
     type Closed = ();
 
-    async fn shutdown(self) -> Result<(), Self::Error> {
-        Err(io::Error::other("teardown refused"))
+    fn shutdown(self) -> impl Future<Output = Result<(), Self::Error>> {
+        ready(Err(io::Error::other("teardown refused")))
     }
 }
 
@@ -373,8 +373,8 @@ impl Broker for UnreachableBroker {
     type Error = io::Error;
     type Connected = NeverConnected;
 
-    async fn connect(self) -> Result<Self::Connected, Self::Error> {
-        Err(io::Error::other("dial refused"))
+    fn connect(self) -> impl Future<Output = Result<Self::Connected, Self::Error>> {
+        ready(Err(io::Error::other("dial refused")))
     }
 }
 
@@ -382,6 +382,9 @@ impl ConnectedBroker for NeverConnected {
     type Error = io::Error;
     type Closed = ();
 
+    // The connected form is uninhabited, so the body diverges: there is no value a `ready(..)`
+    // rewrite could carry, only the divergence wrapped in one more layer.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn shutdown(self) -> Result<(), Self::Error> {
         match self {}
     }

--- a/tests/app_start.rs
+++ b/tests/app_start.rs
@@ -8,6 +8,7 @@
 #![cfg(feature = "macros")]
 
 use std::convert::Infallible;
+use std::future::ready;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -285,8 +286,8 @@ impl Broker for FailingBroker {
     type Error = io::Error;
     type Connected = NeverConnected;
 
-    async fn connect(self) -> Result<Self::Connected, Self::Error> {
-        Err(io::Error::other("dial refused"))
+    fn connect(self) -> impl Future<Output = Result<Self::Connected, Self::Error>> {
+        ready(Err(io::Error::other("dial refused")))
     }
 }
 
@@ -294,6 +295,9 @@ impl ConnectedBroker for NeverConnected {
     type Error = io::Error;
     type Closed = ();
 
+    // The connected form is uninhabited, so the body diverges: there is no value a `ready(..)`
+    // rewrite could carry, only the divergence wrapped in one more layer.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn shutdown(self) -> Result<(), Self::Error> {
         match self {}
     }

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -541,6 +541,116 @@ mod typed_headers_spec {
     }
 }
 
+/// Destinations declared on the message type: a fixed name becomes its channel, a templated one
+/// keeps its placeholders and declares them as the channel's parameters, and a type declaring
+/// nothing contributes no channel at all.
+#[cfg(all(feature = "macros", feature = "json"))]
+mod declared_destinations {
+    use ruststream::memory::{MemoryBroker, MemoryPublish};
+    use ruststream::runtime::{AppInfo, HandlerResult, Out, RustStream};
+    use ruststream::schemars::JsonSchema;
+    use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+    use serde::{Deserialize, Serialize};
+
+    use super::build_spec;
+
+    #[derive(Deserialize, JsonSchema)]
+    struct Order {
+        #[allow(dead_code)]
+        id: u64,
+    }
+
+    /// A confirmed order.
+    #[derive(Outgoing, Serialize, JsonSchema)]
+    #[outgoing(name = "orders.confirmed")]
+    struct OrderConfirmed {
+        id: u64,
+    }
+
+    /// An order placed into a per-tenant, per-region stream.
+    #[derive(Outgoing, Serialize, JsonSchema)]
+    #[outgoing(name = "orders.{tenant}.{region}.v1")]
+    struct OrderPlaced {
+        id: u64,
+    }
+
+    /// An order archived wherever the caller says.
+    #[derive(Outgoing, Serialize, JsonSchema)]
+    struct OrderArchived {
+        id: u64,
+    }
+
+    #[derive(OutSlot)]
+    #[publishes(OrderConfirmed, OrderPlaced, OrderArchived)]
+    struct Events;
+
+    #[subscriber("orders.in")]
+    async fn route(
+        order: &Order,
+        Out(_events): Out<impl Publisher, Events, (OrderConfirmed, OrderPlaced, OrderArchived)>,
+    ) -> HandlerResult {
+        let _ = order;
+        HandlerResult::Ack
+    }
+
+    #[test]
+    fn a_templated_destination_declares_its_parameters() {
+        let app = RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker(
+            MemoryBroker::new(),
+            |b| {
+                b.include(route).out(Events, MemoryPublish).mount();
+            },
+        );
+        let spec = build_spec(&app);
+
+        // The fixed destination is a channel with no parameters.
+        let confirmed = &spec.channels["orders.confirmed"];
+        assert_eq!(confirmed.address, "orders.confirmed");
+        assert!(confirmed.parameters.is_empty());
+
+        // The templated one keeps its placeholders, and every one of them is declared.
+        let placed = &spec.channels["orders.{tenant}.{region}.v1"];
+        assert_eq!(placed.address, "orders.{tenant}.{region}.v1");
+        assert_eq!(
+            placed.parameters.keys().collect::<Vec<_>>(),
+            vec!["region", "tenant"],
+        );
+        assert_eq!(
+            spec.operations["send_orders_in_orders__tenant___region__v1"].action,
+            "send",
+        );
+
+        // A type that declares no destination says nothing about where it goes.
+        assert!(
+            !spec
+                .channels
+                .keys()
+                .any(|channel| channel.contains("archived")),
+            "an undeclared destination must not invent a channel: {:?}",
+            spec.channels.keys().collect::<Vec<_>>(),
+        );
+        assert!(!spec.components.messages.contains_key("OrderArchived"));
+    }
+
+    #[test]
+    fn a_templated_channel_serializes_its_parameters_block() {
+        let app = RustStream::new(AppInfo::new("orders", "0.1.0")).with_broker(
+            MemoryBroker::new(),
+            |b| {
+                b.include(route).out(Events, MemoryPublish).mount();
+            },
+        );
+        let json = serde_json::to_value(build_spec(&app)).expect("the spec serializes");
+        let channel = &json["channels"]["orders.{tenant}.{region}.v1"];
+        assert!(
+            channel["parameters"]["tenant"].is_object(),
+            "got: {channel}"
+        );
+        // A fixed channel omits the block rather than carrying an empty one.
+        assert!(json["channels"]["orders.confirmed"]["parameters"].is_null());
+    }
+}
+
 /// Two handlers on one channel: each opens its own subscription, so each is its own receive
 /// operation rather than the second overwriting the first.
 #[derive(serde::Deserialize)]

--- a/tests/asyncapi.rs
+++ b/tests/asyncapi.rs
@@ -1,6 +1,8 @@
 //! Integration test for `AsyncAPI` document generation.
 #![cfg(all(feature = "asyncapi", feature = "memory"))]
 
+use std::future::ready;
+
 use ruststream::asyncapi::{ViewerOptions, build_spec, render_viewer_html};
 use ruststream::memory::MemoryBroker;
 use ruststream::runtime::{
@@ -141,8 +143,8 @@ impl ruststream::Broker for DescribingBroker {
     type Error = std::convert::Infallible;
     type Connected = ConnectedDescribingBroker;
 
-    async fn connect(self) -> Result<Self::Connected, Self::Error> {
-        Ok(ConnectedDescribingBroker)
+    fn connect(self) -> impl Future<Output = Result<Self::Connected, Self::Error>> {
+        ready(Ok(ConnectedDescribingBroker))
     }
 }
 
@@ -152,8 +154,8 @@ impl ruststream::ConnectedBroker for ConnectedDescribingBroker {
     type Error = std::convert::Infallible;
     type Closed = ();
 
-    async fn shutdown(self) -> Result<(), Self::Error> {
-        Ok(())
+    fn shutdown(self) -> impl Future<Output = Result<(), Self::Error>> {
+        ready(Ok(()))
     }
 }
 

--- a/tests/batch_router_coverage.rs
+++ b/tests/batch_router_coverage.rs
@@ -6,6 +6,7 @@
 
 mod common;
 
+use std::future::ready;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -134,10 +135,13 @@ struct RefusedPublish;
 impl PublishPolicy<ConnectedMemoryBroker> for RefusedPublish {
     type Live = MemoryPublisher;
 
-    async fn pair(self, _connected: &ConnectedMemoryBroker) -> Result<MemoryPublisher, PairError> {
-        Err(PairError::from_boxed(Box::from(
+    fn pair(
+        self,
+        _connected: &ConnectedMemoryBroker,
+    ) -> impl Future<Output = Result<MemoryPublisher, PairError>> {
+        ready(Err(PairError::from_boxed(Box::from(
             "the reply publisher was refused",
-        )))
+        ))))
     }
 }
 
@@ -152,11 +156,11 @@ impl SubscriptionSource<ConnectedMemoryBroker> for ClosedSource {
         "brc-closed"
     }
 
-    async fn subscribe(
+    fn subscribe(
         self,
         _connected: &ConnectedMemoryBroker,
-    ) -> Result<MemorySubscriber, MemoryError> {
-        Err(MemoryError::ShutDown)
+    ) -> impl Future<Output = Result<MemorySubscriber, MemoryError>> {
+        ready(Err(MemoryError::ShutDown))
     }
 }
 

--- a/tests/from_context.rs
+++ b/tests/from_context.rs
@@ -3,6 +3,7 @@
 //! short-circuits the delivery before the body runs.
 
 use std::convert::Infallible;
+use std::future::ready;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -28,8 +29,10 @@ struct Hits(Arc<AtomicU32>);
 
 impl<C: Send> FromContext<C, AppState> for Hits {
     type Rejection = HandlerResult;
-    async fn from_context(ctx: &mut Context<'_, C, AppState>) -> Result<Self, HandlerResult> {
-        Ok(Self(ctx.state().hits.clone()))
+    fn from_context(
+        ctx: &mut Context<'_, C, AppState>,
+    ) -> impl Future<Output = Result<Self, HandlerResult>> {
+        ready(Ok(Self(ctx.state().hits.clone())))
     }
 }
 
@@ -76,8 +79,10 @@ struct Deny;
 
 impl<C: Send> FromContext<C, GuardState> for Deny {
     type Rejection = HandlerResult;
-    async fn from_context(_ctx: &mut Context<'_, C, GuardState>) -> Result<Self, HandlerResult> {
-        Err(HandlerResult::drop())
+    fn from_context(
+        _ctx: &mut Context<'_, C, GuardState>,
+    ) -> impl Future<Output = Result<Self, HandlerResult>> {
+        ready(Err(HandlerResult::drop()))
     }
 }
 

--- a/tests/macro_params.rs
+++ b/tests/macro_params.rs
@@ -1,6 +1,9 @@
 //! Subscriber clause values sourced from constants and statics rather than literals: the
 //! workers count (a `static usize`), the reply destination and a dictionary channel
 //! (`const &str`), and a failure policy (`const FailurePolicy`).
+//!
+//! The dictionary channel belongs to the deprecated name-carrying `#[publishes(..)]` form,
+//! which this file keeps under test: a destination declared on the message type is a literal.
 
 #![cfg(all(
     feature = "memory",
@@ -8,6 +11,7 @@
     feature = "json",
     feature = "testing"
 ))]
+#![allow(deprecated)]
 
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::runtime::{AppInfo, FailurePolicy, HandlerResult, Out, RustStream};

--- a/tests/publish_builder.rs
+++ b/tests/publish_builder.rs
@@ -1,0 +1,246 @@
+//! The publish builder: one call shape over every surface, with the positions the message
+//! type's `#[derive(Outgoing)]` declaration leaves open.
+#![cfg(all(
+    feature = "memory",
+    feature = "macros",
+    feature = "json",
+    feature = "testing"
+))]
+
+use ruststream::codec::JsonCodec;
+use ruststream::memory::{MemoryBroker, MemoryPublish};
+use ruststream::runtime::{AppInfo, HandlerResult, Out, PublishExt, RustStream, TypedPublisher};
+use ruststream::testing::{TestApp, TestableBroker};
+use ruststream::{Broker, Headers, OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Job {
+    id: u64,
+}
+
+/// The headers contract of [`ChunkDone`]: an ordinary serde struct the derive does not touch.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct DoneMeta {
+    task_id: u64,
+}
+
+/// A message bound to one name.
+#[derive(Debug, PartialEq, Outgoing, Serialize, Deserialize)]
+#[outgoing(name = "chunks.progress")]
+struct Progress {
+    percent: u8,
+}
+
+/// A message bound to one name, with a header contract.
+#[derive(Debug, PartialEq, Outgoing, Serialize, Deserialize)]
+#[outgoing(name = "chunks.done", headers = DoneMeta)]
+struct ChunkDone {
+    output_key: String,
+}
+
+/// A message bound to a space of names.
+#[derive(Debug, PartialEq, Outgoing, Serialize, Deserialize)]
+#[outgoing(name = "orders.{tenant}.{region}.v1")]
+struct OrderPlaced {
+    id: u64,
+}
+
+/// A message that is simply sent where the caller says.
+#[derive(Debug, PartialEq, Outgoing, Serialize, Deserialize)]
+struct OrderArchived {
+    id: u64,
+}
+
+#[derive(OutSlot)]
+#[publishes(ChunkDone, Progress, OrderPlaced, OrderArchived)]
+struct Events;
+
+/// Every destination form, through one slot.
+#[subscriber("jobs.in")]
+async fn convert(
+    job: &Job,
+    Out(out): Out<impl Publisher, Events, (ChunkDone, Progress, OrderPlaced, OrderArchived)>,
+) -> HandlerResult {
+    // Fixed name: nothing to say about the destination.
+    if out
+        .message(&Progress { percent: 50 })
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    // Fixed name plus the declared header contract.
+    let done = ChunkDone {
+        output_key: format!("out/{}", job.id),
+    };
+    if out
+        .message(&done)
+        .with_headers(&DoneMeta { task_id: job.id })
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    // Templated name: one setter per placeholder, in declaration order.
+    if out
+        .message(&OrderPlaced { id: job.id })
+        .to()
+        .tenant("acme")
+        .region(7_u32)
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    // Declared with the derive alone: the call site names the destination.
+    if out
+        .message(&OrderArchived { id: job.id })
+        .to("orders.archived")
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    // Bytes: the same shape without a codec position.
+    let mut headers = Headers::new();
+    headers.insert("source", "jobs.in");
+    if out
+        .raw(b"frame")
+        .with_header_map(headers)
+        .to("chunks.raw")
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerResult::retry();
+    }
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_destination_form_resolves_through_one_builder() {
+    let app =
+        RustStream::new(AppInfo::new("builder", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(convert).out(Events, MemoryPublish).mount();
+        });
+    let tb = TestApp::start(app).await.expect("harness start");
+
+    tb.publish("jobs.in", &Job { id: 3 })
+        .await
+        .expect("publish");
+
+    let broker = tb.broker::<MemoryBroker>();
+    broker
+        .published::<Progress>("chunks.progress")
+        .assert_called_once()
+        .with(&Progress { percent: 50 });
+    // The templated address is rendered per publish, placeholders in declaration order.
+    broker
+        .published::<OrderPlaced>("orders.acme.7.v1")
+        .assert_called_once()
+        .with(&OrderPlaced { id: 3 });
+    broker
+        .published::<OrderArchived>("orders.archived")
+        .assert_called_once()
+        .with(&OrderArchived { id: 3 });
+
+    // The declared contract lands in the header map, one entry per field.
+    let done = broker
+        .published::<ChunkDone>("chunks.done")
+        .assert_called_once();
+    assert_eq!(done.messages()[0].headers().get_str("task_id"), Some("3"));
+
+    // The byte path carries its map as it is.
+    let raw = tb.out::<Events>();
+    let framed = raw
+        .messages()
+        .iter()
+        .find(|msg| msg.name() == "chunks.raw")
+        .expect("the raw publish is attributed to the slot");
+    assert_eq!(framed.payload(), b"frame");
+    assert_eq!(framed.headers().get_str("source"), Some("jobs.in"));
+}
+
+/// A bare publisher reaches the same builder through [`PublishExt`], encoding with the crate
+/// default codec unless the call names one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bare_publisher_publishes_through_the_builder() {
+    let broker = MemoryBroker::new();
+    let connected = broker.clone().connect().await.expect("connect");
+    let publisher = connected.publisher();
+
+    publisher
+        .message(&Progress { percent: 100 })
+        .publish()
+        .await
+        .expect("fixed name");
+    publisher
+        .message(&OrderArchived { id: 9 })
+        .with_codec(JsonCodec)
+        .to("orders.archived".to_owned())
+        .publish()
+        .await
+        .expect("call-level codec and a computed name");
+    publisher
+        .raw(b"bytes")
+        .to("audit")
+        .publish()
+        .await
+        .expect("bytes");
+
+    assert_eq!(connected.published("chunks.progress").len(), 1);
+    assert_eq!(connected.published("orders.archived").len(), 1);
+    let audit = connected.published("audit");
+    assert_eq!(audit.len(), 1);
+    assert_eq!(audit[0].payload(), b"bytes");
+}
+
+/// The typed publisher and both transaction surfaces carry the same builder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_typed_publisher_and_transactions_carry_the_builder() {
+    let broker = MemoryBroker::new();
+    let connected = broker.clone().connect().await.expect("connect");
+    let publisher = TypedPublisher::with_codec(connected.publisher(), JsonCodec);
+
+    publisher
+        .message(&Progress { percent: 10 })
+        .publish()
+        .await
+        .expect("typed publisher");
+
+    // The borrowed transaction kind.
+    let transactional =
+        TypedPublisher::with_codec(connected.publisher(), JsonCodec).transactional();
+    let scope = transactional.begin().await.expect("begin");
+    scope
+        .message(&Progress { percent: 20 })
+        .publish()
+        .await
+        .expect("in transaction");
+    scope
+        .raw(b"trace")
+        .to("audit.trail")
+        .publish()
+        .await
+        .expect("bytes in transaction");
+    scope.commit().await.expect("commit");
+
+    // The owned transaction kind.
+    let mut owned = publisher.transaction().await.expect("owned transaction");
+    owned
+        .message(&OrderArchived { id: 1 })
+        .to("orders.archived")
+        .publish()
+        .await
+        .expect("in owned transaction");
+    owned.commit().await.expect("commit");
+
+    assert_eq!(connected.published("chunks.progress").len(), 2);
+    assert_eq!(connected.published("audit.trail").len(), 1);
+    assert_eq!(connected.published("orders.archived").len(), 1);
+}

--- a/tests/publish_builder.rs
+++ b/tests/publish_builder.rs
@@ -230,6 +230,13 @@ async fn the_typed_publisher_and_transactions_carry_the_builder() {
         .expect("bytes in transaction");
     scope.commit().await.expect("commit");
 
+    publisher
+        .raw(b"wire")
+        .to("audit.wire")
+        .publish()
+        .await
+        .expect("bytes through the typed publisher");
+
     // The owned transaction kind.
     let mut owned = publisher.transaction().await.expect("owned transaction");
     owned
@@ -238,9 +245,47 @@ async fn the_typed_publisher_and_transactions_carry_the_builder() {
         .publish()
         .await
         .expect("in owned transaction");
+    owned
+        .raw(b"ledger")
+        .to("audit.ledger")
+        .publish()
+        .await
+        .expect("bytes in owned transaction");
     owned.commit().await.expect("commit");
 
     assert_eq!(connected.published("chunks.progress").len(), 2);
     assert_eq!(connected.published("audit.trail").len(), 1);
+    assert_eq!(connected.published("audit.wire").len(), 1);
     assert_eq!(connected.published("orders.archived").len(), 1);
+    assert_eq!(connected.published("audit.ledger").len(), 1);
+}
+
+/// A builder in flight keeps its wiring out of Debug: it holds a live publisher, and a
+/// diagnostic dump must not print one.
+#[test]
+fn a_publish_builder_hides_its_wiring() {
+    let publisher = MemoryBroker::new().publisher();
+    let pending = publisher.message(&Progress { percent: 1 });
+    assert_eq!(format!("{pending:?}"), "Publish { .. }");
+}
+
+/// The typed headers of a message with no contract are rejected, but an arbitrary transport map
+/// still travels with it: the map stands for no declaration.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_contract_less_message_still_carries_a_header_map() {
+    let broker = MemoryBroker::new();
+    let connected = broker.clone().connect().await.expect("connect");
+
+    let mut headers = Headers::new();
+    headers.insert("x-trace", "abc");
+    connected
+        .publisher()
+        .message(&Progress { percent: 5 })
+        .with_header_map(headers)
+        .publish()
+        .await
+        .expect("map headers on a contract-less message");
+
+    let published = connected.published("chunks.progress");
+    assert_eq!(published[0].headers().get_str("x-trace"), Some("abc"));
 }

--- a/tests/publish_builder.rs
+++ b/tests/publish_builder.rs
@@ -260,6 +260,50 @@ async fn the_typed_publisher_and_transactions_carry_the_builder() {
     assert_eq!(connected.published("audit.ledger").len(), 1);
 }
 
+/// The batch publishing path carries the builder too: the reply travels its own wiring while
+/// the handler's own publishes go through the slot, in one handler.
+#[subscriber(batch("jobs.bulk"), publish("jobs.settled"))]
+async fn settle(
+    jobs: &[Job],
+    Out(out): Out<impl Publisher, Events, Progress>,
+) -> Result<Vec<Job>, HandlerResult> {
+    for job in jobs {
+        if out
+            .message(&Progress {
+                percent: u8::try_from(job.id).unwrap_or(u8::MAX),
+            })
+            .publish()
+            .await
+            .is_err()
+        {
+            return Err(HandlerResult::retry());
+        }
+    }
+    Ok(jobs.iter().map(|job| Job { id: job.id }).collect())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_batch_publishing_handler_carries_the_builder() {
+    let app =
+        RustStream::new(AppInfo::new("bulk", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(settle)
+                .publisher(TypedPublisher::new(MemoryPublish))
+                .out(Events, MemoryPublish)
+                .mount();
+        });
+    let tb = TestApp::start(app).await.expect("harness start");
+
+    tb.publish("jobs.bulk", &Job { id: 4 })
+        .await
+        .expect("publish");
+
+    tb.out::<Events>().assert_called_once();
+    tb.broker::<MemoryBroker>()
+        .published::<Progress>("chunks.progress")
+        .assert_called_once()
+        .with(&Progress { percent: 4 });
+}
+
 /// A builder in flight keeps its wiring out of Debug: it holds a live publisher, and a
 /// diagnostic dump must not print one.
 #[test]

--- a/tests/raw_subscriber.rs
+++ b/tests/raw_subscriber.rs
@@ -7,6 +7,7 @@
 #![cfg(all(feature = "macros", feature = "memory", feature = "testing"))]
 
 use std::convert::Infallible;
+use std::future::ready;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -211,11 +212,14 @@ impl Publisher for FlakyPublisher {
 impl PublishPolicy<ConnectedMemoryBroker> for FlakyPublish {
     type Live = FlakyPublisher;
 
-    async fn pair(self, connected: &ConnectedMemoryBroker) -> Result<FlakyPublisher, PairError> {
-        Ok(FlakyPublisher {
+    fn pair(
+        self,
+        connected: &ConnectedMemoryBroker,
+    ) -> impl Future<Output = Result<FlakyPublisher, PairError>> {
+        ready(Ok(FlakyPublisher {
             inner: connected.publisher(),
             fail_next: self.0,
-        })
+        }))
     }
 }
 

--- a/tests/typed_headers.rs
+++ b/tests/typed_headers.rs
@@ -2,6 +2,11 @@
 //! before the body runs (failing by the subscriber's decode policy), and the `Out` slot
 //! dictionary publishes typed messages - destination from the marker's `#[publishes(..)]`
 //! declaration, headers from the message's `#[message(headers(..))]` contract.
+//!
+//! The publish half is the deprecated dictionary path, kept under test until it is removed (the
+//! `Vec<Frame>` entry is the case only it can express: a foreign type cannot declare a
+//! destination of its own, so the replacement is a `#[derive(Outgoing)]` newtype). The publish
+//! builder that replaces it is covered by `tests/publish_builder.rs`.
 
 #![cfg(all(
     feature = "memory",
@@ -9,6 +14,7 @@
     feature = "json",
     feature = "testing"
 ))]
+#![allow(deprecated)]
 
 use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemoryPublish};

--- a/tests/ui/out_slot_duplicate_publishes.stderr
+++ b/tests/ui/out_slot_duplicate_publishes.stderr
@@ -1,4 +1,4 @@
-error: this type is already in the slot's publish dictionary: one type maps to one channel per slot (use a second slot for a second destination)
+error: this type is already listed on the slot: a type appears once (with the deprecated `= "channel"` form, a second entry would also make its destination ambiguous)
   --> tests/ui/out_slot_duplicate_publishes.rs:12:40
    |
 12 | #[publishes(Report = "reports.hourly", Report = "reports.daily")]

--- a/tests/ui/out_typed_capability_mismatch.stderr
+++ b/tests/ui/out_typed_capability_mismatch.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `InjectHandler<SubscriberBuilder<__RsOutDef_forwar
    |                                                       ^^^^^ unsatisfied trait bound
    |
    = help: the trait `Handler<MemoryMessage>` is not implemented for `InjectHandler<SubscriberBuilder<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, Name, (Open, Open, Open)>, JsonCodec>`
-help: the trait `Handler<Msg, <Def as InjectDef>::Context, State>` is implemented for `InjectHandler<Def, DecodeCodec>`
+help: the trait `Handler<Msg, <Def as InjectDef>::Context, State>` is conditionally implemented for `InjectHandler<Def, DecodeCodec>`
   --> src/runtime/inject.rs
    |
    | / impl<Msg, Def, DecodeCodec, State> Handler<Msg, Def::Context, State>
@@ -15,7 +15,9 @@ help: the trait `Handler<Msg, <Def as InjectDef>::Context, State>` is implemente
 ...  |
    | |     DecodeCodec: Codec,
    | |     State: Send + Sync,
-   | |_______________________^
+   | |                       ^ unsatisfied requirement introduced here: `<SubscriberBuilder<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, Name, (Open, Open, Open)> as InjectDef>::Context == ()`
+   | |_______________________|
+   |
    = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<forward, Name, (Open, Open, Open)>>`
 note: required by a bound in `IncludeSlots::<'s, Mount, B, Layers, C, State, Pipeline, Def, Slots>::mount`
   --> src/runtime/app/include/slot_builder.rs

--- a/tests/ui/out_typed_missing_headers.stderr
+++ b/tests/ui/out_typed_missing_headers.stderr
@@ -1,3 +1,11 @@
+warning: use of deprecated method `ruststream::runtime::TypedSlot::<P, Body, M, EncodeCodec>::publish_typed`: use the publish builder: out.message(&value).publish()
+  --> tests/ui/out_typed_missing_headers.rs:34:10
+   |
+34 |         .publish_typed(&Done {
+   |          ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error[E0271]: type mismatch resolving `<Done as MessageHeaders>::Contract == NoHeaders`
   --> tests/ui/out_typed_missing_headers.rs:34:24
    |

--- a/tests/ui/out_typed_not_in_list.stderr
+++ b/tests/ui/out_typed_not_in_list.stderr
@@ -1,3 +1,11 @@
+warning: use of deprecated method `ruststream::runtime::TypedSlot::<P, Body, M, EncodeCodec>::publish_typed`: use the publish builder: out.message(&value).publish()
+  --> tests/ui/out_typed_not_in_list.rs:32:10
+   |
+32 |         .publish_typed(&Done {
+   |          ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error[E0308]: mismatched types
   --> tests/ui/out_typed_not_in_list.rs:32:24
    |

--- a/tests/ui/out_typed_undeclared_message.stderr
+++ b/tests/ui/out_typed_undeclared_message.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `Rogue` is not in the publish dictionary of the `Events` slot
+error[E0277]: `Rogue` does not define a message set for the `Events` slot
   --> tests/ui/out_typed_undeclared_message.rs:26:1
    |
 26 | #[subscriber("orders")]
@@ -9,10 +9,18 @@ help: the trait `OutMessage<Events>` is not implemented for `Rogue`
    |
 16 | struct Rogue {
    | ^^^^^^^^^^^^
-   = note: declare it on the marker: #[publishes(Rogue = "<channel>")] (the #[derive(OutSlot)] attribute); only declared types publish through publish_typed
+   = note: the third Out argument is a tuple of types, `()` (unrestricted), a #[derive(Outgoing)] type (declares itself and where it goes), or a #[derive(OutMessages)] enum (declares its variants' models)
 help: the trait `OutMessage<Events>` is implemented for `Progress`
   --> tests/ui/out_typed_undeclared_message.rs:20:10
    |
 20 | #[derive(OutSlot)]
    |          ^^^^^^^
+note: required for `Rogue` to implement `OutMessages<Events>`
+  --> tests/ui/out_typed_undeclared_message.rs:16:8
+   |
+15 | #[derive(Message, Serialize)]
+   |          ------- type parameter would need to implement `OutMessages<Events>`
+16 | struct Rogue {
+   |        ^^^^^
+   = help: consider manually implementing `OutMessages<Events>` to avoid undesired bounds
    = note: this error originates in the attribute macro `subscriber` which comes from the expansion of the derive macro `OutSlot` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/out_typed_undeclared_message.stderr
+++ b/tests/ui/out_typed_undeclared_message.stderr
@@ -9,7 +9,7 @@ help: the trait `OutMessage<Events>` is not implemented for `Rogue`
    |
 16 | struct Rogue {
    | ^^^^^^^^^^^^
-   = note: the third Out argument is a tuple of types, `()` (unrestricted), a #[derive(Outgoing)] type (declares itself and where it goes), or a #[derive(OutMessages)] enum (declares its variants' models)
+   = note: the third Out argument is a tuple of types, `()` (unrestricted), a #[derive(Outgoing)] type (declares itself and where it goes), or a #[derive(OutMessages)] enum (declares its variants' models); a #[derive(Message)] type declares itself only while the marker still names its channel in the deprecated #[publishes(Rogue = "<channel>")] form
 help: the trait `OutMessage<Events>` is implemented for `Progress`
   --> tests/ui/out_typed_undeclared_message.rs:20:10
    |

--- a/tests/ui/outgoing_bad_name.rs
+++ b/tests/ui/outgoing_bad_name.rs
@@ -1,0 +1,39 @@
+use ruststream::Outgoing;
+use serde::Serialize;
+
+// A placeholder is the setter that binds it, so it has to be named.
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.{}.v1")]
+struct Anonymous {
+    id: u32,
+}
+
+// One setter cannot bind two segments.
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.{tenant}.{tenant}")]
+struct Repeated {
+    id: u32,
+}
+
+// The declared name is read at compile time, so it is a literal.
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = 7)]
+struct NotAString {
+    id: u32,
+}
+
+// Every parameter is `key = value`.
+#[derive(Outgoing, Serialize)]
+#[outgoing(headers)]
+struct BareParameter {
+    id: u32,
+}
+
+// And only the two the derive knows.
+#[derive(Outgoing, Serialize)]
+#[outgoing(topic = "orders")]
+struct UnknownParameter {
+    id: u32,
+}
+
+fn main() {}

--- a/tests/ui/outgoing_bad_name.stderr
+++ b/tests/ui/outgoing_bad_name.stderr
@@ -1,0 +1,29 @@
+error: empty placeholder in the declared name: name the segment, as in `{tenant}`
+ --> tests/ui/outgoing_bad_name.rs:6:19
+  |
+6 | #[outgoing(name = "orders.{}.v1")]
+  |                   ^^^^^^^^^^^^^^
+
+error: `tenant` appears twice in the declared name: one setter cannot bind two segments
+  --> tests/ui/outgoing_bad_name.rs:13:19
+   |
+13 | #[outgoing(name = "orders.{tenant}.{tenant}")]
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `name` is a string literal: the destination (and its `{placeholder}` segments) is read at compile time
+  --> tests/ui/outgoing_bad_name.rs:20:19
+   |
+20 | #[outgoing(name = 7)]
+   |                   ^
+
+error: every #[outgoing(..)] parameter is `key = value`: `name = "orders.done"`, `headers = OrderMeta`
+  --> tests/ui/outgoing_bad_name.rs:27:12
+   |
+27 | #[outgoing(headers)]
+   |            ^^^^^^^
+
+error: unknown #[outgoing(..)] parameter: expected `name` or `headers`
+  --> tests/ui/outgoing_bad_name.rs:34:12
+   |
+34 | #[outgoing(topic = "orders")]
+   |            ^^^^^

--- a/tests/ui/publish_missing_headers.rs
+++ b/tests/ui/publish_missing_headers.rs
@@ -1,0 +1,38 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DoneMeta {
+    task_id: u64,
+}
+
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.done", headers = DoneMeta)]
+struct Done {
+    key: String,
+}
+
+#[derive(OutSlot)]
+#[publishes(Done)]
+struct Events;
+
+// `Done` declares a headers contract: publishing it without `.with_headers(&meta)` does not
+// compile - the empty headers position does not satisfy the declared `WithHeaders<DoneMeta>`.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events, Done>) -> HandlerResult {
+    let _ = out
+        .message(&Done {
+            key: order.id.to_string(),
+        })
+        .publish()
+        .await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_missing_headers.stderr
+++ b/tests/ui/publish_missing_headers.stderr
@@ -1,20 +1,73 @@
-error[E0599]: the method `publish` exists for struct `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Done>, &__RsOutCodec0, HeadersUnset, FixedName>`, but its trait bounds were not satisfied
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<DoneMeta>` contract
   --> tests/ui/publish_missing_headers.rs:33:10
    |
+33 |         .publish()
+   |          ^^^^^^^ the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
+   |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
+   |
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<DoneMeta>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         Hdrs: SatisfiesContract<T::Contract>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<DoneMeta>` contract
+  --> tests/ui/publish_missing_headers.rs:29:13
+   |
 29 |       let _ = out
-   |  _____________-
+   |  _____________^
 30 | |         .message(&Done {
 31 | |             key: order.id.to_string(),
 32 | |         })
 33 | |         .publish()
-   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
-   | |_________|
+   | |__________________^ the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
    |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
    |
-  ::: src/runtime/publish/builder.rs
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<DoneMeta>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
    |
-   |   pub struct HeadersUnset;
-   |   ----------------------- doesn't satisfy `_: SatisfiesContract<WithHeaders<DoneMeta>>`
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         Hdrs: SatisfiesContract<T::Contract>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<DoneMeta>` contract
+  --> tests/ui/publish_missing_headers.rs:34:10
    |
-   = note: the following trait bounds were not satisfied:
-           `HeadersUnset: SatisfiesContract<WithHeaders<DoneMeta>>`
+34 |         .await;
+   |          ^^^^^ the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
+   |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<DoneMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
+   |
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<DoneMeta>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         Hdrs: SatisfiesContract<T::Contract>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`

--- a/tests/ui/publish_missing_headers.stderr
+++ b/tests/ui/publish_missing_headers.stderr
@@ -1,0 +1,20 @@
+error[E0599]: the method `publish` exists for struct `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Done>, &__RsOutCodec0, HeadersUnset, FixedName>`, but its trait bounds were not satisfied
+  --> tests/ui/publish_missing_headers.rs:33:10
+   |
+29 |       let _ = out
+   |  _____________-
+30 | |         .message(&Done {
+31 | |             key: order.id.to_string(),
+32 | |         })
+33 | |         .publish()
+   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   | |_________|
+   |
+   |
+  ::: src/runtime/publish/builder.rs
+   |
+   |   pub struct HeadersUnset;
+   |   ----------------------- doesn't satisfy `_: SatisfiesContract<WithHeaders<DoneMeta>>`
+   |
+   = note: the following trait bounds were not satisfied:
+           `HeadersUnset: SatisfiesContract<WithHeaders<DoneMeta>>`

--- a/tests/ui/publish_no_destination.rs
+++ b/tests/ui/publish_no_destination.rs
@@ -1,0 +1,28 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// The derive alone: this type is sent where the caller says, so the call site owes a `to(..)`.
+#[derive(Outgoing, Serialize)]
+struct Archived {
+    id: u32,
+}
+
+#[derive(OutSlot)]
+#[publishes(Archived)]
+struct Events;
+
+// Publishing without naming the destination does not compile: the builder's destination
+// position is still `CallerName`, which is not a resolved one.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events, Archived>) -> HandlerResult {
+    let _ = out.message(&Archived { id: order.id }).publish().await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_no_destination.stderr
+++ b/tests/ui/publish_no_destination.stderr
@@ -1,0 +1,13 @@
+error[E0599]: the method `publish` exists for struct `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Archived>, &__RsOutCodec0, HeadersUnset, CallerName>`, but its trait bounds were not satisfied
+  --> tests/ui/publish_no_destination.rs:24:53
+   |
+24 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |                                                     ^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |
+  ::: src/schema.rs
+   |
+   | pub struct CallerName;
+   | --------------------- doesn't satisfy `CallerName: ResolvedName`
+   |
+   = note: the following trait bounds were not satisfied:
+           `CallerName: ResolvedName`

--- a/tests/ui/publish_no_destination.stderr
+++ b/tests/ui/publish_no_destination.stderr
@@ -1,13 +1,71 @@
-error[E0599]: the method `publish` exists for struct `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Archived>, &__RsOutCodec0, HeadersUnset, CallerName>`, but its trait bounds were not satisfied
+error[E0277]: this publish has no destination yet
   --> tests/ui/publish_no_destination.rs:24:53
    |
 24 |     let _ = out.message(&Archived { id: order.id }).publish().await;
-   |                                                     ^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |                                                     ^^^^^^^ the trait `ResolvedName` is not implemented for `CallerName`
    |
-  ::: src/schema.rs
+   = note: a message type declaring no name takes one at the call: `.to("orders.archived")`; one declaring a name template opens its placeholder setters with `.to()`, and the publish appears once every placeholder is bound
+help: the following other types implement trait `ResolvedName`
+  --> src/runtime/publish/builder.rs
    |
-   | pub struct CallerName;
-   | --------------------- doesn't satisfy `CallerName: ResolvedName`
+   | impl ResolvedName for FixedName {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FixedName`
+...
+   | impl ResolvedName for SuppliedName<'_> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuppliedName<'_>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
    |
-   = note: the following trait bounds were not satisfied:
-           `CallerName: ResolvedName`
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+...
+   |         Dest: ResolvedName,
+   |               ^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: this publish has no destination yet
+  --> tests/ui/publish_no_destination.rs:24:13
+   |
+24 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ResolvedName` is not implemented for `CallerName`
+   |
+   = note: a message type declaring no name takes one at the call: `.to("orders.archived")`; one declaring a name template opens its placeholder setters with `.to()`, and the publish appears once every placeholder is bound
+help: the following other types implement trait `ResolvedName`
+  --> src/runtime/publish/builder.rs
+   |
+   | impl ResolvedName for FixedName {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FixedName`
+...
+   | impl ResolvedName for SuppliedName<'_> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuppliedName<'_>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+...
+   |         Dest: ResolvedName,
+   |               ^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: this publish has no destination yet
+  --> tests/ui/publish_no_destination.rs:24:63
+   |
+24 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |                                                               ^^^^^ the trait `ResolvedName` is not implemented for `CallerName`
+   |
+   = note: a message type declaring no name takes one at the call: `.to("orders.archived")`; one declaring a name template opens its placeholder setters with `.to()`, and the publish appears once every placeholder is bound
+help: the following other types implement trait `ResolvedName`
+  --> src/runtime/publish/builder.rs
+   |
+   | impl ResolvedName for FixedName {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `FixedName`
+...
+   | impl ResolvedName for SuppliedName<'_> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuppliedName<'_>`
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+...
+   |         Dest: ResolvedName,
+   |               ^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`

--- a/tests/ui/publish_outside_dictionary.rs
+++ b/tests/ui/publish_outside_dictionary.rs
@@ -1,0 +1,40 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.progress")]
+struct Progress {
+    percent: u8,
+}
+
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.rogue")]
+struct Rogue {
+    note: String,
+}
+
+#[derive(OutSlot)]
+#[publishes(Progress)]
+struct Events;
+
+// `Rogue` declares a destination of its own, but the slot does not publish it: the marker's
+// dictionary is what the generated document reports as leaving the slot, so a publish outside
+// it does not compile.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events>) -> HandlerResult {
+    let _ = out
+        .message(&Rogue {
+            note: order.id.to_string(),
+        })
+        .publish()
+        .await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_outside_dictionary.stderr
+++ b/tests/ui/publish_outside_dictionary.stderr
@@ -1,0 +1,31 @@
+error[E0277]: the `Events` slot does not publish `Rogue`
+  --> tests/ui/publish_outside_dictionary.rs:32:18
+   |
+32 |           .message(&Rogue {
+   |  __________-------_^
+   | |          |
+   | |          required by a bound introduced by this call
+33 | |             note: order.id.to_string(),
+34 | |         })
+   | |_________^ unsatisfied trait bound
+   |
+help: the trait `PublishedThrough<Events>` is not implemented for `Rogue`
+  --> tests/ui/publish_outside_dictionary.rs:18:1
+   |
+18 | struct Rogue {
+   | ^^^^^^^^^^^^
+   = note: the marker lists what leaves through the slot, and the generated document reports that list: add the type to it (`#[derive(OutSlot)] #[publishes(Rogue, ..)]`), or publish through a slot that lists it
+help: the trait `PublishedThrough<Events>` is implemented for `Progress`
+  --> tests/ui/publish_outside_dictionary.rs:22:10
+   |
+22 | #[derive(OutSlot)]
+   |          ^^^^^^^
+note: required by a bound in `TypedSlot::<P, Body, M, EncodeCodec>::message`
+  --> src/runtime/slot.rs
+   |
+   |     pub fn message<'a, T, Index>(
+   |            ------- required by a bound in this associated function
+...
+   |         T: OutgoingDestination + PublishedThrough<M>,
+   |                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `TypedSlot::<P, Body, M, EncodeCodec>::message`
+   = note: this error originates in the derive macro `OutSlot` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/publish_template_missing_headers.rs
+++ b/tests/ui/publish_template_missing_headers.rs
@@ -1,0 +1,39 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PlacedMeta {
+    task_id: u64,
+}
+
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.{tenant}.v1", headers = PlacedMeta)]
+struct Placed {
+    id: u32,
+}
+
+#[derive(OutSlot)]
+#[publishes(Placed)]
+struct Events;
+
+// The headers contract holds on the templated address too: every placeholder is bound here, so
+// the address is complete, and what the publish still owes is the declared `with_headers(&meta)`.
+// The generated terminal reports that contract, rather than reading as a missing method.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events, Placed>) -> HandlerResult {
+    let _ = out
+        .message(&Placed { id: order.id })
+        .to()
+        .tenant("acme")
+        .publish()
+        .await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_template_missing_headers.stderr
+++ b/tests/ui/publish_template_missing_headers.stderr
@@ -1,0 +1,70 @@
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<PlacedMeta>` contract
+  --> tests/ui/publish_template_missing_headers.rs:34:10
+   |
+34 |         .publish()
+   |          ^^^^^^^ the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+   |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
+   |
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
+   = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
+note: required by a bound in `To::<Cont, String>::publish`
+  --> tests/ui/publish_template_missing_headers.rs:15:10
+   |
+15 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<PlacedMeta>` contract
+  --> tests/ui/publish_template_missing_headers.rs:30:13
+   |
+30 |       let _ = out
+   |  _____________^
+31 | |         .message(&Placed { id: order.id })
+32 | |         .to()
+33 | |         .tenant("acme")
+34 | |         .publish()
+   | |__________________^ the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+   |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
+   |
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
+   = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
+note: required by a bound in `To::<Cont, String>::publish`
+  --> tests/ui/publish_template_missing_headers.rs:15:10
+   |
+15 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the headers of this publish do not match the message's `WithHeaders<PlacedMeta>` contract
+  --> tests/ui/publish_template_missing_headers.rs:35:10
+   |
+35 |         .await;
+   |          ^^^^^ the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+   |
+   = note: a message declaring `#[outgoing(headers = Meta)]` is published as `.message(&value).with_headers(&meta)`; one declaring no contract takes no typed headers (an arbitrary map still travels through `.with_header_map(..)`)
+help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented for `HeadersUnset`
+      but trait `SatisfiesContract<NoHeaders>` is implemented for it
+  --> src/runtime/publish/builder.rs
+   |
+   | impl SatisfiesContract<NoHeaders> for HeadersUnset {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
+   = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
+note: required by a bound in `To::<Cont, String>::publish`
+  --> tests/ui/publish_template_missing_headers.rs:15:10
+   |
+15 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/publish_unbound_segment.rs
+++ b/tests/ui/publish_unbound_segment.rs
@@ -1,0 +1,34 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// A space of names: both placeholders have to be bound before the publish exists.
+#[derive(Outgoing, Serialize)]
+#[outgoing(name = "orders.{tenant}.{region}.v1")]
+struct Placed {
+    id: u32,
+}
+
+#[derive(OutSlot)]
+#[publishes(Placed)]
+struct Events;
+
+// `region` is never bound, so the address builder still carries its unbound segment and has no
+// publish terminal - the error names the segment that was forgotten.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events, Placed>) -> HandlerResult {
+    let _ = out
+        .message(&Placed { id: order.id })
+        .to()
+        .tenant("acme")
+        .publish()
+        .await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_unbound_segment.stderr
+++ b/tests/ui/publish_unbound_segment.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `publish` found for struct `To<ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>, String, MissingSegment<Region>>` in the current scope
+  --> tests/ui/publish_unbound_segment.rs:29:10
+   |
+11 |   #[derive(Outgoing, Serialize)]
+   |            -------- method `publish` not found for this struct
+...
+25 |       let _ = out
+   |  _____________-
+26 | |         .message(&Placed { id: order.id })
+27 | |         .to()
+28 | |         .tenant("acme")
+29 | |         .publish()
+   | |         -^^^^^^^ method not found in `To<ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>, String, MissingSegment<Region>>`
+   | |_________|
+   |
+   |
+   = note: the method was found for `To<Cont, String, String>`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `publish`, perhaps you need to implement one of them:
+           candidate #1: `Publisher`
+           candidate #2: `Transaction`

--- a/tests/ui/publish_unbound_segment.stderr
+++ b/tests/ui/publish_unbound_segment.stderr
@@ -19,3 +19,7 @@ error[E0599]: no method named `publish` found for struct `To<ruststream::runtime
    = note: the following traits define an item `publish`, perhaps you need to implement one of them:
            candidate #1: `Publisher`
            candidate #2: `Transaction`
+help: one of the expressions' fields has a method of the same name
+   |
+29 |         .cont.publish()
+   |          +++++

--- a/tests/ui/subscriber_publish_unserializable_reply.stderr
+++ b/tests/ui/subscriber_publish_unserializable_reply.stderr
@@ -4,13 +4,14 @@ error[E0277]: the trait bound `TypedPublisher<MemoryPublisher, JsonCodec>: Reply
 23 |         b.include(handle);
    |           ^^^^^^^ the trait `ReplySink<Receipt, (), PublishIdentity>` is not implemented for `TypedPublisher<MemoryPublisher, JsonCodec>`
    |
-help: the trait `ReplySink<Reply, DeliveryCx, Pipeline>` is implemented for `TypedPublisher<Leaf, ReplyCodec, Transforms>`
+help: the trait `ReplySink<Reply, DeliveryCx, Pipeline>` is conditionally implemented for `TypedPublisher<Leaf, ReplyCodec, Transforms>`
   --> src/runtime/publishing.rs
    |
    | / impl<Reply, DeliveryCx, Pipeline, Leaf, ReplyCodec, Transforms>
    | |     ReplySink<Reply, DeliveryCx, Pipeline> for TypedPublisher<Leaf, ReplyCodec, Transforms>
    | | where
    | |     Reply: Serialize + Sync,
+   | |            --------- unsatisfied requirement introduced here: `Receipt: _serde::Serialize`
 ...  |
    | |     ReplyCodec: Codec,
    | |     Transforms: PublishTransform<DeliveryCx>,
@@ -27,7 +28,7 @@ error[E0277]: the trait bound `PublishingHandler<SubscriberBuilder<handle, Name,
    |           ^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `Handler<MemoryMessage>` is not implemented for `PublishingHandler<SubscriberBuilder<handle, Name, (Open, Open, Open)>, JsonCodec, TypedPublisher<MemoryPublisher, JsonCodec>>`
-help: the trait `Handler<Msg, <Def as PublishingDef>::Context, State>` is implemented for `PublishingHandler<Def, DecodeCodec, Wiring, Pipeline>`
+help: the trait `Handler<Msg, <Def as PublishingDef>::Context, State>` is conditionally implemented for `PublishingHandler<Def, DecodeCodec, Wiring, Pipeline>`
   --> src/runtime/publishing.rs
    |
    | / impl<Msg, Def, DecodeCodec, Wiring, Pipeline, State> Handler<Msg, Def::Context, State>
@@ -35,6 +36,8 @@ help: the trait `Handler<Msg, <Def as PublishingDef>::Context, State>` is implem
    | | where
    | |     Msg: IncomingMessage,
 ...  |
+   | |     Wiring: ReplySink<Def::Reply, Def::Context, Pipeline>,
+   | |             --------------------------------------------- unsatisfied requirement introduced here: `TypedPublisher<MemoryPublisher, JsonCodec>: ReplySink<<SubscriberBuilder<handle, Name, (Open, Open, Open)> as PublishingDef>::Reply, <SubscriberBuilder<handle, Name, (Open, Open, Open)> as PublishingDef>::Context, PublishIdentity>`
    | |     Pipeline: Send + Sync,
    | |     State: Send + Sync,
    | |_______________________^


### PR DESCRIPTION
# Description

Publishing was two surfaces for one job: a byte publish that took a destination and no
declaration, and a typed publish that read its destination off a slot marker's dictionary. Which
one a call site used decided a whole bundle of behaviours at once, and a service wanting a typed
value at a destination computed at run time had to leave the path and rebuild the pieces by hand.

A message type now declares everything about being sent through one derive, with every parameter
in the same `key = value` form: `#[derive(Outgoing)]` with `#[outgoing(name = "orders.done",
headers = OrderMeta)]`. `name` is the destination - a fixed one, or a template whose
`{placeholder}` segments become setters - and `headers` names the contract type, which stays an
ordinary serde struct the derive does not touch.

Publishing is one builder with two entry points, `message(..)` for a value and `raw(..)` for
bytes, on every publish surface (`Out` slots, the typed publisher, both transaction kinds, and any
bare publisher). Which positions a call site has to fill is decided by the message type, so a
publish cannot be under-specified: a fixed name has no `to(..)` at all, a template demands its
placeholders (an unbound one rides in the builder's type, so the error names the segment), and a
type declaring nothing takes a plain name. A declared header contract is demanded the same way.

`Publisher::publish(OutgoingMessage)` is untouched, but stated for what it is: the interface a
broker crate implements, with the builder resolving every position down to one call to it. No
broker crate is affected by this change.

Additive: `publish_typed`, the name-carrying `#[publishes(Type = "channel")]` form and the
`ErasedPublisher` byte pair keep working and are deprecated in place, with their regression
coverage kept. The marker's dictionary reduces to the list of types a slot may publish. In the
generated document a fixed name becomes its channel, a templated one is declared on its templated
address with the parameters block filled from its placeholders, and a type that declares no
destination contributes nothing.

Fixes #231

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable