### PR TITLE
feat: express a subscriber's declarative settings through a builder the macro shares

### DIFF
--- a/crates/ruststream-macros/src/expand.rs
+++ b/crates/ruststream-macros/src/expand.rs
@@ -14,74 +14,84 @@ use crate::parse::{
 };
 
 pub(crate) fn subscriber(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<TokenStream> {
-    reject_raw_combinations(args, func)?;
+    reject_reply_combinations(args)?;
     let parts = handler_parts(args, func)?;
-    let body = if args.raw.is_some() {
-        // The remaining combinations are already rejected above; publish_raw(..) selects the
-        // byte reply form, otherwise raw is the plain form (injected when the signature
-        // carries Out / Seek parameters - the input axis makes raw compose with them).
-        match &args.publish_raw {
-            Some(reply_topic) => expand_publishing(&parts, func, reply_topic, true, true)?,
-            None if !parts.outs.is_empty() || parts.seek.is_some() => expand_injected(&parts, true),
-            None => expand_subscribing(&parts, true),
-        }
-    } else if let Some(reply_topic) = &args.publish_raw {
-        expand_publishing(&parts, func, reply_topic, true, false)?
-    } else {
-        match (&args.batch, &args.publish) {
-            (true, Some(reply_topic)) => expand_batch_publishing(&parts, func, reply_topic)?,
-            (true, None) if !parts.outs.is_empty() || parts.seek.is_some() => {
-                expand_batch_injected(&parts, func)
+    reject_shape_combinations(args, func, &parts)?;
+    let injected = !parts.outs.is_empty() || parts.seek.is_some();
+    let body = match parts.shape {
+        Shape::RawBatch => expand_raw_batch(&parts, func),
+        Shape::Batch => match &args.publish {
+            Some(reply_topic) => expand_batch_publishing(&parts, func, reply_topic)?,
+            None if injected => expand_batch_injected(&parts, func),
+            None => expand_batch(&parts, func),
+        },
+        // The input axis is a flag, not a form, so the byte input composes with every
+        // single-message form.
+        Shape::Single | Shape::Raw => {
+            let raw = parts.shape == Shape::Raw;
+            if let Some(reply_topic) = &args.publish_raw {
+                expand_publishing(&parts, func, reply_topic, true, raw)?
+            } else if let Some(reply_topic) = &args.publish {
+                expand_publishing(&parts, func, reply_topic, false, raw)?
+            } else if injected {
+                expand_injected(&parts, raw)
+            } else {
+                expand_subscribing(&parts, raw)
             }
-            (true, None) => expand_batch(&parts, func),
-            (false, Some(reply_topic)) => {
-                expand_publishing(&parts, func, reply_topic, false, false)?
-            }
-            (false, None) if !parts.outs.is_empty() || parts.seek.is_some() => {
-                expand_injected(&parts, false)
-            }
-            (false, None) => expand_subscribing(&parts, false),
         }
     };
     Ok(body.into())
 }
 
-/// Rejects the argument combinations the byte-level forms do not take: `raw` with batches (one
-/// delivery's bytes only) or the decode failure policy (there is no decode step), an encoded
-/// `publish(..)` reply off raw bytes (the reply of a raw handler is bytes - `publish_raw`), both
-/// reply clauses at once, and a batch with a byte reply.
-fn reject_raw_combinations(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<()> {
+/// The combinations that are wrong before the signature is even read: two reply clauses at once.
+fn reject_reply_combinations(args: &SubscriberArgs) -> syn::Result<()> {
     if let (Some(_), Some(publish_raw)) = (&args.publish, &args.publish_raw) {
         return Err(Error::new_spanned(
             publish_raw,
             "publish(..) and publish_raw(..) are mutually exclusive: one reply, one destination",
         ));
     }
-    if let Some(publish_raw) = &args.publish_raw
-        && args.batch
-    {
+    Ok(())
+}
+
+/// The combinations the inferred shape rules out: an encoded reply off undecoded bytes (the reply
+/// of a raw handler is bytes), a byte reply off a batch, a decode policy where nothing is
+/// materialized, and the injection parameters the raw batch form does not carry yet.
+fn reject_shape_combinations(
+    args: &SubscriberArgs,
+    func: &ItemFn,
+    parts: &HandlerParts<'_>,
+) -> syn::Result<()> {
+    let raw_input = matches!(parts.shape, Shape::Raw | Shape::RawBatch);
+    let batched = matches!(parts.shape, Shape::Batch | Shape::RawBatch);
+    if raw_input && let Some(publish) = &args.publish {
         return Err(Error::new_spanned(
-            publish_raw,
-            "publish_raw(..) is not supported together with batch(..) yet; publish per message \
-             or use the encoded batch reply form",
-        ));
-    }
-    let Some(raw) = &args.raw else {
-        return Ok(());
-    };
-    if args.publish.is_some() {
-        return Err(Error::new(
-            raw.span(),
+            publish,
             "the reply of a raw handler is bytes and is never encoded; use \
              publish_raw(\"dest\") instead of publish(..)",
         ));
     }
-    if args.batch {
-        return Err(Error::new(
-            raw.span(),
-            "raw is not supported together with batch(..); a raw handler takes one delivery's \
-             payload as `&[u8]`",
+    if batched && let Some(publish_raw) = &args.publish_raw {
+        return Err(Error::new_spanned(
+            publish_raw,
+            "publish_raw(..) is not supported together with a batch handler yet; publish per \
+             message or use the encoded batch reply form",
         ));
+    }
+    if parts.shape == Shape::RawBatch {
+        if !parts.outs.is_empty() || parts.seek.is_some() {
+            return Err(Error::new_spanned(
+                &func.sig,
+                "a raw batch handler does not take Out / Seek parameters yet; take the batch as \
+                 `&[T]` for the decoded form, or the payload as `&[u8]` per delivery",
+            ));
+        }
+        if let Some(publish) = &args.publish {
+            return Err(Error::new_spanned(
+                publish,
+                "a raw batch handler has no reply form yet; publish from the body",
+            ));
+        }
     }
     // With a FromHeaders parameter the decode policy still has a job on a raw handler: it
     // settles a header contract that fails to parse.
@@ -90,14 +100,16 @@ fn reject_raw_combinations(args: &SubscriberArgs, func: &ItemFn) -> syn::Result<
         .inputs
         .iter()
         .any(|arg| matches!(arg, FnArg::Typed(pt) if from_headers_ty(&pt.ty).is_some()));
-    if let Some(failure) = &args.on_failure
+    if raw_input
+        && let Some(failure) = &args.on_failure
         && failure.decode.is_some()
         && !has_from_headers
     {
-        return Err(Error::new(
-            raw.span(),
-            "on_failure(decode = ..) does not apply to raw: the payload is not decoded and \
-             there is no FromHeaders parameter; keep only on_failure(panic = ..)",
+        return Err(Error::new_spanned(
+            func.sig.inputs.first(),
+            "on_failure(decode = ..) does not apply to an undecoded payload: this handler takes \
+             the bytes as delivered and declares no FromHeaders parameter; keep only \
+             on_failure(panic = ..)",
         ));
     }
     Ok(())
@@ -121,13 +133,54 @@ struct HandlerParts<'a> {
     extractors: Vec<(&'a Pat, &'a Type)>,
     outs: Vec<OutParam<'a>>,
     seek: Option<(&'a Pat, &'a Type)>,
-    workers_method: TokenStream2,
-    failure_method: TokenStream2,
-    /// The `FailurePolicy` value applied to `FromHeaders` extraction (the `decode` key).
-    headers_policy: TokenStream2,
+    /// What the handler consumes per invocation, inferred from its message parameter.
+    shape: Shape,
+    /// The builder calls the attribute's settings expand into, chained onto
+    /// `SubscriberBuilder::new(..)` inside the generated `Declared::declare`.
+    settings_chain: TokenStream2,
+    /// The source type the declared builder ends up over: the attribute's source, wrapped in
+    /// `StartAt<_, _>` when the attribute names a start position.
+    settings_source_ty: TokenStream2,
+    /// Which settings the attribute fixed, as the builder's `(workers, failures, position)`
+    /// state tuple.
+    settings_state_ty: TokenStream2,
     /// The `headers_schema()` def-method override lifted from the first `FromHeaders<T>`
     /// parameter's contract type, or empty when the handler takes none.
     headers_schema: TokenStream2,
+}
+
+/// The `Declared` impl every expansion emits next to its definition: the mount form, and the
+/// builder the attribute's settings expand into.
+///
+/// This is what makes the attribute sugar over the builder rather than a second implementation:
+/// `#[subscriber("orders", workers(4))]` produces exactly the calls a user would write at the
+/// mount site.
+fn declaration(parts: &HandlerParts<'_>, form: &TokenStream2) -> TokenStream2 {
+    let HandlerParts {
+        name,
+        source_expr,
+        settings_chain,
+        settings_source_ty,
+        settings_state_ty,
+        ..
+    } = parts;
+    quote! {
+        impl ::ruststream::runtime::Declared for #name {
+            type Form = #form;
+            type Settings = ::ruststream::runtime::SubscriberBuilder<
+                #name,
+                #settings_source_ty,
+                #settings_state_ty,
+            >;
+
+            fn declare(self) -> Self::Settings {
+                #[allow(unused_imports)]
+                use ::ruststream::runtime::SubscriberSettings as _;
+                ::ruststream::runtime::SubscriberBuilder::new(self, #source_expr)
+                    #settings_chain
+            }
+        }
+    }
 }
 
 /// The per-delivery context type the handler named in its `ctx: &mut Context<'_, C>` parameter,
@@ -439,22 +492,26 @@ fn extractor_where(
 /// extraction runs `reject` (a `return` settling the delivery by the rejection's `HandlerResult`).
 ///
 /// A `FromHeaders<T>` parameter takes the policy-aware path instead of the generic
-/// [`FromContext`] call, so the subscriber's `on_failure(decode = ..)` policy (interpolated as
-/// `headers_policy`) applies to the header contract exactly like it applies to the payload codec.
+/// [`FromContext`] call, and reads the policy off the delivery context rather than off the
+/// attribute: the effective materialization policy is the one the mount resolved, whether it was
+/// named in `on_failure(..)` or on the builder.
 fn extractor_prelude(
     extractors: &[(&Pat, &Type)],
     ctx_param: &TokenStream2,
     ctx_ty: &TokenStream2,
     state: &TokenStream2,
-    headers_policy: &TokenStream2,
     reject: &TokenStream2,
 ) -> TokenStream2 {
     let binds = extractors.iter().map(|(pat, ty)| {
         if from_headers_ty(ty).is_some() {
             return quote! {
-                let #pat = match <#ty>::extract(&mut *#ctx_param, #headers_policy) {
-                    ::core::result::Result::Ok(__rs_value) => __rs_value,
-                    ::core::result::Result::Err(__rs_err) => { #reject; }
+                let #pat = {
+                    // Read before the mutable borrow the extraction takes.
+                    let __rs_policy = #ctx_param.decode_policy();
+                    match <#ty>::extract(&mut *#ctx_param, __rs_policy) {
+                        ::core::result::Result::Ok(__rs_value) => __rs_value,
+                        ::core::result::Result::Err(__rs_err) => { #reject; }
+                    }
                 };
             };
         }
@@ -472,10 +529,10 @@ fn extractor_prelude(
     quote!(#(#binds)*)
 }
 
-/// Renders the `on_failure(..)` clause as an override of the def's defaulted `failure_policies`
-/// method, or nothing when the clause is absent. Only the keys named in the clause are set; the
-/// rest keep the runtime defaults.
-fn failure_method(args: &SubscriberArgs) -> TokenStream2 {
+/// Renders the `on_failure(..)` clause as the builder step it expands into, or nothing when the
+/// clause is absent. Only the keys named in the clause are set; the rest keep the runtime
+/// defaults.
+fn failure_step(args: &SubscriberArgs) -> TokenStream2 {
     let Some(failure) = &args.on_failure else {
         return quote!();
     };
@@ -490,9 +547,7 @@ fn failure_method(args: &SubscriberArgs) -> TokenStream2 {
         .map(failure_policy_tokens)
         .map(|policy| quote!(.with_decode(#policy)));
     quote! {
-        fn failure_policies(&self) -> ::ruststream::runtime::FailurePolicies {
-            ::ruststream::runtime::FailurePolicies::default() #panic #decode
-        }
+        .on_failure(::ruststream::runtime::FailurePolicies::default() #panic #decode)
     }
 }
 
@@ -505,11 +560,12 @@ fn failure_method(args: &SubscriberArgs) -> TokenStream2 {
 /// handler has no typed input to carry a contract, so without a `FromHeaders` parameter it
 /// emits nothing.
 fn headers_schema_method(
-    args: &SubscriberArgs,
+    shape: Shape,
     extractors: &[(&Pat, &Type)],
     input_ty: &Type,
 ) -> syn::Result<TokenStream2> {
-    if args.batch
+    let batch = matches!(shape, Shape::Batch | Shape::RawBatch);
+    if batch
         && let Some((_, ty)) = extractors
             .iter()
             .find(|(_, ty)| from_headers_ty(ty).is_some())
@@ -526,7 +582,7 @@ fn headers_schema_method(
         .iter()
         .find_map(|(_, ty)| from_headers_ty(ty))
         .map(|contract| {
-            if args.batch {
+            if batch {
                 vec_inner_ty(contract).unwrap_or(contract)
             } else {
                 contract
@@ -534,7 +590,7 @@ fn headers_schema_method(
         })
         .map_or_else(
             || {
-                if args.raw.is_some() {
+                if matches!(shape, Shape::Raw | Shape::RawBatch) {
                     return quote!();
                 }
                 quote! {
@@ -556,21 +612,6 @@ fn headers_schema_method(
             },
         );
     Ok(method)
-}
-
-/// The failure policy applied to `FromHeaders` extraction, as a `FailurePolicy` value: the
-/// `on_failure(decode = ..)` key (one materialization policy covers the payload codec and the
-/// header contract), or the runtime default (drop) when the clause omits it. Interpolated into
-/// the generated extraction call - the handler body has no access to the def's
-/// `failure_policies()`.
-fn headers_policy_tokens(args: &SubscriberArgs) -> TokenStream2 {
-    args.on_failure
-        .as_ref()
-        .and_then(|failure| failure.decode.as_ref())
-        .map_or_else(
-            || quote!(::ruststream::runtime::FailurePolicy::Drop),
-            failure_policy_tokens,
-        )
 }
 
 /// Renders the def's `outgoing()` override: the reply message (typed probes on the reply type,
@@ -722,32 +763,24 @@ fn failure_policy_tokens(policy: &FailurePolicyArg) -> TokenStream2 {
     }
 }
 
-/// Renders the `workers(..)` clause as an override of the def's defaulted `workers` method, or
-/// nothing when the clause is absent.
-fn workers_method(args: &SubscriberArgs, handler: &Ident) -> syn::Result<TokenStream2> {
+/// Renders the `workers(..)` clause as the builder step it expands into, or nothing when the
+/// clause is absent.
+fn workers_step(args: &SubscriberArgs, handler: &Ident, shape: Shape) -> syn::Result<TokenStream2> {
     let Some(WorkersArg { count, by_key }) = &args.workers else {
         return Ok(quote!());
     };
     let count = workers_count(count, handler)?;
     if let Some(marker) = by_key {
-        if args.batch {
+        if matches!(shape, Shape::Batch | Shape::RawBatch) {
             return Err(Error::new(
                 marker.span(),
-                "by_key lanes order single messages per key; they do not apply to batch(..) \
-                 forms",
+                "by_key lanes order single messages per key; they do not apply to a batch \
+                 handler",
             ));
         }
-        return Ok(quote! {
-            fn workers(&self) -> ::ruststream::runtime::Workers {
-                ::ruststream::runtime::Workers::keyed(#count)
-            }
-        });
+        return Ok(quote!(.workers_by_key(#count)));
     }
-    Ok(quote! {
-        fn workers(&self) -> ::ruststream::runtime::Workers {
-            ::ruststream::runtime::Workers::pool(#count)
-        }
-    })
+    Ok(quote!(.workers(#count)))
 }
 
 /// Lowers the `workers(..)` count to a `NonZeroUsize`: an integer literal is checked at
@@ -910,40 +943,69 @@ fn split_seek<'a>(
     Ok(seek)
 }
 
-/// Resolves the message parameter's referent into the def's input type per form: batch unwraps
-/// the `&[T]` slice to its element, raw accepts only `&[u8]` (its type is never emitted), and the
-/// plain form takes `&T`. Each misuse gets an error naming the fix.
-fn input_type<'a>(
+/// What the handler consumes per invocation, read off its message parameter rather than declared
+/// in the attribute: `&T` is one decoded message, `&[u8]` one delivery's payload as delivered,
+/// `&[T]` a whole decoded batch, and `&[&[u8]]` a batch of payloads.
+///
+/// A batch of `u8` values is not a thing anyone means, so `&[u8]` reads as the payload; spelling
+/// `batch(..)` in the attribute still says otherwise, which is what keeps the retiring clause
+/// meaning what it always did.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Shape {
+    Single,
+    Raw,
+    Batch,
+    RawBatch,
+}
+
+/// Resolves the message parameter's referent into the handler's shape and the type the
+/// definition carries as its input (the element for a batch; `[u8]` for the byte shapes, which
+/// never emit it). Each misuse gets an error naming the fix.
+fn resolve_shape<'a>(
     args: &SubscriberArgs,
     reference: &'a syn::TypeReference,
-) -> syn::Result<&'a Type> {
+) -> syn::Result<(Shape, &'a Type)> {
+    let elem = &*reference.elem;
+    // A slice of byte slices is a batch of payloads whatever the clauses say: no other reading
+    // of that parameter exists.
+    if let Type::Slice(slice) = elem
+        && let Type::Reference(inner) = &*slice.elem
+        && is_u8_slice(&inner.elem)
+    {
+        return Ok((Shape::RawBatch, &inner.elem));
+    }
+    if args.raw.is_some() {
+        if args.batch {
+            return Err(Error::new_spanned(
+                elem,
+                "a raw batch handler takes the batch's payloads as a slice of byte slices: \
+                 `&[&[u8]]`",
+            ));
+        }
+        return match elem {
+            byte_slice if is_u8_slice(byte_slice) => Ok((Shape::Raw, byte_slice)),
+            other => Err(Error::new_spanned(
+                other,
+                "a raw subscriber receives the payload bytes: make the message parameter \
+                 `&[u8]` (or `&[&[u8]]` for a batch of payloads), or drop `raw` to decode into \
+                 a typed value",
+            )),
+        };
+    }
     if args.batch {
-        return match &*reference.elem {
-            Type::Slice(slice) => Ok(&slice.elem),
+        return match elem {
+            Type::Slice(slice) => Ok((Shape::Batch, &slice.elem)),
             other => Err(Error::new_spanned(
                 other,
                 "a batch handler takes the whole batch as a slice: `&[T]`",
             )),
         };
     }
-    if args.raw.is_some() {
-        return match &*reference.elem {
-            elem if is_u8_slice(elem) => Ok(elem),
-            other => Err(Error::new_spanned(
-                other,
-                "a raw subscriber receives the payload bytes: make the message parameter \
-                 `&[u8]`, or drop `raw` to decode into a typed value",
-            )),
-        };
+    match elem {
+        byte_slice if is_u8_slice(byte_slice) => Ok((Shape::Raw, byte_slice)),
+        Type::Slice(slice) => Ok((Shape::Batch, &slice.elem)),
+        other => Ok((Shape::Single, other)),
     }
-    if matches!(&*reference.elem, Type::Slice(_)) {
-        return Err(Error::new_spanned(
-            &reference.elem,
-            "a slice parameter needs the batch source form: #[subscriber(batch(..))]; for the \
-             undecoded payload bytes use #[subscriber(.., raw)]",
-        ));
-    }
-    Ok(&reference.elem)
 }
 
 /// True when `ty` is syntactically `[u8]`, the only message parameter shape the raw form takes.
@@ -977,21 +1039,27 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
             "the message parameter must be a reference `&T`",
         ));
     };
-    let input_ty = input_type(args, reference)?;
+    let (shape, input_ty) = resolve_shape(args, reference)?;
     let description = doc_description(&func.attrs);
     let (source_ty, source_expr) = source_tokens(&args.source)?;
-    // `start_at(<position>)` wraps the source in the core `StartAt` decorator, so the
-    // subscription is sought to the position before the first delivery. Orthogonal to the
-    // definition form: every form carries a `Source`.
-    let (source_ty, source_expr) = match &args.start_at {
+    // `start_at(<position>)` decorates the source with the core `StartAt` wrapper, so the
+    // subscription is sought to the position before the first delivery. It is a builder step
+    // like the rest, which is why it changes the declared builder's source type rather than the
+    // definition's own.
+    let (settings_source_ty, start_at_step, position_state) = match &args.start_at {
         Some(position) => {
             let position_ty = position_type(position)?;
             (
                 quote!(::ruststream::StartAt<#source_ty, #position_ty>),
-                quote!(::ruststream::StartAt::new(#source_expr, #position)),
+                quote!(.start_at(#position)),
+                quote!(::ruststream::runtime::Fixed),
             )
         }
-        None => (source_ty, source_expr),
+        None => (
+            source_ty.clone(),
+            quote!(),
+            quote!(::ruststream::runtime::Open),
+        ),
     };
 
     // Captures the input type's JSON Schema for AsyncAPI when it implements `JsonSchema` (and the
@@ -1040,11 +1108,17 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
     let ctx_ty = context_type(func);
     let state_ty = state_type(func);
 
-    let headers_schema = headers_schema_method(args, &extractors, input_ty)?;
-    let headers_policy = headers_policy_tokens(args);
+    let headers_schema = headers_schema_method(shape, &extractors, input_ty)?;
 
-    let workers_method = workers_method(args, &func.sig.ident)?;
-    let failure_method = failure_method(args);
+    // The attribute's settings are the builder calls a user would write at the mount site, and
+    // the settings state records which of them are no longer open there. `start_at` comes last:
+    // it wraps the source the earlier steps left alone.
+    let workers_step = workers_step(args, &func.sig.ident, shape)?;
+    let failure_step = failure_step(args);
+    let workers_state = state_marker(args.workers.is_some());
+    let failure_state = state_marker(args.on_failure.is_some());
+    let settings_chain = quote!(#workers_step #failure_step #start_at_step);
+    let settings_state_ty = quote!((#workers_state, #failure_state, #position_state));
 
     Ok(HandlerParts {
         vis: &func.vis,
@@ -1063,11 +1137,21 @@ fn handler_parts<'a>(args: &SubscriberArgs, func: &'a ItemFn) -> syn::Result<Han
         extractors,
         outs,
         seek,
-        workers_method,
-        failure_method,
-        headers_policy,
+        shape,
+        settings_chain,
+        settings_source_ty,
+        settings_state_ty,
         headers_schema,
     })
+}
+
+/// The settings-state marker of one setting: fixed when the attribute named it, open otherwise.
+fn state_marker(fixed: bool) -> TokenStream2 {
+    if fixed {
+        quote!(::ruststream::runtime::Fixed)
+    } else {
+        quote!(::ruststream::runtime::Open)
+    }
 }
 
 /// Splits a batch publishing handler's declared return type into the reply element type and the
@@ -1133,10 +1217,8 @@ fn expand_batch_publishing(
         extractors,
         outs,
         seek,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     let (reply_elem, call_body) = batch_reply_body(func, block)?;
@@ -1172,20 +1254,18 @@ fn expand_batch_publishing(
         ctx_param,
         &unit_ctx,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::core::result::Result::Err(::core::convert::Into::<
                 ::ruststream::runtime::HandlerResult,
             >::into(__rs_err),)
         ),
     );
+    let declaration = declaration(parts, &form);
     Ok(quote! {
         #[allow(non_camel_case_types)]
         #vis struct #name;
 
-        impl ::ruststream::runtime::IncludeDef for #name {
-            type Form = #form;
-        }
+        #declaration
 
         #scaffold_items
 
@@ -1199,10 +1279,6 @@ fn expand_batch_publishing(
 
             fn source(&self) -> Self::Source { #source_expr }
             fn reply_name(&self) -> &str { #reply_name_body }
-
-            #workers_method
-
-            #failure_method
 
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
@@ -1297,10 +1373,8 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
         extractors,
         outs: _,
         seek: _,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     // Pin the body's type to the declared return type before the `IntoBatchResult` conversion:
@@ -1339,7 +1413,6 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
         ctx_param,
         &unit_ctx,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::ruststream::runtime::IntoBatchResult::into_batch_result(
                 ::core::convert::Into::<::ruststream::runtime::HandlerResult>::into(__rs_err),
@@ -1349,6 +1422,7 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
 
     let (handler_trait, headers_arg, headers_binding, form, headers_def) =
         batch_handler_shape(headers_param, input_ty, &state_in_ctx, name);
+    let declaration = declaration(parts, &form);
 
     quote! {
             #[derive(Clone, Copy)]
@@ -1371,9 +1445,7 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
                 }
             }
 
-            impl ::ruststream::runtime::IncludeDef for #name {
-                type Form = #form;
-            }
+            #declaration
 
             #headers_def
 
@@ -1383,10 +1455,6 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
                 type Source = #source_ty;
 
                 fn source(&self) -> Self::Source { #source_expr }
-
-                #workers_method
-
-            #failure_method
 
                 fn description(&self) -> ::core::option::Option<&str> {
                     #description
@@ -1400,6 +1468,91 @@ fn expand_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
 
                 fn into_handler(self) -> Self { self }
             }
+    }
+}
+
+/// The raw batch form: a handler taking `&[&[u8]]`.
+///
+/// The typed batch without the decode step, so nothing is probed for schemas or `Message`
+/// metadata and no codec takes part; the payload slices are borrowed from the batch's own
+/// messages, which the dispatcher holds for the duration of the call.
+fn expand_raw_batch(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream2 {
+    let HandlerParts {
+        vis,
+        name,
+        block,
+        pat,
+        description,
+        source_ty,
+        source_expr,
+        ctx_param,
+        state_ty,
+        extractors,
+        ..
+    } = parts;
+
+    // As for `expand_batch`: pin the body's type before the `IntoBatchResult` conversion.
+    let outcome_ty = match &func.sig.output {
+        ReturnType::Type(_, ty) => quote!(#ty),
+        ReturnType::Default => quote!(()),
+    };
+    let (impl_generics, state_in_ctx) = match &state_ty {
+        Some(state_ty) => (quote!(), quote!(#state_ty)),
+        None => (
+            quote!(<__RsState: ::core::marker::Send + ::core::marker::Sync>),
+            quote!(__RsState),
+        ),
+    };
+    let unit_ctx = quote!(());
+    let where_clause = extractor_where(extractors, &unit_ctx, &state_in_ctx);
+    let prelude = extractor_prelude(
+        extractors,
+        ctx_param,
+        &unit_ctx,
+        &state_in_ctx,
+        &quote!(
+            return ::ruststream::runtime::IntoBatchResult::into_batch_result(
+                ::core::convert::Into::<::ruststream::runtime::HandlerResult>::into(__rs_err),
+            )
+        ),
+    );
+    let form = quote!(::ruststream::runtime::forms::RawBatch);
+    let declaration = declaration(parts, &form);
+
+    quote! {
+        #[derive(Clone, Copy)]
+        #[allow(non_camel_case_types)]
+        #vis struct #name;
+
+        impl #impl_generics ::ruststream::runtime::RawSliceHandler<#state_in_ctx> for #name
+            #where_clause
+        {
+            async fn handle_slice(
+                &self,
+                #pat: &[&[u8]],
+                #ctx_param: &mut ::ruststream::runtime::Context<'_, (), #state_in_ctx>,
+            ) -> ::ruststream::runtime::BatchResult {
+                #prelude
+                let outcome: #outcome_ty = (async move #block).await;
+                ::ruststream::runtime::IntoBatchResult::into_batch_result(outcome)
+            }
+        }
+
+        #declaration
+
+        impl ::ruststream::runtime::BatchDef for #name {
+            type Input = ::ruststream::runtime::RawBytes;
+            type Handler = Self;
+            type Source = #source_ty;
+
+            fn source(&self) -> Self::Source { #source_expr }
+
+            fn description(&self) -> ::core::option::Option<&str> {
+                #description
+            }
+
+            fn into_handler(self) -> Self { self }
+        }
     }
 }
 
@@ -1423,10 +1576,8 @@ fn expand_batch_injected(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream
         extractors,
         outs,
         seek,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     // The injection tuple is shared with the single-message form; only the form token differs
@@ -1463,22 +1614,20 @@ fn expand_batch_injected(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream
         ctx_param,
         &unit_ctx,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::ruststream::runtime::IntoBatchResult::into_batch_result(
                 ::core::convert::Into::<::ruststream::runtime::HandlerResult>::into(__rs_err),
             )
         ),
     );
+    let declaration = declaration(parts, &form);
 
     quote! {
         #[derive(Clone, Copy)]
         #[allow(non_camel_case_types)]
         #vis struct #name;
 
-        impl ::ruststream::runtime::IncludeDef for #name {
-            type Form = #form;
-        }
+        #declaration
 
         #scaffold_items
 
@@ -1490,10 +1639,6 @@ fn expand_batch_injected(parts: &HandlerParts<'_>, func: &ItemFn) -> TokenStream
             type Injections = (#(#injection_tys,)*);
 
             fn source(&self) -> Self::Source { #source_expr }
-
-            #workers_method
-
-            #failure_method
 
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
@@ -1567,10 +1712,8 @@ fn expand_publishing(
         extractors,
         outs,
         seek,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     let (reply_ty, call_body) = publishing_reply(func, block, bare)?;
@@ -1601,20 +1744,18 @@ fn expand_publishing(
         ctx_param,
         ctx_ty,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::core::result::Result::Err(::core::convert::Into::<
                 ::ruststream::runtime::HandlerResult,
             >::into(__rs_err),)
         ),
     );
+    let declaration = declaration(parts, &form);
     Ok(quote! {
         #[allow(non_camel_case_types)]
         #vis struct #name;
 
-        impl ::ruststream::runtime::IncludeDef for #name {
-            type Form = #form;
-        }
+        #declaration
 
         #scaffold_items
 
@@ -1629,10 +1770,6 @@ fn expand_publishing(
 
             fn source(&self) -> Self::Source { #source_expr }
             fn reply_name(&self) -> &str { #reply_name_body }
-
-            #workers_method
-
-            #failure_method
 
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
@@ -1980,10 +2117,8 @@ fn expand_injected(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
         extractors,
         outs,
         seek,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     let form = injected_form(!outs.is_empty());
@@ -2009,22 +2144,20 @@ fn expand_injected(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
         ctx_param,
         ctx_ty,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::ruststream::runtime::IntoSettle::into_settle(::core::convert::Into::<
                 ::ruststream::runtime::HandlerResult,
             >::into(__rs_err),)
         ),
     );
+    let declaration = declaration(parts, &form);
 
     quote! {
         #[derive(Clone, Copy)]
         #[allow(non_camel_case_types)]
         #vis struct #name;
 
-        impl ::ruststream::runtime::IncludeDef for #name {
-            type Form = #form;
-        }
+        #declaration
 
         #scaffold_items
 
@@ -2037,10 +2170,6 @@ fn expand_injected(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
             type Injections = (#(#injection_tys,)*);
 
             fn source(&self) -> Self::Source { #source_expr }
-
-            #workers_method
-
-            #failure_method
 
             fn description(&self) -> ::core::option::Option<&str> {
                 #description
@@ -2093,10 +2222,8 @@ fn expand_subscribing(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
         extractors,
         outs: _,
         seek: _,
-        workers_method,
-        failure_method,
-        headers_policy,
         headers_schema,
+        ..
     } = parts;
 
     let (input_kind, input_param, input_schema, message_meta) =
@@ -2127,13 +2254,13 @@ fn expand_subscribing(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
         ctx_param,
         ctx_ty,
         &state_in_ctx,
-        headers_policy,
         &quote!(
             return ::ruststream::runtime::IntoSettle::into_settle(::core::convert::Into::<
                 ::ruststream::runtime::HandlerResult,
             >::into(__rs_err),)
         ),
     );
+    let declaration = declaration(parts, &form);
 
     quote! {
             #[derive(Clone, Copy)]
@@ -2156,9 +2283,7 @@ fn expand_subscribing(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
                 }
             }
 
-            impl ::ruststream::runtime::IncludeDef for #name {
-                type Form = #form;
-            }
+            #declaration
 
             impl ::ruststream::runtime::SubscriberDef for #name {
                 type Input = #input_kind;
@@ -2167,10 +2292,6 @@ fn expand_subscribing(parts: &HandlerParts<'_>, raw: bool) -> TokenStream2 {
                 type Source = #source_ty;
 
                 fn source(&self) -> Self::Source { #source_expr }
-
-                #workers_method
-
-            #failure_method
 
                 fn description(&self) -> ::core::option::Option<&str> {
                     #description

--- a/crates/ruststream-macros/src/lib.rs
+++ b/crates/ruststream-macros/src/lib.rs
@@ -20,6 +20,10 @@ use parse::{SubscriberArgs, doc_description};
 
 /// Turns an `async fn` handler into a mountable subscriber definition.
 ///
+/// The attribute carries the declarative settings of the subscription; the *shape* of the
+/// handler - one message, one delivery's payload, a whole batch, a batch of payloads - is read
+/// off the signature, which is the only place it was ever really written.
+///
 /// ```ignore
 /// /// Processes incoming orders.
 /// #[subscriber("orders")]
@@ -37,15 +41,27 @@ use parse::{SubscriberArgs, doc_description};
 /// #[subscriber("requests", publish("responses"))]
 /// async fn confirm(req: &Request) -> Result<Response, HandlerResult> { /* ... */ }
 ///
-/// // batch form: the handler takes the whole decoded batch as a slice; the source's
-/// // subscriber must implement BatchSubscriber.
-/// #[subscriber(batch("orders"))]
+/// // batch form: the slice parameter says the handler takes the whole decoded batch; the
+/// // subscription's subscriber must implement BatchSubscriber (natively, or through the
+/// // buffer the mount site adds).
+/// #[subscriber("orders")]
 /// async fn bill(orders: &[Order]) -> HandlerResult { /* settles the whole batch */ }
 ///
-/// // raw form: no codec, no serde - the handler receives the payload bytes as-is. The
-/// // message parameter must be `&[u8]`; a serde-typed parameter under `raw` is an error.
-/// #[subscriber("frames", raw)]
+/// // raw form: no codec, no serde - the handler receives the payload bytes as-is, said by a
+/// // `&[u8]` message parameter.
+/// #[subscriber("frames")]
 /// async fn on_frame(frame: &[u8]) -> HandlerResult { /* parse it yourself */ }
+///
+/// // raw batch: the batch shape without the decode step; the payloads are borrowed from the
+/// // batch's own messages for the duration of the call.
+/// #[subscriber("frames")]
+/// async fn ingest(frames: &[&[u8]]) -> HandlerResult { /* parse them yourself */ }
+///
+/// // the settings the attribute leaves out are filled in at the mount site, through the same
+/// // builder the attribute expands into:
+/// #[subscriber]
+/// async fn audit(order: &Order) -> HandlerResult { HandlerResult::Ack }
+/// // later: broker_scope.include(audit.name(subject).workers(nonzero!(4)));
 ///
 /// // raw reply form: the returned bytes are published as-is to "frames-out" through the bare
 /// // publisher attached at the include site (b.include(mirror).publisher(policy), or the
@@ -69,19 +85,18 @@ use parse::{SubscriberArgs, doc_description};
 /// reply type). `publish_raw(..)` is the byte reply clause: the handler returns `Vec<u8>` (any
 /// owned `AsRef<[u8]>` type) and the bytes are published unencoded through the bare publisher
 /// paired at the include site; a failed reply publish nacks the delivery with requeue, exactly
-/// like the typed reply form. It composes with both a `raw` and a typed input; `raw` with the
-/// encoded `publish(..)` is rejected (a raw handler's reply is bytes).
+/// like the typed reply form. It composes with both a byte and a typed input; a byte input with
+/// the encoded `publish(..)` is rejected (such a handler's reply is bytes).
 ///
-/// Wrapping the source in `batch(..)` switches the definition to a `BatchDef`: the handler takes
-/// `&[T]` and runs once per batch pulled from the broker's `BatchSubscriber` (use the `Buffered`
-/// adapter for brokers without native batching). It returns any `IntoBatchResult` - one outcome
+/// A `&[T]` message parameter makes the definition a `BatchDef`: the handler runs once per batch
+/// pulled from the subscription's `BatchSubscriber` (added by the mount site's buffer for
+/// subscriptions without native batching). It returns any `IntoBatchResult` - one outcome
 /// for the whole batch (`HandlerResult`, `()`, `Result<_, E>`), or a per-element vector
 /// (`Vec<Settle>`, or `Vec<HandlerResult>`) to settle element `i` of the slice with outcome `i`,
-/// each element carrying its own optional `and_after` continuation. The source type is recovered
-/// from the constructor path, so a generic source spells its parameters:
-/// `batch(Buffered::<Name>::new(Name::new("orders")))`.
+/// each element carrying its own optional `and_after` continuation. A `&[&[u8]]` parameter is
+/// the same shape without the decode step.
 ///
-/// Combining `batch(..)` with `publish(..)` produces a `BatchPublishingDef`: the handler returns
+/// Combining a batch handler with `publish(..)` produces a `BatchPublishingDef`: the handler returns
 /// `Vec<Reply>` (or
 /// `Result<Vec<Reply>, HandlerResult>` for explicit ack control, all-or-nothing - selective
 /// outcomes do not compose with a transaction), every reply is published to the reply name, and
@@ -108,7 +123,7 @@ use parse::{SubscriberArgs, doc_description};
 /// dictionary-driven typed publish path; a `Seek(seeker): Seek<K>` parameter injects the
 /// subscription's own seeker, minted right after the subscription opens (the source's
 /// subscriber must implement the `Seekable` capability). They combine freely in one handler:
-/// with each other, with `raw`, with `batch(..)`, and with every reply form (`publish(..)`,
+/// with each other, with a byte input, with a batch handler, and with every reply form (`publish(..)`,
 /// `publish_raw(..)`, and the batch publishing form). An `Out` parameter's attachment is
 /// required at the include site: `.publisher(..)` on the plain and batch forms, `.out(..)` on
 /// the reply forms (where `.publisher(..)` stays the reply's own attachment).
@@ -142,6 +157,11 @@ use parse::{SubscriberArgs, doc_description};
 /// #[subscriber("orders")]
 /// async fn handle(order: &Order, State(db): State<Db>) -> HandlerResult { /* ... */ }
 /// ```
+///
+/// The attribute expands into the definition and then the settings builder over it, so the
+/// clauses above are exactly the calls a user would write at the mount site (see
+/// `SubscriberSettings` in the core crate). A setting the attribute names is fixed in the
+/// definition's type and its builder method no longer applies, so the two can never disagree.
 #[proc_macro_attribute]
 pub fn subscriber(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as SubscriberArgs);

--- a/crates/ruststream-macros/src/parse.rs
+++ b/crates/ruststream-macros/src/parse.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{
     Attribute, Error, Expr, ExprCall, ExprLit, ExprMethodCall, ExprPath, ExprStruct, Ident, Lit,
-    Meta, Path, Token, Type, TypePath, parenthesized,
+    Meta, Path, Token, Type, TypePath, parenthesized, token,
 };
 
 /// Arguments to `#[subscriber(..)]`: the subscription source (a string literal name, or a
@@ -17,7 +17,7 @@ use syn::{
 /// dispatch concurrency), `start_at(<position>)` (the subscription opens at that position),
 /// and `raw` (the handler takes the payload bytes, undecoded) clauses, in any order.
 pub(crate) struct SubscriberArgs {
-    pub(crate) source: Expr,
+    pub(crate) source: SourceArg,
     pub(crate) batch: bool,
     /// The `publish(..)` destination: a string literal, or a `&'static str` constant.
     pub(crate) publish: Option<Expr>,
@@ -31,6 +31,43 @@ pub(crate) struct SubscriberArgs {
     pub(crate) start_at: Option<Expr>,
     /// The `raw` flag keyword, kept as the parsed [`Ident`] so combination errors can point at it.
     pub(crate) raw: Option<Ident>,
+}
+
+/// The subscription the attribute fixes. The kind is always fixed here (the definition and the
+/// broker extension traits bind on it); what may be deferred is the value that fills it.
+pub(crate) enum SourceArg {
+    /// `#[subscriber]`: the by-name source, its value left to the mount site.
+    OpenName,
+    /// `#[subscriber(RedisStream)]`: a named kind, its value left to the mount site.
+    OpenKind(Type),
+    /// `#[subscriber("orders")]` / `#[subscriber(RedisStream::new("orders").group("w"))]`: the
+    /// value is fixed here too.
+    Fixed(Expr),
+}
+
+/// The clause keywords, so a leading one is not mistaken for a source expression: they parse as
+/// expressions too (`workers(4)` is a call, `raw` a path).
+const CLAUSES: &[&str] = &[
+    "raw",
+    "on_failure",
+    "publish",
+    "publish_raw",
+    "start_at",
+    "workers",
+];
+
+/// True when the next tokens open a clause rather than a source. A clause keyword stands alone,
+/// is followed by a comma, or opens a parenthesized argument list; anything else with the same
+/// name (a `raw::Frames` path) is a source.
+fn peeks_clause(input: ParseStream) -> bool {
+    let fork = input.fork();
+    let Ok(keyword) = fork.parse::<Ident>() else {
+        return false;
+    };
+    if !CLAUSES.contains(&keyword.to_string().as_str()) {
+        return false;
+    }
+    fork.is_empty() || fork.peek(Token![,]) || fork.peek(token::Paren)
 }
 
 pub(crate) struct WorkersArg {
@@ -155,36 +192,22 @@ impl Parse for FailureArg {
 
 impl Parse for SubscriberArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut source: Expr = input.parse()?;
-        // `batch(<source>)` is a marker around the usual source argument, not a constructor:
-        // unwrap it and remember the form. A real constructor is never a bare one-segment call
-        // (free functions are rejected by `source_tokens`), so this cannot misfire.
-        let mut batch = false;
-        if let Expr::Call(call) = &source {
-            if let Expr::Path(ExprPath {
-                path, qself: None, ..
-            }) = &*call.func
-            {
-                if path.is_ident("batch") {
-                    if call.args.len() != 1 {
-                        return Err(Error::new_spanned(
-                            call,
-                            "batch(..) takes exactly one source argument",
-                        ));
-                    }
-                    batch = true;
-                    source = call.args[0].clone();
-                }
-            }
-        }
+        let (source, batch, named_here) = parse_source(input)?;
         let mut publish = None;
         let mut publish_raw = None;
         let mut workers = None;
         let mut on_failure = None;
         let mut start_at = None;
         let mut raw = None;
-        while input.peek(Token![,]) {
-            input.parse::<Token![,]>()?;
+        let mut need_comma = named_here;
+        while !input.is_empty() {
+            if need_comma {
+                input.parse::<Token![,]>()?;
+                if input.is_empty() {
+                    break;
+                }
+            }
+            need_comma = true;
             let keyword: Ident = input.parse()?;
             if keyword == "raw" {
                 if raw.is_some() {
@@ -255,6 +278,57 @@ impl Parse for SubscriberArgs {
     }
 }
 
+/// Parses the leading source argument, if the attribute opens on one. Reports the subscription,
+/// whether the retiring `batch(..)` wrapper was there, and whether anything was consumed (which
+/// decides if the first clause needs a separating comma).
+///
+/// An empty attribute, or one opening on a clause, leaves the subscription unnamed: it is the
+/// by-name source with its value left out, the shortest of the source forms.
+fn parse_source(input: ParseStream) -> syn::Result<(SourceArg, bool, bool)> {
+    if input.is_empty() || peeks_clause(input) {
+        return Ok((SourceArg::OpenName, false, false));
+    }
+    let mut batch = false;
+    let mut expr: Expr = input.parse()?;
+    // `batch(<source>)` is a marker around the usual source argument, not a constructor: unwrap
+    // it and remember the form. A real constructor is never a bare one-segment call (free
+    // functions are rejected by `source_tokens`), so this cannot misfire.
+    if let Expr::Call(call) = &expr
+        && let Expr::Path(ExprPath {
+            path, qself: None, ..
+        }) = &*call.func
+        && path.is_ident("batch")
+    {
+        if call.args.len() != 1 {
+            return Err(Error::new_spanned(
+                call,
+                "batch(..) takes exactly one source argument",
+            ));
+        }
+        batch = true;
+        expr = call.args[0].clone();
+    }
+    Ok((source_arg(expr), batch, true))
+}
+
+/// Classifies a parsed source expression: a bare type path names the kind and leaves the value
+/// to the mount site, anything else (a string literal, a constructor, a builder chain) fixes it
+/// here.
+fn source_arg(expr: Expr) -> SourceArg {
+    match expr {
+        Expr::Path(ExprPath {
+            attrs,
+            qself: None,
+            path,
+        }) if attrs.is_empty() => SourceArg::OpenKind(Type::Path(TypePath {
+            attrs: Vec::new(),
+            qself: None,
+            path,
+        })),
+        other => SourceArg::Fixed(other),
+    }
+}
+
 /// Parses the inside of a `workers(..)` clause: the count, optionally followed by `by_key`.
 fn parse_workers(content: ParseStream) -> syn::Result<WorkersArg> {
     let count: Expr = content.parse()?;
@@ -281,20 +355,32 @@ fn parse_workers(content: ParseStream) -> syn::Result<WorkersArg> {
 /// `SubscribeOptions::new(..).jetstream(..)` is followed down its receivers to that base
 /// constructor, so fluent options that return `Self` can be written inline. Free functions
 /// (`redis::stream(..)`) are still rejected - their result type is not visible in the tokens.
-pub(crate) fn source_tokens(expr: &Expr) -> syn::Result<(TokenStream2, TokenStream2)> {
-    if let Expr::Lit(ExprLit {
-        lit: Lit::Str(name),
-        ..
-    }) = expr
-    {
-        return Ok((
-            quote!(::ruststream::Name),
-            quote!(::ruststream::Name::new(#name)),
-        ));
-    }
-
-    let ty = source_type(expr)?;
-    Ok((quote!(#ty), quote!(#expr)))
+///
+/// The two open forms carry the kind alone: they become `Unnamed<Kind>`, which is no
+/// subscription source until the mount site names it.
+pub(crate) fn source_tokens(source: &SourceArg) -> syn::Result<(TokenStream2, TokenStream2)> {
+    let kind = match source {
+        SourceArg::OpenName => quote!(::ruststream::Name),
+        SourceArg::OpenKind(ty) => quote!(#ty),
+        SourceArg::Fixed(expr) => {
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(name),
+                ..
+            }) = expr
+            {
+                return Ok((
+                    quote!(::ruststream::Name),
+                    quote!(::ruststream::Name::new(#name)),
+                ));
+            }
+            let ty = source_type(expr)?;
+            return Ok((quote!(#ty), quote!(#expr)));
+        }
+    };
+    Ok((
+        quote!(::ruststream::Unnamed<#kind>),
+        quote!(::ruststream::Unnamed::<#kind>::new()),
+    ))
 }
 
 /// Derives the position type from a `start_at(..)` argument, the same way [`source_tokens`]

--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -192,6 +192,55 @@ The macro reads the type out of the constructor call, and also accepts a builder
 kinds (pub/sub versus streams) with different subscriber types - or, as the
 [NATS example](example-nats.md) does, serve them all from one descriptor that branches internally.
 
+Derive `Clone` on the descriptor: it is configuration, and the mount rebuilds it per registration
+so one definition can be mounted on two brokers.
+
+### Naming a kind by one string
+
+A kind identified by a name and nothing else also implements `FromName`, whose single
+constructor builds it from that name:
+
+<!-- inline-rust: one-impl sketch against a broker-crate descriptor that has no in-repo compiled home -->
+```rust
+impl FromName for OrdersStream {
+    fn from_name(name: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(name)
+    }
+}
+```
+
+That is what makes `#[subscriber(OrdersStream)]` legal: the attribute fixes the kind, and the
+mount site supplies the value. A kind that genuinely needs more than a name to exist (a topic
+*and* a subscription name) does not implement it, and that form does not compile for it - which is
+the honest boundary, and spares the descriptor a `Default` that would make an unusable value
+representable.
+
+### Settings in your own vocabulary
+
+Core cannot know that a subscription has a stream, a durable name or a consumer group, so it
+exposes one hook - `map_source`, a transform over the source the mount site is building - and your
+crate layers its own trait on top, bound to your source type:
+
+<!-- inline-rust: the extension-trait shape against a broker-crate descriptor with no in-repo compiled home -->
+```rust
+pub trait NatsSubscriber {
+    fn jetstream(self, stream: impl Into<String>) -> Self;
+    fn durable(self, name: impl Into<String>) -> Self;
+}
+
+impl<Def, W, F, P> NatsSubscriber for SubscriberBuilder<Def, SubscribeOptions, (W, F, P)> {
+    fn jetstream(self, stream: impl Into<String>) -> Self {
+        self.map_source(|source| source.jetstream(stream))
+    }
+    // ..
+}
+```
+
+The trait is local to your crate, so the orphan rule is satisfied, and the bound on the source type
+means the methods simply do not exist on a builder for another broker. Users import the trait to
+reach them, as with any extension trait. This is the same extension shape the `Out` slot vocabulary
+uses below.
+
 ## Capability traits
 
 Implement only the capabilities your broker supports; none are part of the mandatory interface.

--- a/docs/guides/headers.md
+++ b/docs/guides/headers.md
@@ -29,9 +29,9 @@ header, unparsable value) never reaches the body - the delivery settles by the s
 
 --8<-- "examples/typed_headers.rs:handler"
 
-`FromHeaders` composes with `raw` (bytes body, typed headers) and with every other extractor.
+`FromHeaders` composes with a byte body (`&[u8]`, typed headers) and with every other extractor.
 
-On a `batch(..)` form the headers stay per-delivery, so the parameter takes one contract per
+On a batch handler the headers stay per-delivery, so the parameter takes one contract per
 element: `FromHeaders<Vec<T>>`. `meta[i]` belongs to `chunks[i]`, and the two line up by
 construction - an element whose payload or headers fail to materialize is settled by the same
 `on_failure(decode = ..)` policy and never reaches the handler, exactly as on the single-message

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -109,8 +109,8 @@ what this handler sends (`Out<impl Publisher, Marker, (A, B)>`, a single type, o
 destinations and header contracts, feeding the `send` operations of the generated AsyncAPI
 document. See [typed headers](headers.md).
 
-The parameter composes with every subscriber form: next to a `Seek` parameter, on a `raw`
-handler, and on `batch(..)` handlers (`b.include(f).publisher(..)` - the whole page in,
+The parameter composes with every subscriber form: next to a `Seek` parameter, on a byte-input
+handler, and on batch handlers (`b.include(f).publisher(..)` - the whole page in,
 per-element destinations out). On the reply forms - `publish(..)` / `publish_raw(..)` and
 their batch counterpart - `.publisher(..)` stays the reply's own attachment and the injected
 publisher attaches with `.out(marker, ..)` plus the terminal `.mount()` (`DefaultSlot` for a
@@ -199,7 +199,7 @@ policy at the include site with `TypedPublisher::transform`. The full program is
 
 ## Batch replies and transactions
 
-A `#[subscriber(batch(..), publish(..))]` handler consumes a whole decoded batch and returns the
+A `#[subscriber("in", publish("out"))]` handler taking `&[T]` consumes a whole decoded batch and returns the
 replies for it - the consume-transform-produce pattern. `Ok(replies)` publishes every reply to
 the reply name and acks the batch; `Err(result)` publishes nothing and settles the whole batch
 with `result` (all-or-nothing: selective per-element outcomes do not compose with a

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -199,8 +199,8 @@ policy at the include site with `TypedPublisher::transform`. The full program is
 
 ## Batch replies and transactions
 
-A `#[subscriber("in", publish("out"))]` handler taking `&[T]` consumes a whole decoded batch and returns the
-replies for it - the consume-transform-produce pattern. `Ok(replies)` publishes every reply to
+A `#[subscriber("in", publish("out"))]` handler taking `&[T]` consumes a whole decoded batch and
+returns the replies for it - the consume-transform-produce pattern. `Ok(replies)` publishes every reply to
 the reply name and acks the batch; `Err(result)` publishes nothing and settles the whole batch
 with `result` (all-or-nothing: selective per-element outcomes do not compose with a
 transaction):

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -96,8 +96,9 @@ the per-message context hook cannot offer:
 --8<-- "examples/post_settle.rs:batch"
 ```
 
-Batch *publishing* (a batch handler with `publish(..)`) settles all-or-nothing under one transaction, so
-per-element `and_after` does not compose there; it applies to plain batch and single forms only.
+Batch *publishing* (a batch handler with `publish(..)`) settles all-or-nothing under one
+transaction, so per-element `and_after` does not compose there; it applies to plain batch and
+single forms only.
 
 ### Delayed redelivery
 
@@ -240,7 +241,8 @@ b.include(handle.on_failure(..));   // fine: the attribute said nothing about fa
 ```
 
 The methods come from the `SubscriberSettings` trait, which every generated definition implements;
-import it (or the [prelude](../getting-started/index.md)) to reach them.
+import it (or the
+[prelude](https://docs.rs/ruststream/latest/ruststream/prelude/index.html)) to reach them.
 
 Broker-specific settings arrive the same way, in the broker's own vocabulary. Core cannot know that
 a subscription has a JetStream stream or a durable consumer name, so it exposes one hook - a

--- a/docs/guides/subscribers.md
+++ b/docs/guides/subscribers.md
@@ -96,7 +96,7 @@ the per-message context hook cannot offer:
 --8<-- "examples/post_settle.rs:batch"
 ```
 
-Batch *publishing* (`batch(..) + publish(..)`) settles all-or-nothing under one transaction, so
+Batch *publishing* (a batch handler with `publish(..)`) settles all-or-nothing under one transaction, so
 per-element `and_after` does not compose there; it applies to plain batch and single forms only.
 
 ### Delayed redelivery
@@ -134,10 +134,52 @@ per-element delays, so pending entries back off without holding up the rest of t
 
 ## Choosing the subscription source
 
+The attribute always fixes the *kind* of subscription. A subscriber is not one thing - a subject
+and a JetStream consumer are different types, as are a Redis stream, a pub/sub channel and a list
+- and the macro has to name that type to generate the definition. What can be left out is the
+*value* that fills it, which the mount site then supplies. There are four forms, shortest first:
+
+| Form | The kind | The value |
+|---|---|---|
+| `#[subscriber]` | the by-name source | from the mount site |
+| `#[subscriber(RedisStream)]` | named here | from the mount site |
+| `#[subscriber("orders")]` | the by-name source | fixed here |
+| `#[subscriber(RedisStream::new("orders").group("w"))]` | named here | fixed here |
+
 ### By name
 
 `#[subscriber("orders")]` subscribes by name. It works with any broker that implements the
-`Subscribe` capability, which covers the common case.
+`Subscribe` capability, which every broker crate in the family does: a name is mapped to the
+subscription kind that broker considers its default, and the configuration that kind needs beyond
+the name is set once on the broker.
+
+`#[subscriber]` is the same source with its value left out - a name the service only knows while
+it wires itself up, a subject built from a shard number, a topic read from configuration:
+
+```rust
+--8<-- "examples/subscribers.rs:deferred_name"
+```
+
+```rust
+--8<-- "examples/subscribers.rs:name_mount"
+```
+
+A definition that was never named is not mountable: the compiler says so, and names the fix.
+
+### Naming a kind and nothing else
+
+`#[subscriber(RedisStream)]` names the kind and leaves the value out. It works because a
+subscription kind is identified by a name and nothing else: every source in the family is
+constructed from one string, and a small core trait (`FromName`) says so, so the builder calls the
+kind's own constructor when the name arrives. Nothing is ever built from thin air.
+
+```rust
+--8<-- "examples/subscribers.rs:named_kind"
+```
+
+Where a kind genuinely needs more than a name to exist - a Pulsar source takes a topic *and* a
+subscription name - it does not implement the trait, and this form does not compile for it. Those
+kinds are written out in full.
 
 ### Broker-specific descriptors
 
@@ -172,6 +214,42 @@ The macro follows the chain down to the base `Type::new(..)` to name the source 
 in the chain must return `Self`. Free functions are rejected, since their type is not visible to the
 macro.
 
+A source built this way is rebuilt for each mount, so a broker's descriptor type is `Clone` (it is
+configuration, and cloning it is what lets one definition mount on two brokers).
+
+## Settings at the mount site
+
+Name, worker policy, failure policies and the start position are values, so each can be given in
+the attribute, at the mount site, or partly in each. The attribute expands into exactly the calls
+you would write yourself, so there is one implementation of every setting:
+
+```rust
+--8<-- "examples/subscribers.rs:builder_settings"
+```
+
+A setting the attribute named is fixed in the definition's type and its builder method no longer
+applies, so the two can never disagree and there is no precedence rule to remember:
+
+<!-- inline-rust: two compile-fail one-liners; a compiling example cannot host code that must not compile (the pinned diagnostics live in tests/ui) -->
+```rust
+#[subscriber("orders", workers(4))]
+async fn handle(order: &Order) -> HandlerResult { HandlerResult::Ack }
+
+b.include(handle.name("other"));    // does not compile: the name is already given
+b.include(handle.on_failure(..));   // fine: the attribute said nothing about failures
+```
+
+The methods come from the `SubscriberSettings` trait, which every generated definition implements;
+import it (or the [prelude](../getting-started/index.md)) to reach them.
+
+Broker-specific settings arrive the same way, in the broker's own vocabulary. Core cannot know that
+a subscription has a JetStream stream or a durable consumer name, so it exposes one hook - a
+transform over the source it is building - and a broker crate layers its own trait on top, bound to
+its own source type; see
+[Broker authors](../broker-authors/index.md#subscription-sources). The order in a chain follows from
+what each step does: the name comes first because it constructs the source, the broker settings then
+transform it, and the buffer below wraps it last.
+
 ## Mounting handlers
 
 Inside `with_broker`, mount a definition with `include`:
@@ -192,9 +270,9 @@ To group handlers per module and mount them all at once, collect them into a `Ro
 
 ## Batch subscribers
 
-Wrapping the source in `batch(..)` switches the handler to whole-batch consumption: it takes the
-decoded batch as a slice and runs once per batch the broker delivers - one database round-trip,
-one bulk API call.
+A handler that takes a slice consumes whole batches: it runs once per batch the broker delivers -
+one database round-trip, one bulk API call. The shape is read off the signature, so nothing in the
+attribute says it.
 
 ```rust
 --8<-- "examples/subscribers.rs:batch"
@@ -206,15 +284,23 @@ Mount it with `include`, like any other form - the definition carries the batch 
 --8<-- "examples/subscribers.rs:batch_mount"
 ```
 
-The source's subscriber must implement the `BatchSubscriber` capability. Brokers whose clients
-batch natively (Kafka poll, JetStream pull consumers) expose it directly, and batch sizing lives
-in their subscription options; the in-memory broker batches natively too. For any other source,
-the `Buffered` adapter buffers single deliveries client-side, closing a batch by size or by a
-deadline after its first delivery:
+The signature says the handler wants several messages at once; whether they arrive that way is a
+property of the broker, so it is settled where the definition is mounted. The subscription's
+subscriber must implement the `BatchSubscriber` capability: brokers whose clients batch natively
+(Kafka poll, JetStream pull consumers) expose it directly, and batch sizing lives in their
+subscription options; the in-memory broker batches natively too. Where the subscription does not
+batch, the compiler asks for the framework's buffer and the mount supplies it, closing a batch by
+size or by a deadline after its first delivery:
 
 ```rust
 --8<-- "examples/subscribers.rs:batch_buffered"
 ```
+
+The setting is named after the adapter on purpose. Batches come either from the broker (configured
+by the broker's own settings) or from this wrap, and those are different things; a name like
+`max_size` would read as configuring the broker's batching and would quietly wrap a natively
+batching subscription in a second layer. Because it changes the subscription type, it goes last:
+broker settings bound to the unwrapped type stop applying past it.
 
 The semantics differ from single-message handlers in a few ways:
 
@@ -267,7 +353,7 @@ nothing is attached at the include site:
 A seek from inside the handler settles the current message as usual; deliveries queued before
 the target are dropped, and the stream resumes at the target position. The parameter composes
 with the rest of the subscriber surface: with an injected publisher (`Out`) in the same
-handler, with a `raw` input, with `batch(..)` handlers, and with the `publish(..)` /
+handler, with a byte input, with batch handlers, and with the `publish(..)` /
 `publish_raw(..)` reply forms - a `Seek` parameter itself never needs an attachment at the
 include site, so those mounts read exactly as without it.
 
@@ -303,17 +389,26 @@ crate documents both. Broker authors prove the contract with the
 ## Raw subscribers
 
 When the payload is not a serialized value at all (a binary frame, a foreign wire format you
-parse yourself), the `raw` clause takes the codec out of the path entirely: the handler receives
-each delivery's bytes exactly as the broker handed them over.
+parse yourself), a `&[u8]` message parameter takes the codec out of the path entirely: the handler
+receives each delivery's bytes exactly as the broker handed them over.
 
 ```rust
 --8<-- "tests/raw_subscriber.rs:raw"
 ```
 
-The message parameter must be `&[u8]` - a serde-typed parameter under `raw` is a compile error,
-as is `raw` combined with `batch(..)` or an `on_failure(decode = ..)` policy (there is no
-decode step to fail). Extractors, `&mut Context`, `workers(..)`, `on_failure(panic = ..)`, and
-the injected `Out` / `Seek` parameters work unchanged, and a raw subscriber mounts with the
+A batch of payloads is the same thing at the batch shape: `&[&[u8]]` is the typed batch without
+the decode step, with the payloads borrowed from the batch's own messages for the duration of the
+call. Nothing is copied, and the settlement rules are the batch path's.
+
+```rust
+--8<-- "examples/subscribers.rs:raw_batch"
+```
+
+An `on_failure(decode = ..)` policy on either shape is a compile error - there is no decode step
+to fail, unless the handler declares a `FromHeaders` contract, which that policy does cover.
+Extractors, `&mut Context`, `workers(..)`, `on_failure(panic = ..)`, and
+the injected `Out` / `Seek` parameters work unchanged on the single-delivery shape (the batch of
+payloads does not take `Out` / `Seek` yet), and a raw subscriber mounts with the
 same `include` as every other definition - a scope codec, when one is set, simply does not apply
 to it. Because no codec is involved, raw subscribers are also the one subscriber form available
 with no codec feature enabled at all. For a custom serialization format you want *typed*
@@ -378,13 +473,13 @@ integration test.
 
 | Combination | Rule |
 |---|---|
-| `workers(n)` × `batch(..)` | The pool holds up to `n` **batches** in flight. `by_key` does not apply to batch forms: lanes order single messages per key, and the macro rejects the combination at compile time. |
+| `workers(n)` × a batch handler | The pool holds up to `n` **batches** in flight. `by_key` does not apply to batch forms: lanes order single messages per key, and the macro rejects the combination at compile time. |
 | `retry()` / `retry_after` × `workers(n)` | Retried deliveries re-enter the pool and complete like any other delivery. |
 | `retry()` / `retry_after` × `workers(n, by_key)` | Retries complete, but per-key ordering across a retry is **not** promised: a requeued message rejoins the stream from the back. If a key's messages must stay ordered even through failures, the handler has to absorb the failure instead of nacking. |
 | `.transactional()` × `workers(n)` | One transaction per batch, exactly as in the sequential loop. Concurrent batches run concurrent, independent transactions; each stays atomic (commit-then-ack per batch). |
 | `Buffered` × `workers(n)` | Batches still close by `max_size` / `max_wait` only; the pool bounds how many closed batches are processed at once and never affects batch boundaries. |
 | `publish(..)` × `workers(n)` | Replies are produced concurrently, so reply order across deliveries is not promised. A failed reply publish retries only its own delivery. |
-| middleware × `batch(..)` | App-global and router layers wrap per-message handlers and do not apply to batch registrations (a per-message layer cannot wrap a whole-batch handler). |
+| middleware × a batch handler | App-global and router layers wrap per-message handlers and do not apply to batch registrations (a per-message layer cannot wrap a whole-batch handler). |
 
 ## Macro or manual
 

--- a/examples/subscribers.rs
+++ b/examples/subscribers.rs
@@ -1,5 +1,5 @@
-//! The handler forms from the Subscribers guide: the basic contract, the context parameter, and
-//! the manual (macro-free) registration.
+//! The handler forms from the Subscribers guide: the basic contract, the context parameter, the
+//! settings a mount site fills in, and the manual (macro-free) registration.
 //!
 //! ```text
 //! cargo run --example subscribers --features macros,memory,json -- run
@@ -8,10 +8,13 @@
 use std::time::Duration;
 
 use ruststream::codec::JsonCodec;
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, Context, HandlerMetadata, HandlerResult, RustStream, typed};
+use ruststream::memory::{MemoryBroker, MemorySource};
+use ruststream::runtime::{
+    AppInfo, Context, FailurePolicies, FailurePolicy, HandlerMetadata, HandlerResult, RustStream,
+    SubscriberSettings, typed,
+};
 use ruststream::subscriber;
-use ruststream::{Buffered, Name, nonzero};
+use ruststream::{Name, nonzero};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -37,14 +40,41 @@ async fn with_context(order: &Order, ctx: &mut Context<'_>) -> HandlerResult {
 }
 // --8<-- [end:context]
 
+// --8<-- [start:deferred_name]
+/// The by-name source with its value left out: the mount site names the subscription.
+#[subscriber]
+async fn audit(order: &Order) -> HandlerResult {
+    println!("auditing order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:deferred_name]
+
+// --8<-- [start:named_kind]
+/// A named kind carrying only what it needs to exist; the value arrives at the mount site.
+#[subscriber(MemorySource)]
+async fn archive(order: &Order) -> HandlerResult {
+    println!("archiving order {}", order.id);
+    HandlerResult::Ack
+}
+// --8<-- [end:named_kind]
+
 // --8<-- [start:batch]
-/// Settles a whole page of orders in one go.
-#[subscriber(batch("orders"))]
+/// Settles a whole page of orders in one go: the slice parameter is what says so.
+#[subscriber("orders")]
 async fn settle(orders: &[Order]) -> HandlerResult {
     println!("settling {} orders", orders.len());
     HandlerResult::Ack
 }
 // --8<-- [end:batch]
+
+// --8<-- [start:raw_batch]
+/// A batch of payloads: the batch shape without the decode step.
+#[subscriber("frames")]
+async fn ingest(frames: &[&[u8]]) -> HandlerResult {
+    println!("ingesting {} frames", frames.len());
+    HandlerResult::Ack
+}
+// --8<-- [end:raw_batch]
 
 // --8<-- [start:workers]
 /// Up to 16 orders processed concurrently; global order is lost by design.
@@ -66,7 +96,7 @@ async fn per_customer(order: &Order) -> HandlerResult {
 
 // --8<-- [start:batch_selective]
 /// Retries only the entries that are not ready yet; the rest of the page settles.
-#[subscriber(batch("orders"))]
+#[subscriber("orders")]
 async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
     orders
         .iter()
@@ -81,29 +111,51 @@ async fn reconcile(orders: &[Order]) -> Vec<HandlerResult> {
 }
 // --8<-- [end:batch_selective]
 
-// --8<-- [start:batch_buffered]
-// Client-side batching for sources without native batches: close a batch at 128 deliveries or
-// 20 ms after its first one. The macro recovers the source type from the constructor path, so
-// the generic parameter is spelled out.
-#[subscriber(batch(Buffered::<Name>::new(Name::new("orders"))
-    .max_size(nonzero!(128))
-    .max_wait(Duration::from_millis(20))))]
+/// Whether batches arrive at all is a property of the broker, so it is settled at the mount.
+#[subscriber]
 async fn drain(orders: &[Order]) -> HandlerResult {
     println!("draining {} orders", orders.len());
     HandlerResult::Ack
 }
-// --8<-- [end:batch_buffered]
+
+/// A handler whose declarative settings are all left to the mount site.
+#[subscriber]
+async fn bill(order: &Order) -> HandlerResult {
+    println!("billing order {}", order.id);
+    HandlerResult::Ack
+}
 
 #[ruststream::app]
 fn app() -> RustStream {
+    let shard = 7;
     RustStream::new(AppInfo::new("subscribers", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
         b.include(handle);
         b.include(with_context);
+        // --8<-- [start:name_mount]
+        b.include(audit.name(format!("audit-{shard}")));
+        // --8<-- [end:name_mount]
+        b.include(archive.name("archive"));
         // --8<-- [start:batch_mount]
         b.include(settle);
         // --8<-- [end:batch_mount]
+        b.include(ingest);
         b.include(reconcile);
-        b.include(drain);
+        // --8<-- [start:batch_buffered]
+        // Client-side batching for subscriptions without native batches: close a batch at 128
+        // deliveries, or 20 ms after its first one.
+        b.include(
+            drain
+                .name("orders")
+                .buffered(nonzero!(128), Duration::from_millis(20)),
+        );
+        // --8<-- [end:batch_buffered]
+        // --8<-- [start:builder_settings]
+        b.include(
+            bill.name("orders")
+                .workers(nonzero!(4))
+                .on_failure(FailurePolicies::default().with_decode(FailurePolicy::Skip)),
+        );
+        // --8<-- [end:builder_settings]
         b.include(fan_out);
         b.include(per_customer);
         // --8<-- [start:manual]

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -15,6 +15,13 @@ use crate::{Broker, ConnectedBroker, IncomingMessage, OutgoingMessage, Publisher
 /// Brokers that batch on the wire (`Kafka`, `JetStream` pull consumers) implement this so the
 /// runtime can dispatch a whole batch through middleware in one go. Brokers without native
 /// batching simply do not implement it.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not deliver messages in batches",
+    label = "this subscription has no batching of its own",
+    note = "a handler taking `&[T]` needs batches: add the framework's buffer at the mount site, \
+            `b.include(handle.buffered(nonzero!(64), Duration::from_millis(10)))`, or mount the \
+            definition on a subscription kind that batches on the wire"
+)]
 pub trait BatchSubscriber: Subscriber {
     /// Container yielded by [`batches`]. Implementations choose between [`Vec`], custom
     /// iterators, or anything else that yields the underlying [`Subscriber::Message`].

--- a/src/conformance/harness.rs
+++ b/src/conformance/harness.rs
@@ -79,7 +79,8 @@ where
 ///   cannot satisfy it, which is exactly the contract: construct cheaply, connect in
 ///   [`Broker::connect`].
 /// * `make_source` builds the broker's subscription descriptor for a subject (the macro-subscriber
-///   path).
+///   path). The descriptor is `Clone`: it is configuration, and the mount rebuilds it per
+///   registration, so a definition can be mounted on more than one broker.
 /// * `make_publisher` produces a publisher from the connected form.
 ///
 /// Run it from the broker crate, against a real server where one is needed (NATS, Kafka, ...) or
@@ -112,7 +113,7 @@ pub async fn lifecycle<B, MkBroker, Src, MkSrc, Pub, MkPub>(
 ) where
     B: Broker,
     MkBroker: Fn() -> B,
-    Src: SubscriptionSource<Connected<B>> + Send,
+    Src: SubscriptionSource<Connected<B>> + Clone + Send,
     Src::Subscriber: Send,
     MkSrc: Fn(&str) -> Src,
     Pub: Publisher,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use message::{IncomingMessage, OutgoingMessage, RawMessage};
 pub use publisher::{DefaultPublish, PairError, PublishPolicy, Publisher};
 pub use schema::{HeadersContract, Message, MessageHeaders, NoHeaders, WithHeaders};
 pub use subscriber::Subscriber;
-pub use subscription::{Name, StartAt, SubscriptionSource};
+pub use subscription::{FromName, Name, StartAt, SubscriptionSource, Unnamed};
 pub use typed_headers::{DeserializeHeadersError, SerializeHeadersError};
 
 pub mod codec;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -36,9 +36,9 @@ use std::{
 #[cfg(feature = "testing")]
 use crate::testing::coordinator::Coordinator;
 use crate::{
-    AckError, Broker, ConnectedBroker, DefaultPublish, DescribeServer, Headers, IncomingMessage,
-    OutgoingMessage, PairError, PublishPolicy, Publisher, RawMessage, ServerSpec, Subscribe,
-    Subscriber, SubscriptionSource,
+    AckError, Broker, ConnectedBroker, DefaultPublish, DescribeServer, FromName, Headers,
+    IncomingMessage, OutgoingMessage, PairError, PublishPolicy, Publisher, RawMessage, ServerSpec,
+    Subscribe, Subscriber, SubscriptionSource,
 };
 use bytes::Bytes;
 use futures::Stream;
@@ -531,6 +531,14 @@ impl MemorySource {
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self { name: name.into() }
+    }
+}
+
+// The in-memory subscription needs nothing beyond a name, so it offers the name-only
+// constructor the `#[subscriber(MemorySource)]` form builds through.
+impl FromName for MemorySource {
+    fn from_name(name: impl Into<std::borrow::Cow<'static, str>>) -> Self {
+        Self::new(name.into().into_owned())
     }
 }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -25,6 +25,7 @@ pub use capability::{
 };
 
 use std::{
+    borrow::Cow,
     collections::HashMap,
     convert::Infallible,
     fmt,
@@ -537,7 +538,7 @@ impl MemorySource {
 // The in-memory subscription needs nothing beyond a name, so it offers the name-only
 // constructor the `#[subscriber(MemorySource)]` form builds through.
 impl FromName for MemorySource {
-    fn from_name(name: impl Into<std::borrow::Cow<'static, str>>) -> Self {
+    fn from_name(name: impl Into<Cow<'static, str>>) -> Self {
         Self::new(name.into().into_owned())
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,6 +2,7 @@
 //!
 //! `use ruststream::prelude::*;` brings in the application object and its builder, the handler
 //! surface (the settlement enum, the per-delivery context, the extractor parameters), the
+//! subscriber settings a mount site fills in, the
 //! publishing types a handler reaches for, and - with the `macros` feature - the attribute
 //! macros and derives. It deliberately stops there: brokers, codecs and the optional feature
 //! modules (`asyncapi`, `metrics`, `logging`, `otel`, `testing`) stay explicit imports, because
@@ -21,7 +22,7 @@
 
 pub use crate::runtime::{
     App, AppInfo, Context, Ctx, FromHeaders, FromRef, HandlerResult, Out, Router, RunningApp,
-    RustStream, Seek, State, TypedPublisher,
+    RustStream, Seek, State, SubscriberSettings, TypedPublisher,
 };
 pub use crate::{
     Broker, Headers, IncomingMessage, Message, Name, OutSlot, OutgoingMessage, PublishPolicy,

--- a/src/runtime/app/include/forms_eager.rs
+++ b/src/runtime/app/include/forms_eager.rs
@@ -13,7 +13,7 @@ use crate::runtime::input::{DecodeWith, InputKind, RawBytes};
 use crate::runtime::middleware::Layer;
 use crate::runtime::subscriber_def::SubscriberDef;
 use crate::runtime::typed::Typed;
-use crate::runtime::{SliceHandler, SliceHandlerWithHeaders};
+use crate::runtime::{RawSliceHandler, SliceHandler, SliceHandlerWithHeaders};
 
 use super::{IncludeMount, MountCodec, forms};
 use crate::runtime::app::scope::BrokerScope;
@@ -163,6 +163,28 @@ where
         let source = def.source();
         let codec = scope.codec.mount_codec();
         scope.mount_batch(source, def, codec);
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Raw batch: eager, and no codec anywhere - the handler borrows the batch's payloads as they
+// arrived, so the scope codec parameter `C` is left unconstrained.
+
+impl<'s, B, Layers, C, State, Pipeline, Def> IncludeMount<'s, B, Layers, C, State, Pipeline, Def>
+    for forms::RawBatch
+where
+    B: Broker + 'static,
+    Def: BatchDef<Input = RawBytes>,
+    Def::Source: SubscriptionSource<Connected<B>> + Send + 'static,
+    <Def::Source as SubscriptionSource<Connected<B>>>::Subscriber: BatchSubscriber + Send + 'static,
+    Def::Handler: RawSliceHandler<State> + 'static,
+    State: Send + Sync + 'static,
+{
+    type Out = ();
+
+    fn begin(def: Def, scope: &'s mut BrokerScope<B, Layers, C, State, Pipeline>) {
+        let source = def.source();
+        scope.mount_raw_batch(source, def);
     }
 }
 

--- a/src/runtime/app/include/mod.rs
+++ b/src/runtime/app/include/mod.rs
@@ -42,15 +42,18 @@ impl<B: Broker + 'static, Layers, C, State, Pipeline> BrokerScope<B, Layers, C, 
     /// Decoding uses the scope codec when one was set
     /// ([`with_broker_codec`](crate::runtime::RustStream::with_broker_codec)), else the
     /// [`DefaultCodec`](crate::codec::DefaultCodec).
-    pub fn include<'s, Def>(
+    pub fn include<'s, D>(
         &'s mut self,
-        def: Def,
-    ) -> <Def::Form as IncludeMount<'s, B, Layers, C, State, Pipeline, Def>>::Out
+        def: D,
+    ) -> <D::Form as IncludeMount<'s, B, Layers, C, State, Pipeline, D::Settings>>::Out
     where
-        Def: crate::runtime::IncludeDef,
-        Def::Form: IncludeMount<'s, B, Layers, C, State, Pipeline, Def>,
+        D: crate::runtime::Declared,
+        D::Form: IncludeMount<'s, B, Layers, C, State, Pipeline, D::Settings>,
     {
-        <Def::Form as IncludeMount<'s, B, Layers, C, State, Pipeline, Def>>::begin(def, self)
+        <D::Form as IncludeMount<'s, B, Layers, C, State, Pipeline, D::Settings>>::begin(
+            def.declare(),
+            self,
+        )
     }
 }
 

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -8,7 +8,8 @@ use crate::{BatchSubscriber, Broker, Connected, Publisher, Subscriber, Subscript
 
 use crate::PublishPolicy;
 use crate::runtime::batch::{
-    BatchDef, BatchWithHeadersDef, RawBatch, TypedBatch, TypedBatchWithHeaders, batch_metadata,
+    BatchDef, BatchWithHeadersDef, RawBatch, RawSliceHandler, TypedBatch, TypedBatchWithHeaders,
+    batch_metadata,
 };
 use crate::runtime::batch_inject::{BatchInjectCall, BatchInjectHandler, batch_inject_metadata};
 use crate::runtime::batch_publishing::{
@@ -17,7 +18,7 @@ use crate::runtime::batch_publishing::{
 use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
 use crate::runtime::inject::{FromStartup, InjectCall, InjectHandler, inject_metadata};
-use crate::runtime::input::{DecodeWith, InputKind};
+use crate::runtime::input::{DecodeWith, InputKind, RawBytes};
 use crate::runtime::lifecycle::{BoxError, ConnectedSlot};
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{BlanketLayer, Identity, Layer};
@@ -275,8 +276,8 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
     where
         Source: SubscriptionSource<Connected<B>> + Send + 'static,
         Source::Subscriber: BatchSubscriber + Send + 'static,
-        Def: BatchDef<Input = crate::runtime::RawBytes>,
-        Def::Handler: crate::runtime::RawSliceHandler<State> + 'static,
+        Def: BatchDef<Input = RawBytes>,
+        Def::Handler: RawSliceHandler<State> + 'static,
         State: Send + Sync + 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -8,7 +8,7 @@ use crate::{BatchSubscriber, Broker, Connected, Publisher, Subscriber, Subscript
 
 use crate::PublishPolicy;
 use crate::runtime::batch::{
-    BatchDef, BatchWithHeadersDef, TypedBatch, TypedBatchWithHeaders, batch_metadata,
+    BatchDef, BatchWithHeadersDef, RawBatch, TypedBatch, TypedBatchWithHeaders, batch_metadata,
 };
 use crate::runtime::batch_inject::{BatchInjectCall, BatchInjectHandler, batch_inject_metadata};
 use crate::runtime::batch_publishing::{
@@ -265,6 +265,24 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
         // the adapter names the def's input kind explicitly.
         let handler = TypedBatch::<_, Def::Input, _, _>::over(codec, def.into_handler())
             .with_decode(policies.decode);
+        self.sink
+            .push_subscribe_batch(source, handler, meta, policies, workers);
+    }
+
+    /// Mounts a raw batch definition on `source`: no codec anywhere, the handler borrows the
+    /// batch's payloads as they arrived.
+    pub(super) fn mount_raw_batch<Source, Def>(&mut self, source: Source, def: Def)
+    where
+        Source: SubscriptionSource<Connected<B>> + Send + 'static,
+        Source::Subscriber: BatchSubscriber + Send + 'static,
+        Def: BatchDef<Input = crate::runtime::RawBytes>,
+        Def::Handler: crate::runtime::RawSliceHandler<State> + 'static,
+        State: Send + Sync + 'static,
+    {
+        let meta = batch_metadata(source.name().to_owned(), &def);
+        let policies = def.failure_policies();
+        let workers = def.workers();
+        let handler = RawBatch::over(def.into_handler());
         self.sink
             .push_subscribe_batch(source, handler, meta, policies, workers);
     }

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -10,7 +10,7 @@
 
 #[cfg(feature = "otel")]
 use std::sync::LazyLock;
-use std::{future::Future, marker::PhantomData};
+use std::{fmt, future::Future, marker::PhantomData};
 
 #[cfg(feature = "otel")]
 use opentelemetry::metrics::Histogram;
@@ -370,8 +370,8 @@ impl<M, Input, DecodeCodec, Inner> TypedBatch<M, Input, DecodeCodec, Inner> {
     }
 }
 
-impl<M, Input, DecodeCodec, Inner> std::fmt::Debug for TypedBatch<M, Input, DecodeCodec, Inner> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<M, Input, DecodeCodec, Inner> fmt::Debug for TypedBatch<M, Input, DecodeCodec, Inner> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TypedBatch")
             .field("decode", &self.decode)
             .finish_non_exhaustive()
@@ -437,10 +437,10 @@ impl<M, Input, DecodeCodec, HeaderContract, Inner>
     }
 }
 
-impl<M, Input, DecodeCodec, HeaderContract, Inner> std::fmt::Debug
+impl<M, Input, DecodeCodec, HeaderContract, Inner> fmt::Debug
     for TypedBatchWithHeaders<M, Input, DecodeCodec, HeaderContract, Inner>
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TypedBatchWithHeaders")
             .field("decode", &self.decode)
             .finish_non_exhaustive()
@@ -496,8 +496,8 @@ impl<M, Inner> RawBatch<M, Inner> {
     }
 }
 
-impl<M, Inner> std::fmt::Debug for RawBatch<M, Inner> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<M, Inner> fmt::Debug for RawBatch<M, Inner> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawBatch").finish_non_exhaustive()
     }
 }
@@ -660,7 +660,7 @@ where
 /// input. Not `async`: the outcome is decided before the delivery is settled, so the borrowed
 /// error never crosses an await.
 fn rejection<S>(
-    err: &impl std::fmt::Display,
+    err: &impl fmt::Display,
     reason: &str,
     decode: FailurePolicy,
     ctx: &Context<'_, (), S>,

--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -193,6 +193,22 @@ where
     }
 }
 
+/// A handler invoked with one whole batch of undecoded payloads.
+///
+/// The byte-level counterpart of [`SliceHandler`], selected by a `&[&[u8]]` message parameter:
+/// a raw batch is the typed batch without the decode step, so the handler sees the payloads as
+/// a slice of byte slices borrowed from the batch's own messages, which the dispatcher holds for
+/// the duration of the call. Nothing is copied, and the settlement rules are the batch path's.
+pub trait RawSliceHandler<S = ()>: Send + Sync {
+    /// Handles one batch of payloads, with the per-batch [`Context`] carrying the typed app
+    /// state `S`.
+    fn handle_slice(
+        &self,
+        batch: &[&[u8]],
+        ctx: &mut Context<'_, (), S>,
+    ) -> impl Future<Output = BatchResult> + Send;
+}
+
 /// A batch handler definition produced by `#[subscriber(batch(..))]`.
 ///
 /// The batch counterpart of [`SubscriberDef`](super::SubscriberDef): same metadata surface, but
@@ -457,6 +473,55 @@ where
         let tasks = ctx.tasks().clone();
         let result = self.inner.handle_slice(&values, contracts, ctx).await;
         settle_batch(accepted, result, &subscription, &tasks).await;
+    }
+}
+
+/// The batch adapter of the byte input kind: no codec, no decode, no rejections.
+///
+/// Every delivery reaches the handler, as a borrowed payload view; the [`BatchResult`] settles
+/// the deliveries behind those views exactly as on the typed path.
+pub struct RawBatch<M, Inner> {
+    inner: Inner,
+    _phantom: PhantomData<fn(M)>,
+}
+
+impl<M, Inner> RawBatch<M, Inner> {
+    /// Builds the adapter over the batch handler, like [`TypedBatch::over`].
+    #[must_use]
+    pub(crate) fn over(inner: Inner) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<M, Inner> std::fmt::Debug for RawBatch<M, Inner> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawBatch").finish_non_exhaustive()
+    }
+}
+
+impl<M, Inner, S> BatchHandler<M, S> for RawBatch<M, Inner>
+where
+    M: IncomingMessage,
+    Inner: RawSliceHandler<S>,
+    S: Send + Sync,
+{
+    async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_, (), S>) {
+        let subscription = ctx.name().to_owned();
+        if batch.is_empty() {
+            return;
+        }
+        #[cfg(feature = "otel")]
+        record_batch_size(&subscription, batch.len());
+        let tasks = ctx.tasks().clone();
+        // The views borrow the deliveries, so they are gone before the batch is settled.
+        let result = {
+            let payloads: Vec<&[u8]> = batch.iter().map(IncomingMessage::payload).collect();
+            self.inner.handle_slice(&payloads, ctx).await
+        };
+        settle_batch(batch, result, &subscription, &tasks).await;
     }
 }
 

--- a/src/runtime/batch/tests.rs
+++ b/src/runtime/batch/tests.rs
@@ -545,3 +545,55 @@ async fn decode_and_ack_failures_are_logged_with_their_subscription() {
         Some(AckError::Timeout.to_string().as_str())
     );
 }
+
+/// A batch handler over undecoded payloads, for the raw batch adapter below.
+struct Frames(Arc<Mutex<Vec<Vec<u8>>>>);
+
+impl RawSliceHandler for Frames {
+    async fn handle_slice(&self, batch: &[&[u8]], _ctx: &mut Context<'_>) -> BatchResult {
+        self.0
+            .lock()
+            .unwrap()
+            .extend(batch.iter().map(|frame| frame.to_vec()));
+        BatchResult::Uniform(HandlerResult::Ack)
+    }
+}
+
+#[tokio::test]
+async fn a_raw_batch_lends_the_payloads_and_settles_the_deliveries() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("raw-batch");
+    publish_payloads(&broker, "raw-batch", &[b"one", b"two"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = RawBatch::over(Frames(Arc::clone(&seen)));
+    assert!(format!("{handler:?}").contains("RawBatch"));
+
+    let state = ();
+    let delivery = Delivery::empty();
+    let headers = Headers::new();
+    let mut ctx = Context::new("raw-batch", &headers, &state, (), &delivery);
+    let batch = pull_batch(&mut sub).await;
+    handler.handle_batch(batch, &mut ctx).await;
+
+    assert_eq!(
+        seen.lock().unwrap().as_slice(),
+        [b"one".to_vec(), b"two".to_vec()],
+    );
+}
+
+#[tokio::test]
+async fn an_empty_raw_batch_reaches_no_handler() {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = RawBatch::over(Frames(Arc::clone(&seen)));
+
+    let state = ();
+    let delivery = Delivery::empty();
+    let headers = Headers::new();
+    let mut ctx = Context::new("raw-batch", &headers, &state, (), &delivery);
+    handler
+        .handle_batch(Vec::<MemoryMessage>::new(), &mut ctx)
+        .await;
+
+    assert!(seen.lock().unwrap().is_empty());
+}

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use crate::{Field, FieldMut, Headers};
 
 use super::dispatch::Delivery;
-use super::failure::ErrorShutdown;
+use super::failure::{ErrorShutdown, FailurePolicy};
 use super::handler::HandlerResult;
 
 /// A post-settle continuation: a boxed `Send` future the dispatcher runs after the message (or
@@ -73,6 +73,10 @@ pub struct Context<'a, C = (), S = ()> {
     delivery: &'a Delivery,
     after: Vec<AfterHook>,
     failfast: Option<&'a ErrorShutdown>,
+    /// The subscriber's materialization policy, set by the dispatcher from the definition's
+    /// failure policies. It reaches the handler body because a `FromHeaders` contract is parsed
+    /// there rather than in the decode adapter.
+    decode: FailurePolicy,
     /// Set by the [`Typed`](super::typed::Typed) decode adapter when the payload fails to decode,
     /// so the dispatcher can record the outcome as a decode failure (otherwise indistinguishable
     /// from a handler drop). Present under the `testing` feature (harness classification) and the
@@ -110,6 +114,7 @@ impl<'a, C, S> Context<'a, C, S> {
             delivery,
             after: Vec::new(),
             failfast: None,
+            decode: FailurePolicy::Drop,
             #[cfg(any(feature = "testing", feature = "otel"))]
             decode_failed: false,
         }
@@ -143,6 +148,36 @@ impl<'a, C, S> Context<'a, C, S> {
     pub(crate) fn with_failfast(mut self, failfast: &'a ErrorShutdown) -> Self {
         self.failfast = Some(failfast);
         self
+    }
+
+    /// Attaches the subscriber's effective materialization policy, so a handler-side contract
+    /// (a [`FromHeaders`](super::FromHeaders) parameter) settles by the same policy as the
+    /// payload codec no matter where the policy was named - in the attribute, or on the builder
+    /// at the mount site.
+    pub(crate) fn with_decode_policy(mut self, decode: FailurePolicy) -> Self {
+        self.decode = decode;
+        self
+    }
+
+    /// The materialization policy in force for this delivery: what happens to a payload that
+    /// does not decode, or a header contract that does not parse.
+    ///
+    /// The `#[subscriber]` expansion reads it to settle a failed
+    /// [`FromHeaders`](super::FromHeaders) extraction; a hand-written handler can read it for the
+    /// same reason.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruststream::runtime::{Context, FailurePolicy};
+    ///
+    /// fn policy(ctx: &Context<'_>) -> FailurePolicy {
+    ///     ctx.decode_policy()
+    /// }
+    /// ```
+    #[must_use]
+    pub fn decode_policy(&self) -> FailurePolicy {
+        self.decode
     }
 
     /// Triggers a fail-fast shutdown for `reason` if a handle is attached, naming this delivery's

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -577,8 +577,9 @@ async fn dispatch<H, M, C, St>(
     // Build the broker's typed per-delivery context from the message, then attach the fail-fast
     // handle.
     let cx = C::build(&msg);
-    let mut ctx =
-        Context::new(name, msg.headers(), state, cx, delivery).with_failfast(&failure.shutdown);
+    let mut ctx = Context::new(name, msg.headers(), state, cx, delivery)
+        .with_failfast(&failure.shutdown)
+        .with_decode_policy(failure.policies.decode);
     // Catch a panicking handler so it cannot silently kill the dispatch loop (which would stop the
     // subscriber consuming) or leave the message unsettled. AssertUnwindSafe is required because
     // the future borrows `&mut ctx`; that state is discarded with the failed delivery.
@@ -685,7 +686,9 @@ async fn run_batch<H, M, St>(
     let empty = Headers::new();
     // A batch has no single broker message, so its per-delivery context is unit (`C = ()`); the
     // shared app state is threaded the same way as on the single-message path.
-    let mut ctx = Context::new(name, &empty, state, (), delivery).with_failfast(&failure.shutdown);
+    let mut ctx = Context::new(name, &empty, state, (), delivery)
+        .with_failfast(&failure.shutdown)
+        .with_decode_policy(failure.policies.decode);
     // See `dispatch`: the harness's slot scope attributes `Out` publishes to their slot.
     #[cfg(feature = "testing")]
     let result = in_slot_scope(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,6 +21,7 @@ mod publish_source;
 mod publisher_registry;
 mod publishing;
 mod router;
+mod settings;
 mod slot;
 mod subscriber_def;
 mod typed;
@@ -42,8 +43,8 @@ pub use app::{
 #[cfg(feature = "testing")]
 pub(crate) use app::{LifecycleHook, RegisteredBroker, Starter, TestParts};
 pub use batch::{
-    BatchDef, BatchResult, BatchWithHeadersDef, IntoBatchResult, SliceHandler,
-    SliceHandlerWithHeaders, TypedBatch, TypedBatchWithHeaders,
+    BatchDef, BatchResult, BatchWithHeadersDef, IntoBatchResult, RawBatch, RawSliceHandler,
+    SliceHandler, SliceHandlerWithHeaders, TypedBatch, TypedBatchWithHeaders,
 };
 pub use batch_inject::{BatchInjectCall, BatchInjectDef, BatchInjectHandler};
 pub use batch_publishing::{BatchPublishingCall, BatchPublishingDef, BatchPublishingHandler};
@@ -81,6 +82,10 @@ pub use router::{
 };
 #[doc(hidden)]
 pub use router::{RouterCommit, RouterMount, RouterSlotCommit};
+pub use settings::{
+    AllOpen, BufferedStep, Declared, FailureStep, Fixed, MapSourceStep, NameStep, Open,
+    StartAtStep, SubscriberBuilder, SubscriberSettings, WorkersStep,
+};
 #[doc(hidden)]
 pub use slot::{BindSlot, InitSlots, IntoSlotSource, MissingSlot, SlotPos, WithSource};
 pub use slot::{

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -8,8 +8,8 @@ use crate::codec::Codec;
 use crate::{BatchSubscriber, Broker, Connected, Subscriber, SubscriptionSource};
 
 use crate::runtime::batch::{
-    BatchDef, BatchWithHeadersDef, SliceHandler, TypedBatch, TypedBatchWithHeaders, batch_metadata,
-    typed_batch,
+    BatchDef, BatchWithHeadersDef, RawBatch, SliceHandler, TypedBatch, TypedBatchWithHeaders,
+    batch_metadata, typed_batch,
 };
 use crate::runtime::batch_inject::{BatchInjectDef, batch_inject_metadata};
 use crate::runtime::batch_publishing::{BatchPublishingDef, batch_publishing_metadata};
@@ -33,8 +33,8 @@ use super::routes_publish::{BatchPublishingRoute, PublishingRoute, RawReplyRoute
 use super::sink::RouterSink;
 use super::{
     BatchInjectedRouter, BatchPublishingRouter, IncludedBatchRouter,
-    IncludedBatchWithHeadersRouter, IncludedRouter, InjectedRouter, MergedRouter, PublishingRouter,
-    RawReplyRouter, SourceMessage, SubscribedBatchRouter,
+    IncludedBatchWithHeadersRouter, IncludedRawBatchRouter, IncludedRouter, InjectedRouter,
+    MergedRouter, PublishingRouter, RawReplyRouter, SourceMessage, SubscribedBatchRouter,
 };
 
 /// A statically-typed, lazily-bound group of handler registrations, not attached to any broker.
@@ -315,6 +315,40 @@ impl<B: Broker + 'static, Routes, RouteCodec, RouteLayers>
         // kind explicitly.
         let handler = TypedBatch::<_, Def::Input, _, _>::over(codec, def.into_handler())
             .with_decode(policies.decode);
+        Router {
+            routes: (
+                BatchRoute {
+                    source,
+                    handler,
+                    meta,
+                    policies,
+                    workers,
+                },
+                self.routes,
+            ),
+            codec: self.codec,
+            layers: self.layers,
+            _broker: PhantomData,
+        }
+    }
+
+    /// Mounts a raw batch definition on `source`: the handler borrows the batch's payloads as
+    /// they arrived, so no codec takes part.
+    pub(super) fn mount_raw_batch<Source, Def>(
+        self,
+        source: Source,
+        def: Def,
+    ) -> IncludedRawBatchRouter<B, Source, Def, RouteCodec, RouteLayers, Routes>
+    where
+        Source: SubscriptionSource<Connected<B>> + Send + 'static,
+        Source::Subscriber: BatchSubscriber + Send + 'static,
+        Def: BatchDef<Input = crate::runtime::RawBytes>,
+        Def::Handler: 'static,
+    {
+        let meta = batch_metadata(source.name().to_owned(), &def);
+        let policies = def.failure_policies();
+        let workers = def.workers();
+        let handler = RawBatch::over(def.into_handler());
         Router {
             routes: (
                 BatchRoute {

--- a/src/runtime/router/builder.rs
+++ b/src/runtime/router/builder.rs
@@ -1,5 +1,6 @@
 //! The [`Router`] builder: chaining registrations, codecs and layers, and mounting the result.
 
+use std::fmt;
 use std::marker::PhantomData;
 
 use serde::de::DeserializeOwned;
@@ -17,7 +18,7 @@ use crate::runtime::dispatch::Workers;
 use crate::runtime::failure::FailurePolicies;
 use crate::runtime::handler::Handler;
 use crate::runtime::inject::{InjectDef, inject_metadata};
-use crate::runtime::input::DecodeWith;
+use crate::runtime::input::{DecodeWith, RawBytes};
 use crate::runtime::metadata::HandlerMetadata;
 use crate::runtime::middleware::{BlanketLayer, Identity, Stack};
 use crate::runtime::publish::PublishPipeline;
@@ -89,8 +90,8 @@ impl<B: Broker + 'static> Default for Router<B, (), (), Identity> {
     }
 }
 
-impl<B, Routes, C, Layers> std::fmt::Debug for Router<B, Routes, C, Layers> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<B, Routes, C, Layers> fmt::Debug for Router<B, Routes, C, Layers> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Router").finish_non_exhaustive()
     }
 }
@@ -342,7 +343,7 @@ impl<B: Broker + 'static, Routes, RouteCodec, RouteLayers>
     where
         Source: SubscriptionSource<Connected<B>> + Send + 'static,
         Source::Subscriber: BatchSubscriber + Send + 'static,
-        Def: BatchDef<Input = crate::runtime::RawBytes>,
+        Def: BatchDef<Input = RawBytes>,
         Def::Handler: 'static,
     {
         let meta = batch_metadata(source.name().to_owned(), &def);

--- a/src/runtime/router/form_eager.rs
+++ b/src/runtime/router/form_eager.rs
@@ -16,8 +16,8 @@ use crate::runtime::subscriber_def::SubscriberDef;
 use super::builder::Router;
 use super::mount::{MountCodec, RouterMount};
 use super::{
-    BatchInjectedRouter, IncludedBatchRouter, IncludedBatchWithHeadersRouter, IncludedRouter,
-    InjectedRouter, forms,
+    BatchInjectedRouter, IncludedBatchRouter, IncludedBatchWithHeadersRouter,
+    IncludedRawBatchRouter, IncludedRouter, InjectedRouter, forms,
 };
 
 impl<B, Routes, RouteCodec, RouteLayers, Def> RouterMount<B, Routes, RouteCodec, RouteLayers, Def>
@@ -115,6 +115,24 @@ where
         let codec = router.codec.mount_codec();
         let source = def.source();
         router.mount_batch(source, def, codec)
+    }
+}
+
+// A raw batch decodes nothing, so the chain's codec parameter stays unconstrained here too.
+impl<B, Routes, RouteCodec, RouteLayers, Def> RouterMount<B, Routes, RouteCodec, RouteLayers, Def>
+    for forms::RawBatch
+where
+    B: Broker + 'static,
+    Def: BatchDef<Input = RawBytes>,
+    Def::Source: SubscriptionSource<Connected<B>> + Send + 'static,
+    SourceSubscriber<B, Def::Source>: BatchSubscriber + Send + 'static,
+    Def::Handler: 'static,
+{
+    type Out = IncludedRawBatchRouter<B, Def::Source, Def, RouteCodec, RouteLayers, Routes>;
+
+    fn begin(def: Def, router: Router<B, Routes, RouteCodec, RouteLayers>) -> Self::Out {
+        let source = def.source();
+        router.mount_raw_batch(source, def)
     }
 }
 

--- a/src/runtime/router/forms.rs
+++ b/src/runtime/router/forms.rs
@@ -37,9 +37,12 @@ pub struct PublishingOut;
 /// A byte-reply subscriber whose handler also takes an `Out` parameter.
 #[derive(Debug, Clone, Copy)]
 pub struct RawReplyOut;
-/// A batch subscriber (`#[subscriber(batch("in"))]`).
+/// A batch subscriber (a handler taking `&[T]`).
 #[derive(Debug, Clone, Copy)]
 pub struct Batch;
+/// A raw batch subscriber (a handler taking `&[&[u8]]`): a batch with no decode step.
+#[derive(Debug, Clone, Copy)]
+pub struct RawBatch;
 /// A batch subscriber reading a typed header contract per element
 /// (`#[subscriber(batch("in"))]` with a `FromHeaders<Vec<H>>` parameter).
 #[derive(Debug, Clone, Copy)]

--- a/src/runtime/router/include.rs
+++ b/src/runtime/router/include.rs
@@ -20,7 +20,8 @@ use crate::runtime::metadata::HandlerMetadata;
 
 use super::SubscribedBatchRouter;
 use super::builder::Router;
-use super::mount::{IncludeDef, MountCodec, RouterMount};
+use super::mount::{MountCodec, RouterMount};
+use crate::runtime::settings::Declared;
 
 impl<B: Broker + 'static, Routes, RouteCodec, RouteLayers>
     Router<B, Routes, RouteCodec, RouteLayers>
@@ -61,15 +62,18 @@ impl<B: Broker + 'static, Routes, RouteCodec, RouteLayers>
     /// }
     /// # }
     /// ```
-    pub fn include<Def>(
+    pub fn include<D>(
         self,
-        def: Def,
-    ) -> <Def::Form as RouterMount<B, Routes, RouteCodec, RouteLayers, Def>>::Out
+        def: D,
+    ) -> <D::Form as RouterMount<B, Routes, RouteCodec, RouteLayers, D::Settings>>::Out
     where
-        Def: IncludeDef,
-        Def::Form: RouterMount<B, Routes, RouteCodec, RouteLayers, Def>,
+        D: Declared,
+        D::Form: RouterMount<B, Routes, RouteCodec, RouteLayers, D::Settings>,
     {
-        <Def::Form as RouterMount<B, Routes, RouteCodec, RouteLayers, Def>>::begin(def, self)
+        <D::Form as RouterMount<B, Routes, RouteCodec, RouteLayers, D::Settings>>::begin(
+            def.declare(),
+            self,
+        )
     }
 
     /// Attaches a slice handler to a batch subscription described by `source`, decoding each

--- a/src/runtime/router/mod.rs
+++ b/src/runtime/router/mod.rs
@@ -44,7 +44,9 @@ pub(crate) use mount::{
 pub use routes::{RouterDef, RouterHandlers};
 pub use sink::RouterSink;
 
-use crate::runtime::batch::{BatchDef, BatchWithHeadersDef, TypedBatch, TypedBatchWithHeaders};
+use crate::runtime::batch::{
+    BatchDef, BatchWithHeadersDef, RawBatch, TypedBatch, TypedBatchWithHeaders,
+};
 use crate::runtime::input::Decoded;
 use crate::runtime::subscriber_def::SubscriberDef;
 use crate::runtime::typed::Typed;
@@ -77,6 +79,14 @@ type BatchTypedRoute<B, S, D, C> = BatchRoute<
 /// produces. `RC` / `RL` are the router's own codec and layer parameters, carried unchanged.
 type IncludedBatchRouter<B, S, D, C, RC, RL, R> =
     Router<B, (BatchTypedRoute<B, S, D, C>, R), RC, RL>;
+
+/// The route a raw [`BatchDef`] `D` mounted on source `S` becomes: no codec is involved, so the
+/// adapter carries only the message type and the handler.
+type RawBatchRoute<B, S, D> =
+    BatchRoute<S, RawBatch<SourceMessage<B, S>, <D as BatchDef>::Handler>>;
+
+/// The router that mounting a raw [`BatchDef`] `D` on source `S` onto `R` produces.
+type IncludedRawBatchRouter<B, S, D, RC, RL, R> = Router<B, (RawBatchRoute<B, S, D>, R), RC, RL>;
 
 /// The route a [`BatchWithHeadersDef`] `D` mounted on source `S` (decoded with `C`) becomes: the
 /// element contracts are parsed by the adapter, so the route type differs only in that adapter.

--- a/src/runtime/settings.rs
+++ b/src/runtime/settings.rs
@@ -1,0 +1,446 @@
+//! The declarative settings of a subscriber, as a builder the `#[subscriber]` attribute shares.
+//!
+//! Name, worker policy, failure policies and start position are values, so each can be named in
+//! the attribute, or at the mount site, or partly in each. Both paths run through the same
+//! [`SubscriberBuilder`]: the attribute expands into [`Declared::declare`], which applies exactly
+//! the settings it names, and the mount site chains the rest on the result.
+//!
+//! What the attribute already fixed is fixed in the type: each setting's builder step is a trait
+//! implemented only for the state where that setting is still open, so naming it twice is a
+//! compile error carrying its own message rather than a precedence rule to remember.
+//!
+//! ```
+//! # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+//! # mod demo {
+//! use ruststream::nonzero;
+//! use ruststream::runtime::{HandlerResult, SubscriberSettings};
+//! use ruststream::subscriber;
+//! # #[derive(serde::Deserialize)]
+//! # struct Order;
+//!
+//! // The attribute fixes the worker policy; the name is left to the mount site.
+//! #[subscriber(workers(4))]
+//! async fn audit(order: &Order) -> HandlerResult {
+//!     HandlerResult::Ack
+//! }
+//!
+//! # fn wire(subject: String) {
+//! let _mountable = audit.name(subject);
+//! # }
+//! # }
+//! ```
+
+mod forward;
+
+use std::borrow::Cow;
+use std::fmt;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use crate::{Buffered, FromName, StartAt, Unnamed};
+
+use super::dispatch::Workers;
+use super::failure::FailurePolicies;
+use super::router::IncludeDef;
+
+/// A setting the attribute left out, still fillable at the mount site.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Open;
+
+/// A setting already named, in the attribute or by an earlier builder call.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Fixed;
+
+/// The settings state of a definition whose attribute named none of them.
+pub type AllOpen = (Open, Open, Open);
+
+/// A value `include` accepts: a `#[subscriber]` definition, or a settings builder over one.
+///
+/// The macro implements it on the generated definition, applying the settings its attribute
+/// named; every hand-written definition gets it for free through its
+/// [`IncludeDef`] impl, and so does the builder itself, which makes
+/// [`SubscriberSettings`] chainable from either end.
+pub trait Declared: Sized {
+    /// The mount form token the definition dispatches on (one of the markers in
+    /// [`forms`](super::forms)).
+    type Form;
+
+    /// The definition the mount machinery drives: the settings builder for a macro-generated
+    /// definition, the definition itself for a hand-written one.
+    type Settings;
+
+    /// Applies the settings the declaration fixed.
+    fn declare(self) -> Self::Settings;
+}
+
+// A hand-written definition names its own form and carries its own settings, so it is already
+// what the mount machinery drives.
+impl<T: IncludeDef> Declared for T {
+    type Form = <T as IncludeDef>::Form;
+    type Settings = Self;
+
+    fn declare(self) -> Self {
+        self
+    }
+}
+
+/// The declarative settings of one subscriber, over the definition the macro generated.
+///
+/// Built by [`Declared::declare`] and grown by the [`SubscriberSettings`] methods; the mount
+/// machinery reads the source and the policies off it instead of off the definition, so an
+/// attribute-named setting and a mount-site one take the same path.
+///
+/// The `State` parameter records which settings are still open, as
+/// `(workers, failure policies, start position)` over [`Open`] / [`Fixed`]. The subscription's
+/// name is recorded in `Src` instead: an unnamed definition carries [`Unnamed<S>`], which is no
+/// [`SubscriptionSource`](crate::SubscriptionSource) at all, so mounting it is a compile error.
+pub struct SubscriberBuilder<Def, Src, State> {
+    def: Def,
+    source: Src,
+    workers: Workers,
+    failures: FailurePolicies,
+    _state: PhantomData<fn() -> State>,
+}
+
+impl<Def, Src> SubscriberBuilder<Def, Src, AllOpen> {
+    /// The builder over `def` subscribing on `source`, with every setting still open.
+    ///
+    /// Called by the `#[subscriber]` expansion; a hand-written definition that wants the same
+    /// surface calls it from its own [`Declared`] impl.
+    #[must_use]
+    pub fn new(def: Def, source: Src) -> Self {
+        Self {
+            def,
+            source,
+            workers: Workers::sequential(),
+            failures: FailurePolicies::default(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<Def, Src, State> SubscriberBuilder<Def, Src, State> {
+    /// The pieces a step rebuilds from: the source moves out, so a step can wrap it without
+    /// demanding `Clone` of a broker's descriptor.
+    fn into_parts(self) -> (Def, Src, Workers, FailurePolicies) {
+        (self.def, self.source, self.workers, self.failures)
+    }
+
+    /// Rebuilds a builder from moved-out pieces, at whatever source and settings state the step
+    /// produced.
+    fn from_parts<NewSrc, NewState>(
+        def: Def,
+        source: NewSrc,
+        workers: Workers,
+        failures: FailurePolicies,
+    ) -> SubscriberBuilder<Def, NewSrc, NewState> {
+        SubscriberBuilder {
+            def,
+            source,
+            workers,
+            failures,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<Def, Src, State> Declared for SubscriberBuilder<Def, Src, State>
+where
+    Def: Declared,
+{
+    type Form = Def::Form;
+    type Settings = Self;
+
+    fn declare(self) -> Self {
+        self
+    }
+}
+
+impl<Def, Src, State> fmt::Debug for SubscriberBuilder<Def, Src, State> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SubscriberBuilder")
+            .field("workers", &self.workers)
+            .field("failures", &self.failures)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Naming the subscription, which is what constructs the source. See
+/// [`SubscriberSettings::name`].
+#[diagnostic::on_unimplemented(
+    message = "this subscriber's subscription is already named",
+    label = "the name is fixed in the `#[subscriber(..)]` attribute",
+    note = "a setting is named once: keep the name in the attribute, or leave the attribute's \
+            source open (`#[subscriber]`, `#[subscriber(Kind)]`) and name it here"
+)]
+pub trait NameStep: Sized {
+    /// The builder over the constructed source.
+    type Out;
+
+    /// Builds the subscription kind from `name`.
+    fn apply_name(self, name: Cow<'static, str>) -> Self::Out;
+}
+
+impl<Def, S: FromName, State> NameStep for SubscriberBuilder<Def, Unnamed<S>, State> {
+    type Out = SubscriberBuilder<Def, S, State>;
+
+    fn apply_name(self, name: Cow<'static, str>) -> Self::Out {
+        let (def, _unnamed, workers, failures) = self.into_parts();
+        Self::from_parts(def, S::from_name(name), workers, failures)
+    }
+}
+
+/// Setting the dispatch concurrency. See [`SubscriberSettings::workers`].
+#[diagnostic::on_unimplemented(
+    message = "this subscriber's worker policy is already fixed",
+    label = "`workers(..)` is named in the `#[subscriber(..)]` attribute",
+    note = "a setting is named once: keep `workers(..)` in the attribute, or drop it there and \
+            name the policy here"
+)]
+pub trait WorkersStep: Sized {
+    /// The builder with the worker policy fixed.
+    type Out;
+
+    /// Fixes the dispatch concurrency.
+    fn apply_workers(self, workers: Workers) -> Self::Out;
+}
+
+impl<Def, Src, F, P> WorkersStep for SubscriberBuilder<Def, Src, (Open, F, P)> {
+    type Out = SubscriberBuilder<Def, Src, (Fixed, F, P)>;
+
+    fn apply_workers(self, workers: Workers) -> Self::Out {
+        let (def, source, _default, failures) = self.into_parts();
+        Self::from_parts(def, source, workers, failures)
+    }
+}
+
+/// Setting the failure policies. See [`SubscriberSettings::on_failure`].
+#[diagnostic::on_unimplemented(
+    message = "this subscriber's failure policies are already fixed",
+    label = "`on_failure(..)` is named in the `#[subscriber(..)]` attribute",
+    note = "a setting is named once: keep `on_failure(..)` in the attribute, or drop it there \
+            and name the policies here"
+)]
+pub trait FailureStep: Sized {
+    /// The builder with the failure policies fixed.
+    type Out;
+
+    /// Fixes the panic and materialization policies.
+    fn apply_failures(self, policies: FailurePolicies) -> Self::Out;
+}
+
+impl<Def, Src, W, P> FailureStep for SubscriberBuilder<Def, Src, (W, Open, P)> {
+    type Out = SubscriberBuilder<Def, Src, (W, Fixed, P)>;
+
+    fn apply_failures(self, policies: FailurePolicies) -> Self::Out {
+        let (def, source, workers, _defaults) = self.into_parts();
+        Self::from_parts(def, source, workers, policies)
+    }
+}
+
+/// Setting the start position, which decorates the source. See
+/// [`SubscriberSettings::start_at`].
+#[diagnostic::on_unimplemented(
+    message = "this subscriber's start position is already fixed",
+    label = "`start_at(..)` is named in the `#[subscriber(..)]` attribute",
+    note = "a setting is named once: keep `start_at(..)` in the attribute, or drop it there and \
+            name the position here"
+)]
+pub trait StartAtStep<P>: Sized {
+    /// The builder over the position-decorated source.
+    type Out;
+
+    /// Opens the subscription at `position` instead of the broker's default.
+    fn apply_start_at(self, position: P) -> Self::Out;
+}
+
+impl<Def, Src, W, F, P> StartAtStep<P> for SubscriberBuilder<Def, Src, (W, F, Open)> {
+    type Out = SubscriberBuilder<Def, StartAt<Src, P>, (W, F, Fixed)>;
+
+    fn apply_start_at(self, position: P) -> Self::Out {
+        let (def, source, workers, failures) = self.into_parts();
+        Self::from_parts(def, StartAt::new(source, position), workers, failures)
+    }
+}
+
+/// Wrapping the source in the framework's own buffer. See [`SubscriberSettings::buffered`].
+pub trait BufferedStep: Sized {
+    /// The builder over the buffered source.
+    type Out;
+
+    /// Buffers single deliveries into batches on the client.
+    fn apply_buffered(self, max_size: NonZeroUsize, max_wait: Duration) -> Self::Out;
+}
+
+impl<Def, Src, State> BufferedStep for SubscriberBuilder<Def, Src, State> {
+    type Out = SubscriberBuilder<Def, Buffered<Src>, State>;
+
+    fn apply_buffered(self, max_size: NonZeroUsize, max_wait: Duration) -> Self::Out {
+        let (def, source, workers, failures) = self.into_parts();
+        let buffered = Buffered::new(source).max_size(max_size).max_wait(max_wait);
+        Self::from_parts(def, buffered, workers, failures)
+    }
+}
+
+/// Transforming the source under construction: the hook a broker's own settings trait layers on.
+/// See [`SubscriberSettings::map_source`].
+pub trait MapSourceStep<F>: Sized {
+    /// The builder over the transformed source.
+    type Out;
+
+    /// Replaces the source with `f`'s result.
+    fn apply_map_source(self, f: F) -> Self::Out;
+}
+
+impl<Def, Src, State, F, NewSrc> MapSourceStep<F> for SubscriberBuilder<Def, Src, State>
+where
+    F: FnOnce(Src) -> NewSrc,
+{
+    type Out = SubscriberBuilder<Def, NewSrc, State>;
+
+    fn apply_map_source(self, f: F) -> Self::Out {
+        let (def, source, workers, failures) = self.into_parts();
+        Self::from_parts(def, f(source), workers, failures)
+    }
+}
+
+/// The declarative settings, chainable on a `#[subscriber]` definition and on the builder alike.
+///
+/// Every method is available exactly while its setting is open: the attribute fixes what it
+/// names, and the corresponding step trait is implemented only for the open state, so a second
+/// naming fails to compile with a message of its own.
+///
+/// The order in a chain follows from what each step does to the source: [`name`](Self::name)
+/// comes first because it constructs the source, a broker's own settings then transform it
+/// through [`map_source`](Self::map_source), and [`buffered`](Self::buffered) wraps it last -
+/// broker methods bound to the unwrapped source type stop applying past the wrap.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+/// # mod demo {
+/// use ruststream::nonzero;
+/// use ruststream::runtime::{FailurePolicies, FailurePolicy, HandlerResult, SubscriberSettings};
+/// use ruststream::subscriber;
+/// # #[derive(serde::Deserialize)]
+/// # struct Order;
+///
+/// #[subscriber]
+/// async fn audit(order: &Order) -> HandlerResult {
+///     HandlerResult::Ack
+/// }
+///
+/// # fn wire(shard: u8) {
+/// let _mountable = audit
+///     .name(format!("orders-{shard}"))
+///     .workers(nonzero!(4))
+///     .on_failure(FailurePolicies::default().with_decode(FailurePolicy::Skip));
+/// # }
+/// # }
+/// ```
+pub trait SubscriberSettings: Declared {
+    /// Names the subscription, building the kind the attribute fixed.
+    ///
+    /// Available while the attribute left the source open (`#[subscriber]` for the by-name
+    /// source, `#[subscriber(Kind)]` for a named kind); the kind is built through
+    /// [`FromName`].
+    fn name(self, name: impl Into<Cow<'static, str>>) -> <Self::Settings as NameStep>::Out
+    where
+        Self::Settings: NameStep,
+    {
+        self.declare().apply_name(name.into())
+    }
+
+    /// Processes up to `count` deliveries (or batches) of this subscriber concurrently, each in
+    /// its own task. The mount-site spelling of `workers(n)`.
+    fn workers(self, count: NonZeroUsize) -> <Self::Settings as WorkersStep>::Out
+    where
+        Self::Settings: WorkersStep,
+    {
+        self.declare().apply_workers(Workers::pool(count))
+    }
+
+    /// Runs `count` sequential lanes keyed by the message's partition key, preserving per-key
+    /// ordering. The mount-site spelling of `workers(n, by_key)`.
+    fn workers_by_key(self, count: NonZeroUsize) -> <Self::Settings as WorkersStep>::Out
+    where
+        Self::Settings: WorkersStep,
+    {
+        self.declare().apply_workers(Workers::keyed(count))
+    }
+
+    /// Sets the policies applied to a handler panic and to a delivery that fails to
+    /// materialize. The mount-site spelling of `on_failure(panic = .., decode = ..)`.
+    fn on_failure(self, policies: FailurePolicies) -> <Self::Settings as FailureStep>::Out
+    where
+        Self::Settings: FailureStep,
+    {
+        self.declare().apply_failures(policies)
+    }
+
+    /// Opens the subscription at `position` instead of the broker's default. The mount-site
+    /// spelling of `start_at(<position>)`.
+    fn start_at<P>(self, position: P) -> <Self::Settings as StartAtStep<P>>::Out
+    where
+        Self::Settings: StartAtStep<P>,
+    {
+        self.declare().apply_start_at(position)
+    }
+
+    /// Wraps the subscription in the framework's own buffer, so a handler taking `&[T]` gets
+    /// batches on a broker whose subscription does not batch by itself.
+    ///
+    /// A batch closes at `max_size` deliveries, or `max_wait` after its first one. Named after
+    /// the adapter on purpose: batches come either from the broker (configured through the
+    /// broker's own settings) or from this wrap, and the two are different things.
+    fn buffered(
+        self,
+        max_size: NonZeroUsize,
+        max_wait: Duration,
+    ) -> <Self::Settings as BufferedStep>::Out
+    where
+        Self::Settings: BufferedStep,
+    {
+        self.declare().apply_buffered(max_size, max_wait)
+    }
+
+    /// Transforms the source under construction.
+    ///
+    /// The hook a broker crate layers its own settings trait on: core cannot know that a
+    /// subscription has a `JetStream` stream or a consumer group, so the broker declares a trait
+    /// over `SubscriberBuilder` bound to its own source type and implements each method as one
+    /// `map_source` call. The bound means those methods simply do not exist on a builder for
+    /// another broker.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+    /// # mod demo {
+    /// use ruststream::memory::MemorySource;
+    /// use ruststream::runtime::{HandlerResult, SubscriberSettings};
+    /// use ruststream::subscriber;
+    /// # #[derive(serde::Deserialize)]
+    /// # struct Order;
+    ///
+    /// #[subscriber(MemorySource)]
+    /// async fn audit(order: &Order) -> HandlerResult {
+    ///     HandlerResult::Ack
+    /// }
+    ///
+    /// # fn wire() {
+    /// let _mountable = audit.name("orders").map_source(|source| source);
+    /// # }
+    /// # }
+    /// ```
+    fn map_source<F>(self, f: F) -> <Self::Settings as MapSourceStep<F>>::Out
+    where
+        Self::Settings: MapSourceStep<F>,
+    {
+        self.declare().apply_map_source(f)
+    }
+}
+
+impl<D: Declared> SubscriberSettings for D {}

--- a/src/runtime/settings.rs
+++ b/src/runtime/settings.rs
@@ -447,14 +447,16 @@ impl<D: Declared> SubscriberSettings for D {}
 
 #[cfg(test)]
 mod tests {
-    use super::{Declared, SubscriberBuilder, SubscriberSettings};
+    use std::time::Duration;
+
+    use super::{AllOpen, Declared, SubscriberBuilder, SubscriberSettings};
+    use crate::memory::ConnectedMemoryBroker;
     use crate::runtime::dispatch::Workers;
     use crate::runtime::failure::{FailurePolicies, FailurePolicy};
     use crate::runtime::forms;
+    use crate::runtime::input::Decoded;
     use crate::runtime::subscriber_def::SubscriberDef;
-    use crate::{Name, Unnamed};
-
-    use std::time::Duration;
+    use crate::{Name, SubscriptionSource, Unnamed, nonzero};
 
     /// Stands in for a generated definition: the steps only move it around, so it carries the
     /// bare structural surface a definition has, and none of the settings.
@@ -462,7 +464,7 @@ mod tests {
     struct Stub;
 
     impl SubscriberDef for Stub {
-        type Input = crate::runtime::input::Decoded<u32>;
+        type Input = Decoded<u32>;
         type Context = ();
         type Handler = ();
         type Source = Name;
@@ -476,7 +478,7 @@ mod tests {
 
     impl Declared for Stub {
         type Form = forms::Subscribing;
-        type Settings = SubscriberBuilder<Self, Unnamed<Name>, super::AllOpen>;
+        type Settings = SubscriberBuilder<Self, Unnamed<Name>, AllOpen>;
 
         fn declare(self) -> Self::Settings {
             SubscriberBuilder::new(self, Unnamed::new())
@@ -487,15 +489,15 @@ mod tests {
     fn the_steps_collect_the_settings_the_mount_reads_back() {
         let built = Stub
             .name("orders")
-            .workers(crate::nonzero!(4))
+            .workers(nonzero!(4))
             .on_failure(FailurePolicies::default().with_decode(FailurePolicy::Skip))
-            .buffered(crate::nonzero!(8), Duration::from_millis(5));
+            .buffered(nonzero!(8), Duration::from_millis(5));
 
-        assert_eq!(built.workers, Workers::pool(crate::nonzero!(4)));
+        assert_eq!(built.workers, Workers::pool(nonzero!(4)));
         assert_eq!(built.failures.decode, FailurePolicy::Skip);
         // The buffer wraps the named source, so the name survives the wrap.
         assert_eq!(
-            crate::SubscriptionSource::<crate::memory::ConnectedMemoryBroker>::name(&built.source),
+            SubscriptionSource::<ConnectedMemoryBroker>::name(&built.source),
             "orders",
         );
         // The definition rides along untouched: the builder only ever adds settings.
@@ -504,8 +506,8 @@ mod tests {
 
     #[test]
     fn keyed_lanes_are_the_same_slot_as_the_pool() {
-        let built = Stub.name("orders").workers_by_key(crate::nonzero!(2));
-        assert_eq!(built.workers, Workers::keyed(crate::nonzero!(2)));
+        let built = Stub.name("orders").workers_by_key(nonzero!(2));
+        assert_eq!(built.workers, Workers::keyed(nonzero!(2)));
     }
 
     #[test]

--- a/src/runtime/settings.rs
+++ b/src/runtime/settings.rs
@@ -444,3 +444,81 @@ pub trait SubscriberSettings: Declared {
 }
 
 impl<D: Declared> SubscriberSettings for D {}
+
+#[cfg(test)]
+mod tests {
+    use super::{Declared, SubscriberBuilder, SubscriberSettings};
+    use crate::runtime::dispatch::Workers;
+    use crate::runtime::failure::{FailurePolicies, FailurePolicy};
+    use crate::runtime::forms;
+    use crate::runtime::subscriber_def::SubscriberDef;
+    use crate::{Name, Unnamed};
+
+    use std::time::Duration;
+
+    /// Stands in for a generated definition: the steps only move it around, so it carries the
+    /// bare structural surface a definition has, and none of the settings.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Stub;
+
+    impl SubscriberDef for Stub {
+        type Input = crate::runtime::input::Decoded<u32>;
+        type Context = ();
+        type Handler = ();
+        type Source = Name;
+
+        fn source(&self) -> Name {
+            Name::new("stub")
+        }
+
+        fn into_handler(self) {}
+    }
+
+    impl Declared for Stub {
+        type Form = forms::Subscribing;
+        type Settings = SubscriberBuilder<Self, Unnamed<Name>, super::AllOpen>;
+
+        fn declare(self) -> Self::Settings {
+            SubscriberBuilder::new(self, Unnamed::new())
+        }
+    }
+
+    #[test]
+    fn the_steps_collect_the_settings_the_mount_reads_back() {
+        let built = Stub
+            .name("orders")
+            .workers(crate::nonzero!(4))
+            .on_failure(FailurePolicies::default().with_decode(FailurePolicy::Skip))
+            .buffered(crate::nonzero!(8), Duration::from_millis(5));
+
+        assert_eq!(built.workers, Workers::pool(crate::nonzero!(4)));
+        assert_eq!(built.failures.decode, FailurePolicy::Skip);
+        // The buffer wraps the named source, so the name survives the wrap.
+        assert_eq!(
+            crate::SubscriptionSource::<crate::memory::ConnectedMemoryBroker>::name(&built.source),
+            "orders",
+        );
+        // The definition rides along untouched: the builder only ever adds settings.
+        assert_eq!(built.def, Stub);
+    }
+
+    #[test]
+    fn keyed_lanes_are_the_same_slot_as_the_pool() {
+        let built = Stub.name("orders").workers_by_key(crate::nonzero!(2));
+        assert_eq!(built.workers, Workers::keyed(crate::nonzero!(2)));
+    }
+
+    #[test]
+    fn a_builder_declares_itself_and_reports_its_settings() {
+        let built = Stub.name("orders").map_source(|source| source);
+        // Chaining from a builder goes through the same trait, which is what lets the attribute
+        // and the mount site share one implementation.
+        let same = built.declare();
+        assert_eq!(SubscriberDef::workers(&same), Workers::sequential());
+        assert_eq!(
+            SubscriberDef::failure_policies(&same),
+            FailurePolicies::default()
+        );
+        assert!(format!("{same:?}").contains("SubscriberBuilder"));
+    }
+}

--- a/src/runtime/settings/forward.rs
+++ b/src/runtime/settings/forward.rs
@@ -1,0 +1,283 @@
+//! What a [`SubscriberBuilder`] is to the mount machinery: the definition it wraps, with the
+//! source and the policies it collected in place of the definition's own.
+//!
+//! Every definition form forwards the same way - the structural pieces (input kind, context,
+//! handler, injections, reply) come from the wrapped definition, the declarative settings come
+//! from the builder - so the mount impls never learn that a builder is involved.
+//!
+//! The source is rebuilt per mount, so it is cloned rather than moved: a definition mounted on
+//! two brokers hands each of them its own value, exactly as a definition's own `source()` does.
+//!
+//! Associated types are named through the wrapped definition rather than through `Self`: the
+//! builder implements every definition form, so a bare `Self::Input` would be ambiguous.
+
+use std::future::Future;
+use std::marker::PhantomData;
+
+use crate::ConnectedBroker;
+
+use super::SubscriberBuilder;
+use crate::runtime::batch::{BatchDef, BatchResult, BatchWithHeadersDef};
+use crate::runtime::batch_inject::{BatchInjectCall, BatchInjectDef};
+use crate::runtime::batch_publishing::{BatchPublishingCall, BatchPublishingDef};
+use crate::runtime::context::Context;
+use crate::runtime::dispatch::Workers;
+use crate::runtime::failure::FailurePolicies;
+use crate::runtime::handler::{HandlerResult, Settle};
+use crate::runtime::inject::{InjectCall, InjectDef};
+use crate::runtime::input::InputKind;
+use crate::runtime::metadata::OutgoingMessageMetadata;
+use crate::runtime::publishing::{PublishingCall, PublishingDef};
+use crate::runtime::slot::{BindSlots, HasSlots};
+use crate::runtime::subscriber_def::SubscriberDef;
+
+/// The metadata methods every definition trait shares, forwarded to the wrapped definition, plus
+/// the two settings the builder owns.
+macro_rules! forward_common {
+    ($def:ty) => {
+        fn source(&self) -> Src {
+            self.source.clone()
+        }
+
+        fn workers(&self) -> Workers {
+            self.workers
+        }
+
+        fn failure_policies(&self) -> FailurePolicies {
+            self.failures
+        }
+
+        fn description(&self) -> Option<&str> {
+            <Def as $def>::description(&self.def)
+        }
+
+        fn input_schema(&self) -> Option<String> {
+            <Def as $def>::input_schema(&self.def)
+        }
+
+        fn headers_schema(&self) -> Option<String> {
+            <Def as $def>::headers_schema(&self.def)
+        }
+
+        fn message_name(&self) -> Option<&'static str> {
+            <Def as $def>::message_name(&self.def)
+        }
+
+        fn message_description(&self) -> Option<&'static str> {
+            <Def as $def>::message_description(&self.def)
+        }
+    };
+}
+
+/// The `outgoing()` declaration, on the forms that carry one.
+macro_rules! forward_outgoing {
+    ($def:ty) => {
+        fn outgoing(&self) -> Vec<OutgoingMessageMetadata> {
+            <Def as $def>::outgoing(&self.def)
+        }
+    };
+}
+
+impl<Def, Src, State> SubscriberDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: SubscriberDef,
+    Src: Clone,
+{
+    type Input = <Def as SubscriberDef>::Input;
+    type Context = <Def as SubscriberDef>::Context;
+    type Handler = <Def as SubscriberDef>::Handler;
+    type Source = Src;
+
+    forward_common!(SubscriberDef);
+
+    fn into_handler(self) -> <Def as SubscriberDef>::Handler {
+        self.def.into_handler()
+    }
+}
+
+impl<Def, Src, State> BatchDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchDef,
+    Src: Clone,
+{
+    type Input = <Def as BatchDef>::Input;
+    type Handler = <Def as BatchDef>::Handler;
+    type Source = Src;
+
+    forward_common!(BatchDef);
+
+    fn into_handler(self) -> <Def as BatchDef>::Handler {
+        self.def.into_handler()
+    }
+}
+
+impl<Def, Src, State> BatchWithHeadersDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchWithHeadersDef,
+    Src: Clone,
+{
+    type Headers = <Def as BatchWithHeadersDef>::Headers;
+}
+
+impl<Def, Src, State> InjectDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: InjectDef,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    type Input = <Def as InjectDef>::Input;
+    type Context = <Def as InjectDef>::Context;
+    type Source = Src;
+    type Injections = <Def as InjectDef>::Injections;
+
+    forward_common!(InjectDef);
+    forward_outgoing!(InjectDef);
+}
+
+impl<Def, Src, State, S> InjectCall<S> for SubscriberBuilder<Def, Src, State>
+where
+    Def: InjectCall<S>,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    fn call(
+        &self,
+        input: &<<Def as InjectDef>::Input as InputKind>::Target,
+        injections: &<Def as InjectDef>::Injections,
+        ctx: &mut Context<'_, <Def as InjectDef>::Context, S>,
+    ) -> impl Future<Output = Settle> + Send {
+        self.def.call(input, injections, ctx)
+    }
+}
+
+impl<Def, Src, State> PublishingDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: PublishingDef,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    type Input = <Def as PublishingDef>::Input;
+    type Injections = <Def as PublishingDef>::Injections;
+    type Reply = <Def as PublishingDef>::Reply;
+    type Context = <Def as PublishingDef>::Context;
+    type Source = Src;
+
+    forward_common!(PublishingDef);
+    forward_outgoing!(PublishingDef);
+
+    fn reply_name(&self) -> &str {
+        self.def.reply_name()
+    }
+}
+
+impl<Def, Src, State, S> PublishingCall<S> for SubscriberBuilder<Def, Src, State>
+where
+    Def: PublishingCall<S>,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    fn call(
+        &self,
+        input: &<<Def as PublishingDef>::Input as InputKind>::Target,
+        injections: &<Def as PublishingDef>::Injections,
+        ctx: &mut Context<'_, <Def as PublishingDef>::Context, S>,
+    ) -> impl Future<Output = Result<<Def as PublishingDef>::Reply, HandlerResult>> + Send {
+        self.def.call(input, injections, ctx)
+    }
+}
+
+impl<Def, Src, State> BatchInjectDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchInjectDef,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    type Input = <Def as BatchInjectDef>::Input;
+    type Source = Src;
+    type Injections = <Def as BatchInjectDef>::Injections;
+
+    forward_common!(BatchInjectDef);
+    forward_outgoing!(BatchInjectDef);
+}
+
+impl<Def, Src, State, S> BatchInjectCall<S> for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchInjectCall<S>,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    fn call(
+        &self,
+        batch: &[<<Def as BatchInjectDef>::Input as InputKind>::Owned],
+        injections: &<Def as BatchInjectDef>::Injections,
+        ctx: &mut Context<'_, (), S>,
+    ) -> impl Future<Output = BatchResult> + Send {
+        self.def.call(batch, injections, ctx)
+    }
+}
+
+impl<Def, Src, State> BatchPublishingDef for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchPublishingDef,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    type Input = <Def as BatchPublishingDef>::Input;
+    type Injections = <Def as BatchPublishingDef>::Injections;
+    type Reply = <Def as BatchPublishingDef>::Reply;
+    type Source = Src;
+
+    forward_common!(BatchPublishingDef);
+    forward_outgoing!(BatchPublishingDef);
+
+    fn reply_name(&self) -> &str {
+        self.def.reply_name()
+    }
+}
+
+impl<Def, Src, State, S> BatchPublishingCall<S> for SubscriberBuilder<Def, Src, State>
+where
+    Def: BatchPublishingCall<S>,
+    Src: Clone + Send + Sync,
+    State: Send + Sync,
+{
+    fn call(
+        &self,
+        batch: &[<<Def as BatchPublishingDef>::Input as InputKind>::Owned],
+        injections: &<Def as BatchPublishingDef>::Injections,
+        ctx: &mut Context<'_, (), S>,
+    ) -> impl Future<Output = Result<Vec<<Def as BatchPublishingDef>::Reply>, HandlerResult>> + Send
+    {
+        self.def.call(batch, injections, ctx)
+    }
+}
+
+impl<Def: HasSlots, Src, State> HasSlots for SubscriberBuilder<Def, Src, State> {
+    type Markers = Def::Markers;
+}
+
+// Binding the slots instantiates the publisher-generic definition; the settings and the source
+// ride along, so the bound value is the same builder over the bound definition.
+impl<Def, Src, State, C, Sources> BindSlots<C, Sources> for SubscriberBuilder<Def, Src, State>
+where
+    C: ConnectedBroker,
+    Def: BindSlots<C, Sources>,
+{
+    type Bound = SubscriberBuilder<Def::Bound, Src, State>;
+    type Extra = Def::Extra;
+
+    fn bind(self, sources: Sources) -> (Self::Bound, Self::Extra) {
+        let (def, source, workers, failures) = self.into_parts();
+        let (bound, extra) = def.bind(sources);
+        (
+            SubscriberBuilder {
+                def: bound,
+                source,
+                workers,
+                failures,
+                _state: PhantomData,
+            },
+            extra,
+        )
+    }
+}

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -10,7 +10,7 @@
 //! takes a source (a name string or a broker config value), the runtime resolves it once against
 //! the [`ConnectedBroker`] form produced by [`Broker::connect`](crate::Broker::connect).
 
-use std::{borrow::Cow, future::Future};
+use std::{borrow::Cow, future::Future, marker::PhantomData};
 
 use crate::{ConnectedBroker, Seekable, Seeker, Subscribe, Subscriber};
 
@@ -37,6 +37,13 @@ use crate::{ConnectedBroker, Seekable, Seeker, Subscribe, Subscriber};
 ///     source.subscribe(connected).await
 /// }
 /// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not open a subscription on `{C}`",
+    label = "not a subscription source for this broker",
+    note = "a subscriber left unnamed carries `Unnamed<..>` until the mount site names it: \
+            `b.include(handle.name(\"orders\"))`",
+    note = "otherwise the source belongs to a different broker than the one being mounted on"
+)]
 pub trait SubscriptionSource<C: ConnectedBroker> {
     /// The subscriber type this source opens.
     type Subscriber: Subscriber;
@@ -81,6 +88,99 @@ impl Name {
     #[must_use]
     pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
         Self(name.into())
+    }
+}
+
+/// A subscription kind identified by a name and nothing else.
+///
+/// Every source in the broker family is constructed from one string - `new(topic)` for Kafka,
+/// `new(subject)` for NATS, `new(key)` or `new(channel)` for Redis - and this trait says so, so
+/// the mount site can build the kind once the name arrives:
+/// `#[subscriber(RedisStream)]` names the kind and leaves the value to
+/// `b.include(handle.name(subject))`.
+///
+/// A kind that genuinely needs more than a name to exist (a Pulsar source takes a topic *and* a
+/// subscription name) does not implement it, and the name-only attribute form does not compile
+/// for that kind. That is the honest boundary: nothing is ever built from thin air, and no
+/// source needs a `Default` that would make a stream without a key representable.
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::{FromName, Name};
+///
+/// fn build<S: FromName>(name: &'static str) -> S {
+///     S::from_name(name)
+/// }
+///
+/// let source: Name = build("orders");
+/// # let _ = source;
+/// ```
+pub trait FromName {
+    /// Builds the source bound to `name`.
+    #[must_use]
+    fn from_name(name: impl Into<Cow<'static, str>>) -> Self;
+}
+
+impl FromName for Name {
+    fn from_name(name: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(name)
+    }
+}
+
+/// The stand-in a definition carries while its subscription has no name yet.
+///
+/// `#[subscriber]` and `#[subscriber(Kind)]` fix the subscription *kind* and leave its value to
+/// the mount site, so the definition's source starts as `Unnamed<Kind>`. It deliberately
+/// implements no [`SubscriptionSource`]: mounting a definition that was never named is a compile
+/// error, not a startup one. [`name`](crate::runtime::SubscriberSettings::name) replaces it with
+/// the kind itself, built through [`FromName`].
+///
+/// # Examples
+///
+/// ```
+/// use ruststream::{FromName, Name, Unnamed};
+///
+/// let placeholder: Unnamed<Name> = Unnamed::new();
+/// let named: Name = placeholder.into_named("orders");
+/// # let _ = named;
+/// ```
+pub struct Unnamed<S>(PhantomData<fn() -> S>);
+
+impl<S> Unnamed<S> {
+    /// The placeholder for a subscription of kind `S` whose name is still missing.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    /// Builds the subscription kind now that its name is known.
+    #[must_use]
+    pub fn into_named(self, name: impl Into<Cow<'static, str>>) -> S
+    where
+        S: FromName,
+    {
+        S::from_name(name)
+    }
+}
+
+impl<S> Default for Unnamed<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Clone for Unnamed<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S> Copy for Unnamed<S> {}
+
+impl<S> std::fmt::Debug for Unnamed<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Unnamed").finish_non_exhaustive()
     }
 }
 
@@ -137,6 +237,7 @@ impl<C: Subscribe> SubscriptionSource<C> for Name {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Clone)]
 pub struct StartAt<S, P> {
     inner: S,
     position: P,

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -10,7 +10,7 @@
 //! takes a source (a name string or a broker config value), the runtime resolves it once against
 //! the [`ConnectedBroker`] form produced by [`Broker::connect`](crate::Broker::connect).
 
-use std::{borrow::Cow, future::Future, marker::PhantomData};
+use std::{borrow::Cow, fmt, future::Future, marker::PhantomData};
 
 use crate::{ConnectedBroker, Seekable, Seeker, Subscribe, Subscriber};
 
@@ -178,8 +178,8 @@ impl<S> Clone for Unnamed<S> {
 
 impl<S> Copy for Unnamed<S> {}
 
-impl<S> std::fmt::Debug for Unnamed<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<S> fmt::Debug for Unnamed<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Unnamed").finish_non_exhaustive()
     }
 }
@@ -254,8 +254,8 @@ impl<S, P> StartAt<S, P> {
     }
 }
 
-impl<S, P> std::fmt::Debug for StartAt<S, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<S, P> fmt::Debug for StartAt<S, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StartAt").finish_non_exhaustive()
     }
 }

--- a/tests/batch_router_coverage.rs
+++ b/tests/batch_router_coverage.rs
@@ -142,6 +142,7 @@ impl PublishPolicy<ConnectedMemoryBroker> for RefusedPublish {
 }
 
 /// A source whose subscription never opens.
+#[derive(Clone)]
 struct ClosedSource;
 
 impl SubscriptionSource<ConnectedMemoryBroker> for ClosedSource {

--- a/tests/macro_subscriber.rs
+++ b/tests/macro_subscriber.rs
@@ -43,7 +43,9 @@ async fn handle(order: &Order) -> HandlerResult {
 
 /// A broker-specific subscription descriptor (stand-in for e.g. a Redis stream), named by the
 /// definition itself. Proves a macro def works on an arbitrary `SubscriptionSource`, not just a
-/// topic string.
+/// topic string. `Clone` because the mount rebuilds the source from the definition's settings
+/// builder, the way a broker descriptor is cloned per registration.
+#[derive(Clone)]
 struct StreamSource {
     name: String,
 }

--- a/tests/prelude.rs
+++ b/tests/prelude.rs
@@ -39,6 +39,14 @@ async fn confirm(order: &Order, State(seen): State<Arc<AtomicU64>>) -> Confirmat
     Confirmation { id: order.id }
 }
 
+/// A subscription named where the service is wired up, through the settings surface the prelude
+/// has to carry too.
+#[subscriber]
+async fn audit(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    HandlerResult::Ack
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_prelude_carries_a_canonical_service() {
     let seen = Arc::new(AtomicU64::new(0));
@@ -51,6 +59,7 @@ async fn the_prelude_carries_a_canonical_service() {
         .with_broker(MemoryBroker::new(), |b| {
             b.include(confirm)
                 .publisher(TypedPublisher::new(MemoryPublish));
+            b.include(audit.name("orders"));
         });
 
     let test = TestApp::start(app).await.expect("the app should start");

--- a/tests/subscriber_settings.rs
+++ b/tests/subscriber_settings.rs
@@ -52,11 +52,7 @@ async fn a_bare_attribute_is_named_at_the_mount_site() {
         .publish(OutgoingMessage::new(&subject, &order_bytes(11)))
         .await
         .expect("publish failed");
-    wait_for(
-        || !NAMED.lock().unwrap().is_empty(),
-        Duration::from_secs(5),
-    )
-    .await;
+    wait_for(|| !NAMED.lock().unwrap().is_empty(), Duration::from_secs(5)).await;
     assert_eq!(NAMED.lock().unwrap().as_slice(), [11]);
     running.shutdown().await.expect("shutdown failed");
 }
@@ -127,11 +123,7 @@ async fn the_builder_supplies_the_worker_policy() {
             .await
             .expect("publish failed");
     }
-    wait_for(
-        || PEAK.load(Ordering::SeqCst) > 1,
-        Duration::from_secs(5),
-    )
-    .await;
+    wait_for(|| PEAK.load(Ordering::SeqCst) > 1, Duration::from_secs(5)).await;
     running.shutdown().await.expect("shutdown failed");
 }
 
@@ -244,15 +236,7 @@ async fn the_builder_supplies_the_buffer() {
             .expect("publish failed");
     }
     wait_for(
-        || {
-            BUFFERED
-                .lock()
-                .unwrap()
-                .iter()
-                .map(Vec::len)
-                .sum::<usize>()
-                >= 3
-        },
+        || BUFFERED.lock().unwrap().iter().map(Vec::len).sum::<usize>() >= 3,
         Duration::from_secs(5),
     )
     .await;
@@ -279,8 +263,8 @@ async fn a_raw_batch_handler_borrows_the_payloads() {
     let broker = MemoryBroker::new();
     let publisher = broker.publisher();
 
-    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
-        .with_broker(broker, |b| b.include(ingest));
+    let app =
+        RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| b.include(ingest));
     let running = app.start().await.expect("startup failed");
 
     for frame in [b"one".as_slice(), b"two".as_slice()] {
@@ -289,11 +273,7 @@ async fn a_raw_batch_handler_borrows_the_payloads() {
             .await
             .expect("publish failed");
     }
-    wait_for(
-        || FRAMES.lock().unwrap().len() >= 2,
-        Duration::from_secs(5),
-    )
-    .await;
+    wait_for(|| FRAMES.lock().unwrap().len() >= 2, Duration::from_secs(5)).await;
     assert_eq!(
         FRAMES.lock().unwrap().as_slice(),
         [b"one".to_vec(), b"two".to_vec()],

--- a/tests/subscriber_settings.rs
+++ b/tests/subscriber_settings.rs
@@ -1,0 +1,334 @@
+//! Integration tests for the declarative settings a subscriber carries: the ones the attribute
+//! fixes, the ones the mount site fills in through the builder, and the four source forms.
+//!
+//! Apps come up through `start()`, which resolves only after subscriptions are open, so each
+//! message is published exactly once; the tests wait on the handlers' recorded state.
+#![cfg(feature = "macros")]
+
+mod common;
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use common::wait_for;
+use ruststream::memory::{MemoryBroker, MemoryPosition, MemorySource};
+use ruststream::runtime::{
+    AppInfo, FailurePolicies, FailurePolicy, HandlerResult, Router, RustStream, SubscriberSettings,
+};
+use ruststream::{OutgoingMessage, Publisher, nonzero, subscriber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Order {
+    id: u32,
+}
+
+fn order_bytes(id: u32) -> Vec<u8> {
+    serde_json::to_vec(&Order { id }).unwrap()
+}
+
+static NAMED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// The shortest source form: the by-name source with its value left to the mount site.
+#[subscriber]
+async fn audit(order: &Order) -> HandlerResult {
+    NAMED.lock().unwrap().push(order.id);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bare_attribute_is_named_at_the_mount_site() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    // The name is a value the service only knows here, which is the whole point of the form.
+    let subject = format!("audit-{}", 7);
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(broker, |b| b.include(audit.name(subject.clone())));
+    let running = app.start().await.expect("startup failed");
+
+    publisher
+        .publish(OutgoingMessage::new(&subject, &order_bytes(11)))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || !NAMED.lock().unwrap().is_empty(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(NAMED.lock().unwrap().as_slice(), [11]);
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static KIND: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// A named kind carrying only what it needs to exist: the value arrives through the builder,
+/// which constructs it through the kind's own from-name constructor.
+#[subscriber(MemorySource)]
+async fn record(order: &Order) -> HandlerResult {
+    KIND.lock().unwrap().push(order.id);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_named_kind_is_built_from_the_name_the_mount_site_gives() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        // `map_source` is the hook a broker's own settings trait layers on; the identity
+        // transform pins that it composes between the name and the mount.
+        b.include(record.name("record-kind").map_source(|source| source));
+    });
+    let running = app.start().await.expect("startup failed");
+
+    publisher
+        .publish(OutgoingMessage::new("record-kind", &order_bytes(3)))
+        .await
+        .expect("publish failed");
+    wait_for(|| !KIND.lock().unwrap().is_empty(), Duration::from_secs(5)).await;
+    assert_eq!(KIND.lock().unwrap().as_slice(), [3]);
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static CONCURRENT: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+/// The worker policy is left open by the attribute and named at the mount site.
+#[subscriber("workers-from-builder")]
+async fn parallel(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    let in_flight = CONCURRENT.fetch_add(1, Ordering::SeqCst) + 1;
+    PEAK.fetch_max(in_flight, Ordering::SeqCst);
+    // Yield so a second delivery can overlap this one when the pool allows it.
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+    CONCURRENT.fetch_sub(1, Ordering::SeqCst);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_builder_supplies_the_worker_policy() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(broker, |b| b.include(parallel.workers(nonzero!(4))));
+    let running = app.start().await.expect("startup failed");
+
+    for id in 0..4u32 {
+        publisher
+            .publish(OutgoingMessage::new(
+                "workers-from-builder",
+                &order_bytes(id),
+            ))
+            .await
+            .expect("publish failed");
+    }
+    wait_for(
+        || PEAK.load(Ordering::SeqCst) > 1,
+        Duration::from_secs(5),
+    )
+    .await;
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static SKIPPED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// The failure policies are left open by the attribute and named at the mount site.
+#[subscriber("failures-from-builder")]
+async fn tolerant(order: &Order) -> HandlerResult {
+    SKIPPED.lock().unwrap().push(order.id);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_builder_supplies_the_failure_policies() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include(tolerant.on_failure(FailurePolicies::default().with_decode(FailurePolicy::Skip)));
+    });
+    let running = app.start().await.expect("startup failed");
+
+    // The undecodable payload is skipped by the mount-site policy; the next one still arrives.
+    publisher
+        .publish(OutgoingMessage::new(
+            "failures-from-builder",
+            b"not json".as_slice(),
+        ))
+        .await
+        .expect("publish failed");
+    publisher
+        .publish(OutgoingMessage::new(
+            "failures-from-builder",
+            &order_bytes(9),
+        ))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || !SKIPPED.lock().unwrap().is_empty(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(SKIPPED.lock().unwrap().as_slice(), [9]);
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static REPLAYED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// The start position is left open by the attribute and named at the mount site.
+#[subscriber(MemorySource)]
+async fn replay(order: &Order) -> HandlerResult {
+    REPLAYED.lock().unwrap().push(order.id);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_builder_supplies_the_start_position() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+    // Published before the service exists: only a subscription opened at the start sees it.
+    publisher
+        .publish(OutgoingMessage::new("replay", &order_bytes(42)))
+        .await
+        .expect("publish failed");
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include(replay.name("replay").start_at(MemoryPosition::start()));
+    });
+    let running = app.start().await.expect("startup failed");
+
+    wait_for(
+        || !REPLAYED.lock().unwrap().is_empty(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(REPLAYED.lock().unwrap().as_slice(), [42]);
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static BUFFERED: Mutex<Vec<Vec<u32>>> = Mutex::new(Vec::new());
+
+/// A batch shape read off the signature; where the batches come from is settled at the mount.
+#[subscriber]
+async fn correlate(orders: &[Order]) -> HandlerResult {
+    BUFFERED
+        .lock()
+        .unwrap()
+        .push(orders.iter().map(|o| o.id).collect());
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_builder_supplies_the_buffer() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0")).with_broker(broker, |b| {
+        b.include(
+            correlate
+                .name("correlate")
+                .buffered(nonzero!(8), Duration::from_millis(5)),
+        );
+    });
+    let running = app.start().await.expect("startup failed");
+
+    for id in 0..3u32 {
+        publisher
+            .publish(OutgoingMessage::new("correlate", &order_bytes(id)))
+            .await
+            .expect("publish failed");
+    }
+    wait_for(
+        || {
+            BUFFERED
+                .lock()
+                .unwrap()
+                .iter()
+                .map(Vec::len)
+                .sum::<usize>()
+                >= 3
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    let flattened: Vec<u32> = BUFFERED.lock().unwrap().iter().flatten().copied().collect();
+    assert_eq!(flattened, vec![0, 1, 2]);
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static FRAMES: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+
+/// A batch of payloads: the typed batch without the decode step, borrowed from the batch's own
+/// messages.
+#[subscriber("frames")]
+async fn ingest(frames: &[&[u8]]) -> HandlerResult {
+    FRAMES
+        .lock()
+        .unwrap()
+        .extend(frames.iter().map(|f| f.to_vec()));
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_raw_batch_handler_borrows_the_payloads() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(broker, |b| b.include(ingest));
+    let running = app.start().await.expect("startup failed");
+
+    for frame in [b"one".as_slice(), b"two".as_slice()] {
+        publisher
+            .publish(OutgoingMessage::new("frames", frame))
+            .await
+            .expect("publish failed");
+    }
+    wait_for(
+        || FRAMES.lock().unwrap().len() >= 2,
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(
+        FRAMES.lock().unwrap().as_slice(),
+        [b"one".to_vec(), b"two".to_vec()],
+    );
+    running.shutdown().await.expect("shutdown failed");
+}
+
+static ROUTED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// The same surface on the router: `include` takes the settings builder there too.
+#[subscriber]
+async fn routed(order: &Order) -> HandlerResult {
+    ROUTED.lock().unwrap().push(order.id);
+    HandlerResult::Ack
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_router_mounts_the_settings_builder() {
+    let broker = MemoryBroker::new();
+    let publisher = broker.publisher();
+
+    let routes = Router::<MemoryBroker>::new().include(routed.name("routed").workers(nonzero!(2)));
+    let app = RustStream::new(AppInfo::new("svc", "0.1.0"))
+        .with_broker(broker, |b| b.include_router(routes));
+    let running = app.start().await.expect("startup failed");
+
+    publisher
+        .publish(OutgoingMessage::new("routed", &order_bytes(5)))
+        .await
+        .expect("publish failed");
+    wait_for(
+        || !ROUTED.lock().unwrap().is_empty(),
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(ROUTED.lock().unwrap().as_slice(), [5]);
+    running.shutdown().await.expect("shutdown failed");
+}

--- a/tests/ui/out_typed_capability_mismatch.stderr
+++ b/tests/ui/out_typed_capability_mismatch.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `InjectHandler<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, JsonCodec>: Handler<MemoryMessage>` is not satisfied
+error[E0277]: the trait bound `InjectHandler<SubscriberBuilder<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, Name, (Open, Open, Open)>, JsonCodec>: Handler<MemoryMessage>` is not satisfied
   --> tests/ui/out_typed_capability_mismatch.rs:34:55
    |
 34 |         b.include(forward).out(Events, MemoryPublish).mount();
    |                                                       ^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Handler<MemoryMessage>` is not implemented for `InjectHandler<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, JsonCodec>`
+   = help: the trait `Handler<MemoryMessage>` is not implemented for `InjectHandler<SubscriberBuilder<__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>, Name, (Open, Open, Open)>, JsonCodec>`
 help: the trait `Handler<Msg, <Def as InjectDef>::Context, State>` is implemented for `InjectHandler<Def, DecodeCodec>`
   --> src/runtime/inject.rs
    |
@@ -16,7 +16,7 @@ help: the trait `Handler<Msg, <Def as InjectDef>::Context, State>` is implemente
    | |     DecodeCodec: Codec,
    | |     State: Send + Sync,
    | |_______________________^
-   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, forward>`
+   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<forward, Name, (Open, Open, Open)>>`
 note: required by a bound in `IncludeSlots::<'s, Mount, B, Layers, C, State, Pipeline, Def, Slots>::mount`
   --> src/runtime/app/include/slot_builder.rs
    |
@@ -51,7 +51,7 @@ help: the following other types implement trait `RequestReply`
    |   impl RequestReply for MemoryRequester {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MemoryRequester`
    = note: required for `SlotPublisher<MemoryPublisher, Events>` to implement `RequestReply`
-note: required for `__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>` to implement `InjectCall<()>`
+note: required for `__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, JsonCodec>` to implement `InjectDef`
   --> tests/ui/out_typed_capability_mismatch.rs:23:1
    |
 23 | #[subscriber("orders")]
@@ -59,7 +59,7 @@ note: required for `__RsOutDef_forward<SlotPublisher<MemoryPublisher, Events>, J
 ...
 26 |     Out(out): Out<impl RequestReply, Events, Progress>,
    |                        ------------ unsatisfied trait bound introduced here
-   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, forward>`
+   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<forward, Name, (Open, Open, Open)>>`
 note: required by a bound in `IncludeSlots::<'s, Mount, B, Layers, C, State, Pipeline, Def, Slots>::mount`
   --> src/runtime/app/include/slot_builder.rs
    |

--- a/tests/ui/subscriber_batch_without_batching.rs
+++ b/tests/ui/subscriber_batch_without_batching.rs
@@ -1,0 +1,55 @@
+use futures::Stream;
+use ruststream::memory::{ConnectedMemoryBroker, MemoryBroker, MemoryError, MemorySubscriber};
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use ruststream::{Subscribe, Subscriber, SubscriptionSource};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+/// A subscriber with no batching of its own: it forwards single deliveries and stops there.
+struct OneAtATime(MemorySubscriber);
+
+impl Subscriber for OneAtATime {
+    type Message = <MemorySubscriber as Subscriber>::Message;
+    type Error = <MemorySubscriber as Subscriber>::Error;
+
+    fn stream(&mut self) -> impl Stream<Item = Result<Self::Message, Self::Error>> + Send + '_ {
+        self.0.stream()
+    }
+}
+
+#[derive(Clone)]
+struct Trickle {
+    name: &'static str,
+}
+
+impl SubscriptionSource<ConnectedMemoryBroker> for Trickle {
+    type Subscriber = OneAtATime;
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    async fn subscribe(self, connected: &ConnectedMemoryBroker) -> Result<OneAtATime, MemoryError> {
+        Ok(OneAtATime(Subscribe::subscribe(connected, self.name).await?))
+    }
+}
+
+// The signature asks for several messages at once; this subscription delivers one at a time, so
+// the mount asks for the framework's buffer.
+#[subscriber(Trickle { name: "orders" })]
+async fn handle(orders: &[Order]) -> HandlerResult {
+    let _ = orders.len();
+    HandlerResult::Ack
+}
+
+fn main() {
+    let _app =
+        RustStream::new(AppInfo::new("app", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(handle);
+        });
+}

--- a/tests/ui/subscriber_batch_without_batching.stderr
+++ b/tests/ui/subscriber_batch_without_batching.stderr
@@ -1,0 +1,23 @@
+error[E0277]: `OneAtATime` does not deliver messages in batches
+  --> tests/ui/subscriber_batch_without_batching.rs:53:15
+   |
+53 |             b.include(handle);
+   |               ^^^^^^^ this subscription has no batching of its own
+   |
+help: the trait `BatchSubscriber` is not implemented for `OneAtATime`
+  --> tests/ui/subscriber_batch_without_batching.rs:14:1
+   |
+14 | struct OneAtATime(MemorySubscriber);
+   | ^^^^^^^^^^^^^^^^^
+   = note: a handler taking `&[T]` needs batches: add the framework's buffer at the mount site, `b.include(handle.buffered(nonzero!(64), Duration::from_millis(10)))`, or mount the definition on a subscription kind that batches on the wire
+help: the following other types implement trait `BatchSubscriber`
+  --> src/memory/capability.rs
+   |
+   | impl BatchSubscriber for MemorySubscriber {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MemorySubscriber`
+   |
+  ::: src/buffered.rs
+   |
+   | impl<S: Subscriber> BatchSubscriber for BufferedSubscriber<S> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `BufferedSubscriber<S>`
+   = note: required for `Batch` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Trickle, (Open, Open, Open)>>`

--- a/tests/ui/subscriber_bytes_without_raw.rs
+++ b/tests/ui/subscriber_bytes_without_raw.rs
@@ -1,8 +1,0 @@
-use ruststream::subscriber;
-
-// A `&[u8]` parameter without the `raw` flag is ambiguous between a batch of `u8` values and the
-// undecoded payload; the error points at both spellings.
-#[subscriber("frames")]
-async fn handle(frame: &[u8]) {}
-
-fn main() {}

--- a/tests/ui/subscriber_bytes_without_raw.stderr
+++ b/tests/ui/subscriber_bytes_without_raw.stderr
@@ -1,5 +1,0 @@
-error: a slice parameter needs the batch source form: #[subscriber(batch(..))]; for the undecoded payload bytes use #[subscriber(.., raw)]
- --> tests/ui/subscriber_bytes_without_raw.rs:6:25
-  |
-6 | async fn handle(frame: &[u8]) {}
-  |                         ^^^^

--- a/tests/ui/subscriber_name_already_fixed.rs
+++ b/tests/ui/subscriber_name_already_fixed.rs
@@ -1,0 +1,19 @@
+use ruststream::runtime::{HandlerResult, SubscriberSettings};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// The attribute names the subscription, so the builder step that would name it does not apply.
+#[subscriber("orders")]
+async fn handle(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    HandlerResult::Ack
+}
+
+fn main() {
+    let _renamed = handle.name("other");
+}

--- a/tests/ui/subscriber_name_already_fixed.stderr
+++ b/tests/ui/subscriber_name_already_fixed.stderr
@@ -1,0 +1,13 @@
+error[E0277]: this subscriber's subscription is already named
+  --> tests/ui/subscriber_name_already_fixed.rs:18:27
+   |
+18 |     let _renamed = handle.name("other");
+   |                           ^^^^ the name is fixed in the `#[subscriber(..)]` attribute
+   |
+   = help: the trait `NameStep` is not implemented for `SubscriberBuilder<handle, Name, (Open, Open, Open)>`
+   = note: a setting is named once: keep the name in the attribute, or leave the attribute's source open (`#[subscriber]`, `#[subscriber(Kind)]`) and name it here
+help: the trait `NameStep` is implemented for `SubscriberBuilder<Def, Unnamed<S>, State>`
+  --> src/runtime/settings.rs
+   |
+   | impl<Def, S: FromName, State> NameStep for SubscriberBuilder<Def, Unnamed<S>, State> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/subscriber_out_capability_mismatch.stderr
+++ b/tests/ui/subscriber_out_capability_mismatch.stderr
@@ -25,14 +25,14 @@ help: the following other types implement trait `RequestReply`
    |   impl RequestReply for MemoryRequester {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MemoryRequester`
    = note: required for `SlotPublisher<MemoryPublisher, DefaultSlot>` to implement `RequestReply`
-note: required for `__RsOutDef_forward<SlotPublisher<MemoryPublisher, DefaultSlot>, JsonCodec>` to implement `InjectCall<()>`
+note: required for `__RsOutDef_forward<SlotPublisher<MemoryPublisher, DefaultSlot>, JsonCodec>` to implement `InjectDef`
   --> tests/ui/subscriber_out_capability_mismatch.rs:14:1
    |
 14 | #[subscriber("orders")]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 15 | async fn forward(order: &Order, Out(_out): Out<impl RequestReply>) -> HandlerResult {
    |                                                     ------------ unsatisfied trait bound introduced here
-   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, forward>`
+   = note: required for `(ruststream::runtime::WithSource<MemoryPublish>,)` to implement `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<forward, Name, (Open, Open, Open)>>`
 note: required by a bound in `IncludeSlots::<'_, Mount, B, Layers, C, State, Pipeline, Def, (ruststream::runtime::MissingSlot<M>,)>::publisher`
   --> src/runtime/app/include/slot_builder.rs
    |

--- a/tests/ui/subscriber_out_unbound_slot.stderr
+++ b/tests/ui/subscriber_out_unbound_slot.stderr
@@ -4,7 +4,7 @@ error[E0277]: not every Out slot of this handler is bound
 25 |         b.include(transcode).out(Encoded, MemoryPublish).mount();
    |                                                          ^^^^^ the attachment still contains a `MissingSlot<..>` naming the unbound slot
    |
-   = help: the trait `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, transcode>` is not implemented for `(ruststream::runtime::WithSource<MemoryPublish>, ruststream::runtime::MissingSlot<Audit>)`
+   = help: the trait `ruststream::runtime::SlotCommit<runtime::router::mount::InjectMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<transcode, Name, (Open, Open, Open)>>` is not implemented for `(ruststream::runtime::WithSource<MemoryPublish>, ruststream::runtime::MissingSlot<Audit>)`
    = note: bind each remaining slot with .out(marker, policy) before .mount()
    = help: the following other types implement trait `ruststream::runtime::SlotCommit<Mount, B, Layers, C, State, Pipeline, Def>`:
              `(runtime::router::mount::DefaultBareReply, Slots)` implements `ruststream::runtime::SlotCommit<runtime::router::mount::PublishInjectMount, B, Layers, C, State, Pipeline, Def>`

--- a/tests/ui/subscriber_publish_unserializable_reply.stderr
+++ b/tests/ui/subscriber_publish_unserializable_reply.stderr
@@ -15,17 +15,18 @@ help: the trait `ReplySink<Reply, DeliveryCx, Pipeline>` is implemented for `Typ
    | |     ReplyCodec: Codec,
    | |     Transforms: PublishTransform<DeliveryCx>,
    | |_____________________________________________^
-   = note: required for `ruststream::runtime::WithSource<TypedPublisher<MemoryPublish, JsonCodec>>` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
+   = note: required for `ruststream::runtime::WithSource<TypedPublisher<MemoryPublish, JsonCodec>>` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`
    = note: 1 redundant requirement hidden
-   = note: required for `runtime::router::mount::DefaultReply` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
-   = note: required for `Publishing` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
+   = note: required for `runtime::router::mount::DefaultReply` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`
+   = note: required for `Publishing` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`
 
-error[E0277]: the trait bound `PublishingHandler<handle, JsonCodec, TypedPublisher<MemoryPublisher, JsonCodec>>: Handler<MemoryMessage>` is not satisfied
+error[E0277]: the trait bound `PublishingHandler<SubscriberBuilder<handle, Name, (Open, Open, Open)>, JsonCodec, TypedPublisher<MemoryPublisher, JsonCodec>>: Handler<MemoryMessage>` is not satisfied
   --> tests/ui/subscriber_publish_unserializable_reply.rs:23:11
    |
 23 |         b.include(handle);
-   |           ^^^^^^^ the trait `Handler<MemoryMessage>` is not implemented for `PublishingHandler<handle, JsonCodec, TypedPublisher<MemoryPublisher, JsonCodec>>`
+   |           ^^^^^^^ unsatisfied trait bound
    |
+   = help: the trait `Handler<MemoryMessage>` is not implemented for `PublishingHandler<SubscriberBuilder<handle, Name, (Open, Open, Open)>, JsonCodec, TypedPublisher<MemoryPublisher, JsonCodec>>`
 help: the trait `Handler<Msg, <Def as PublishingDef>::Context, State>` is implemented for `PublishingHandler<Def, DecodeCodec, Wiring, Pipeline>`
   --> src/runtime/publishing.rs
    |
@@ -37,7 +38,7 @@ help: the trait `Handler<Msg, <Def as PublishingDef>::Context, State>` is implem
    | |     Pipeline: Send + Sync,
    | |     State: Send + Sync,
    | |_______________________^
-   = note: required for `ruststream::runtime::WithSource<TypedPublisher<MemoryPublish, JsonCodec>>` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
+   = note: required for `ruststream::runtime::WithSource<TypedPublisher<MemoryPublish, JsonCodec>>` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`
    = note: 1 redundant requirement hidden
-   = note: required for `runtime::router::mount::DefaultReply` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
-   = note: required for `Publishing` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
+   = note: required for `runtime::router::mount::DefaultReply` to implement `runtime::app::include::commit::CommitVia<runtime::router::mount::PublishMount, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`
+   = note: required for `Publishing` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Name, (Open, Open, Open)>>`

--- a/tests/ui/subscriber_raw_batch.rs
+++ b/tests/ui/subscriber_raw_batch.rs
@@ -1,6 +1,7 @@
 use ruststream::subscriber;
 
-// `raw` takes one delivery's payload; it does not combine with the batch source form.
+// A raw batch is the typed batch without the decode step, so its handler takes the whole batch's
+// payloads; `&[u8]` is one delivery's payload, which is a different shape.
 #[subscriber(batch("frames"), raw)]
 async fn handle(frames: &[u8]) {}
 

--- a/tests/ui/subscriber_raw_batch.stderr
+++ b/tests/ui/subscriber_raw_batch.stderr
@@ -1,5 +1,5 @@
-error: raw is not supported together with batch(..); a raw handler takes one delivery's payload as `&[u8]`
- --> tests/ui/subscriber_raw_batch.rs:4:31
+error: a raw batch handler takes the batch's payloads as a slice of byte slices: `&[&[u8]]`
+ --> tests/ui/subscriber_raw_batch.rs:6:26
   |
-4 | #[subscriber(batch("frames"), raw)]
-  |                               ^^^
+6 | async fn handle(frames: &[u8]) {}
+  |                          ^^^^

--- a/tests/ui/subscriber_raw_encoded_publish.stderr
+++ b/tests/ui/subscriber_raw_encoded_publish.stderr
@@ -1,5 +1,5 @@
 error: the reply of a raw handler is bytes and is never encoded; use publish_raw("dest") instead of publish(..)
- --> tests/ui/subscriber_raw_encoded_publish.rs:5:24
+ --> tests/ui/subscriber_raw_encoded_publish.rs:5:37
   |
 5 | #[subscriber("frames", raw, publish("out"))]
-  |                        ^^^
+  |                                     ^^^^^

--- a/tests/ui/subscriber_raw_on_failure_decode.stderr
+++ b/tests/ui/subscriber_raw_on_failure_decode.stderr
@@ -1,5 +1,5 @@
-error: on_failure(decode = ..) does not apply to raw: the payload is not decoded and there is no FromHeaders parameter; keep only on_failure(panic = ..)
- --> tests/ui/subscriber_raw_on_failure_decode.rs:4:24
+error: on_failure(decode = ..) does not apply to an undecoded payload: this handler takes the bytes as delivered and declares no FromHeaders parameter; keep only on_failure(panic = ..)
+ --> tests/ui/subscriber_raw_on_failure_decode.rs:5:17
   |
-4 | #[subscriber("frames", raw, on_failure(decode = drop))]
-  |                        ^^^
+5 | async fn handle(frame: &[u8]) {}
+  |                 ^^^^^^^^^^^^

--- a/tests/ui/subscriber_raw_typed_param.stderr
+++ b/tests/ui/subscriber_raw_typed_param.stderr
@@ -1,4 +1,4 @@
-error: a raw subscriber receives the payload bytes: make the message parameter `&[u8]`, or drop `raw` to decode into a typed value
+error: a raw subscriber receives the payload bytes: make the message parameter `&[u8]` (or `&[&[u8]]` for a batch of payloads), or drop `raw` to decode into a typed value
  --> tests/ui/subscriber_raw_typed_param.rs:6:25
   |
 6 | async fn handle(frame: &String) {}

--- a/tests/ui/subscriber_seek_wrong_seeker.stderr
+++ b/tests/ui/subscriber_seek_wrong_seeker.stderr
@@ -5,4 +5,4 @@ error[E0271]: type mismatch resolving `<MemorySubscriber as Seekable>::Seeker ==
    |           ^^^^^^^ expected `ForeignSeeker`, found `MemorySeeker`
    |
    = note: required for `(ruststream::prelude::Seek<ForeignSeeker>,)` to implement `FromStartup<MemoryBroker, MemorySubscriber, ((),)>`
-   = note: required for `ruststream::runtime::forms::Seek` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, handle>`
+   = note: required for `ruststream::runtime::forms::Seek` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, MemorySource, (Open, Open, Open)>>`

--- a/tests/ui/subscriber_unnamed_mount.rs
+++ b/tests/ui/subscriber_unnamed_mount.rs
@@ -1,0 +1,23 @@
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, HandlerResult, RustStream};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// A bare attribute is the by-name source with its value left out, so the definition is not
+// mountable until the mount site names it.
+#[subscriber]
+async fn handle(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    HandlerResult::Ack
+}
+
+fn main() {
+    RustStream::new(AppInfo::new("app", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(handle);
+    });
+}

--- a/tests/ui/subscriber_unnamed_mount.stderr
+++ b/tests/ui/subscriber_unnamed_mount.stderr
@@ -1,0 +1,15 @@
+error[E0277]: `Unnamed<Name>` does not open a subscription on `ConnectedMemoryBroker`
+  --> tests/ui/subscriber_unnamed_mount.rs:21:11
+   |
+21 |         b.include(handle);
+   |           ^^^^^^^ not a subscription source for this broker
+   |
+   = help: the trait `SubscriptionSource<ConnectedMemoryBroker>` is not implemented for `Unnamed<Name>`
+   = note: a subscriber left unnamed carries `Unnamed<..>` until the mount site names it: `b.include(handle.name("orders"))`
+   = note: otherwise the source belongs to a different broker than the one being mounted on
+help: the trait `SubscriptionSource<ConnectedMemoryBroker>` is implemented for `MemorySource`
+  --> src/memory/mod.rs
+   |
+   | impl SubscriptionSource<ConnectedMemoryBroker> for MemorySource {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: required for `Subscribing` to implement `runtime::app::include::IncludeMount<'_, MemoryBroker, Identity, (), (), PublishIdentity, SubscriberBuilder<handle, Unnamed<Name>, (Open, Open, Open)>>`

--- a/tests/ui/subscriber_workers_already_fixed.rs
+++ b/tests/ui/subscriber_workers_already_fixed.rs
@@ -1,0 +1,20 @@
+use ruststream::nonzero;
+use ruststream::runtime::{HandlerResult, SubscriberSettings};
+use ruststream::subscriber;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// The attribute fixes the worker policy, so the mount site cannot disagree with it.
+#[subscriber("orders", workers(2))]
+async fn handle(order: &Order) -> HandlerResult {
+    let _ = order.id;
+    HandlerResult::Ack
+}
+
+fn main() {
+    let _widened = handle.workers(nonzero!(4));
+}

--- a/tests/ui/subscriber_workers_already_fixed.stderr
+++ b/tests/ui/subscriber_workers_already_fixed.stderr
@@ -1,0 +1,13 @@
+error[E0277]: this subscriber's worker policy is already fixed
+  --> tests/ui/subscriber_workers_already_fixed.rs:19:27
+   |
+19 |     let _widened = handle.workers(nonzero!(4));
+   |                           ^^^^^^^ `workers(..)` is named in the `#[subscriber(..)]` attribute
+   |
+   = help: the trait `WorkersStep` is not implemented for `SubscriberBuilder<handle, Name, (Fixed, Open, Open)>`
+   = note: a setting is named once: keep `workers(..)` in the attribute, or drop it there and name the policy here
+help: the trait `WorkersStep` is implemented for `SubscriberBuilder<Def, Src, (Open, F, P)>`
+  --> src/runtime/settings.rs
+   |
+   | impl<Def, Src, F, P> WorkersStep for SubscriberBuilder<Def, Src, (Open, F, P)> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

Everything declarative about a subscriber could be said in one place only, the attribute, so a
setting the service knows only while it wires itself up had no path in at all. And the macro was
the only implementation of those settings, which left a user who wants to build a subscriber
programmatically with nothing to build it with.

The declarative settings - name, worker policy, failure policies, start position, the framework's
buffer - now live on a builder over the generated definition, which both registration surfaces
accept wherever they accept a definition. The attribute expands into that same builder, so a
setting has one implementation and the attribute is sugar over it rather than a parallel path.

Which settings a builder still accepts is carried in its type: one step trait per setting,
implemented only for the state where that setting is still open. There is no precedence rule to
remember - naming a setting twice does not compile, and each step carries its own message saying
so. A definition whose subscription was never named is not mountable by the same mechanism.

The attribute always fixes the subscription *kind*, in one of four forms from an empty attribute
up to a fully spelled-out source; what may be deferred is the value that fills it. The two short
forms rest on a small core trait giving a kind its own from-name constructor, so nothing is ever
built from thin air, and a kind that genuinely needs more than a name simply does not offer it.
Broker-specific settings arrive through a broker-owned trait layered over a core source-transform
hook, the same extension shape the `Out` slot vocabulary already uses.

The second kind of information the attribute carried - the shape of the handler - is read off the
signature, which is the only place it was ever really written: one message, one delivery's
payload, a whole decoded batch, or a batch of payloads. That last one is new: a raw batch is the
typed batch without the decode step, with the payloads borrowed from the batch's own messages.
Whether batches arrive at all is a property of the broker, so it is settled where the definition
is mounted, and the batching capability now says which fix applies when the subscription has no
batching of its own.

Fixes #234

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable

## Notes for the reviewer

Decisions the issue left open, taken here:

- **A subscription source is now `Clone`.** The mount rebuilds the source from the builder rather
  than re-evaluating the attribute's expression, so a broker descriptor used with `#[subscriber]`
  derives `Clone`. It is configuration, and cloning it is what lets one definition mount on two
  brokers; documented in the broker-authors guide.
- **The failure policies are one setting, not two.** An `on_failure(..)` clause naming only
  `decode` still closes the whole slot. Splitting the panic and materialization keys into separate
  slots would double the state without a case asking for it.
- **The materialization policy travels on the delivery context.** A `FromHeaders` contract is
  parsed in the handler body, so the macro used to interpolate the attribute's `decode` policy
  there; it now reads the effective policy off the context, which is what makes a policy named on
  the builder apply to the header contract as well.
- **A raw batch does not take `Out` / `Seek` yet.** The combination needs a parallel injection
  path at the byte shape; the macro rejects it with a message naming the alternatives rather than
  landing a half-shape.
- **The retiring clauses keep their meaning while they parse.** `batch(..)` still says "this
  slice is a batch", so a batch of `u8` stays expressible; without it a `&[u8]` parameter reads as
  the payload, which is what nobody would mean otherwise. `raw` with `batch(..)` now asks for
  `&[&[u8]]` instead of being rejected outright.
- **Double buffering stays legal.** Refusing a second wrap would need a negative bound, the same
  reason the issue gives for wrapping a natively batching subscription.