### PR TITLE
feat: report a missing Serialize derive through serde's own guidance

### DIFF
--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -401,7 +401,7 @@ where
 impl<Sink, T, Enc, Hdrs, Dest> Publish<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>
 where
     Sink: PublishSink,
-    T: OutgoingDestination + MessageHeaders + Serialize + Sync,
+    T: OutgoingDestination + MessageHeaders + Sync,
     Enc: PublishCodec,
     Hdrs: PublishHeaders,
 {
@@ -416,11 +416,13 @@ where
     ///
     /// As cancel-safe as the sink's own send: dropping the future mid-flight may leave the
     /// message in an indeterminate state.
-    // The two position bounds sit on the method, not on the impl block: a bound the impl block
-    // carries makes an under-specified publish "method not found", which drops the guidance
-    // these traits declare, while a bound the method carries reports it.
+    // The position bounds and the encodability of the value sit on the method, not on the impl
+    // block: a bound the impl block carries makes an under-specified publish "method not found",
+    // which drops the guidance these traits declare - serde's own note about the missing derive
+    // included - while a bound the method carries reports it.
     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
     where
+        T: Serialize,
         Hdrs: SatisfiesContract<T::Contract>,
         Dest: ResolvedName,
     {

--- a/tests/ui/publish_missing_headers.stderr
+++ b/tests/ui/publish_missing_headers.stderr
@@ -17,7 +17,7 @@ note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'
    |
    |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
    |                  ------- required by a bound in this associated function
-   |     where
+...
    |         Hdrs: SatisfiesContract<T::Contract>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
 
@@ -45,7 +45,7 @@ note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'
    |
    |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
    |                  ------- required by a bound in this associated function
-   |     where
+...
    |         Hdrs: SatisfiesContract<T::Contract>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
 
@@ -68,6 +68,6 @@ note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'
    |
    |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
    |                  ------- required by a bound in this associated function
-   |     where
+...
    |         Hdrs: SatisfiesContract<T::Contract>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`

--- a/tests/ui/publish_missing_serialize.rs
+++ b/tests/ui/publish_missing_serialize.rs
@@ -1,0 +1,30 @@
+use ruststream::runtime::{HandlerResult, Out};
+use ruststream::{OutSlot, Outgoing, Publisher, subscriber};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Order {
+    id: u32,
+}
+
+// The address is declared and the type carries no headers contract, so the publish is complete
+// as written; what is missing is the `Serialize` derive that lets the codec encode it.
+#[derive(Outgoing)]
+#[outgoing(name = "orders.archived")]
+struct Archived {
+    id: u32,
+}
+
+#[derive(OutSlot)]
+#[publishes(Archived)]
+struct Events;
+
+// Publishing a value the codec cannot encode does not compile, and the rejection carries serde's
+// own guidance about the missing derive rather than reading as a missing method.
+#[subscriber("orders")]
+async fn forward(order: &Order, Out(out): Out<impl Publisher, Events, Archived>) -> HandlerResult {
+    let _ = out.message(&Archived { id: order.id }).publish().await;
+    HandlerResult::Ack
+}
+
+fn main() {}

--- a/tests/ui/publish_missing_serialize.stderr
+++ b/tests/ui/publish_missing_serialize.stderr
@@ -1,0 +1,95 @@
+error[E0277]: the trait bound `Archived: serde::Serialize` is not satisfied
+  --> tests/ui/publish_missing_serialize.rs:26:53
+   |
+26 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |                                                     ^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `_serde::Serialize` is not implemented for `Archived`
+  --> tests/ui/publish_missing_serialize.rs:14:1
+   |
+14 | struct Archived {
+   | ^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Archived` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `_serde::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         T: Serialize,
+   |            ^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: the trait bound `Archived: serde::Serialize` is not satisfied
+  --> tests/ui/publish_missing_serialize.rs:26:13
+   |
+26 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `_serde::Serialize` is not implemented for `Archived`
+  --> tests/ui/publish_missing_serialize.rs:14:1
+   |
+14 | struct Archived {
+   | ^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Archived` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `_serde::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         T: Serialize,
+   |            ^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+
+error[E0277]: the trait bound `Archived: serde::Serialize` is not satisfied
+  --> tests/ui/publish_missing_serialize.rs:26:63
+   |
+26 |     let _ = out.message(&Archived { id: order.id }).publish().await;
+   |                                                               ^^^^^ unsatisfied trait bound
+   |
+help: the trait `_serde::Serialize` is not implemented for `Archived`
+  --> tests/ui/publish_missing_serialize.rs:14:1
+   |
+14 | struct Archived {
+   | ^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Archived` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `_serde::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+note: required by a bound in `ruststream::runtime::Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`
+  --> src/runtime/publish/builder.rs
+   |
+   |     pub async fn publish(self) -> Result<(), PublishError<Sink::Error>>
+   |                  ------- required by a bound in this associated function
+   |     where
+   |         T: Serialize,
+   |            ^^^^^^^^^ required by this bound in `Publish::<Sink, MessageBody<'_, T>, Enc, Hdrs, Dest>::publish`


### PR DESCRIPTION
# Description

Moves the `Serialize` bound on the typed publish terminal from its impl block into the method's
own `where` clause, so a forgotten derive reports as an unsatisfied bound carrying serde's own
guidance instead of as a missing method. Adds the compile-fail case, which had none.

Fixes #240

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site) - none
      needed: no API changes, only the diagnostic text, which no page quotes
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`, and the UI snapshots with `RUN_UI_TESTS=1`)
