### PR TITLE
feat: report an unbound address placeholder through its own guidance

### DIFF
--- a/crates/ruststream-macros/src/outgoing.rs
+++ b/crates/ruststream-macros/src/outgoing.rs
@@ -275,7 +275,7 @@ fn parse_template(literal: &LitStr) -> syn::Result<Template> {
 }
 
 /// The generated address builder of a templated name: one setter per placeholder, and a publish
-/// terminal that exists only once every one of them is bound.
+/// terminal callable only once every one of them is bound.
 fn template_builder(
     name: &Ident,
     vis: &syn::Visibility,
@@ -329,7 +329,9 @@ fn template_builder(
         .enumerate()
         .map(|(index, placeholder)| setter(index, placeholder, &markers, &fields, &states));
 
-    let bound = fields.iter().map(|_| quote!(::std::string::String));
+    let bound = states
+        .iter()
+        .map(|state| quote!(#state: ::ruststream::runtime::BoundSegment));
     let format_string = template.format_string();
     let format_args = fields.iter().map(|field| quote!(self.#field));
     let (_, ty_generics, _) = generics.split_for_impl();
@@ -349,8 +351,8 @@ fn template_builder(
 
             /// One publish whose templated address is being bound, segment by segment.
             ///
-            /// The publish terminal appears once every placeholder is bound; until then the
-            /// unbound ones ride in this type, so the compile error names them.
+            /// The publish terminal is callable once every placeholder is bound; until then
+            /// the unbound ones ride in this type, so the compile error names them.
             #[must_use = "an address builder does nothing until publish() is awaited"]
             pub struct To<Cont #(, #states)*> {
                 pub(super) cont: Cont,
@@ -366,7 +368,7 @@ fn template_builder(
 
             #(#setters)*
 
-            impl<Cont> To<Cont #(, #bound)*> {
+            impl<Cont #(, #states)*> To<Cont #(, #states)*> {
                 /// Renders the declared name with the bound segments and publishes to it.
                 ///
                 /// # Errors
@@ -374,9 +376,11 @@ fn template_builder(
                 /// Returns [`PublishError`](::ruststream::runtime::PublishError) when the
                 /// payload cannot be encoded, the typed headers cannot be serialized, or the
                 /// broker rejects the message.
-                // The bound sits on the method, not on the impl block: carried by the block it
-                // turns a publish the message's own declarations reject into "method not
-                // found", which drops the guidance those declarations come with.
+                // Every bound sits on the method, not on the impl block: on the block they
+                // turn a publish the message's own declarations reject into "method not
+                // found", which drops the guidance those declarations come with. The segment
+                // witnesses are here for the same reason, so a forgotten placeholder is
+                // reported by the witness instead of by the terminal being absent.
                 pub async fn publish(
                     self,
                 ) -> ::core::result::Result<
@@ -387,6 +391,7 @@ fn template_builder(
                 >
                 where
                     Cont: ::ruststream::runtime::PublishAt,
+                    #(#bound,)*
                 {
                     // A templated address is rendered per publish: that allocation is what
                     // computing an address at run time costs, and the fixed form avoids it.

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -142,8 +142,9 @@ The declaration decides which destination position the call site has:
 - **A fixed name** resolves the destination, so there is no `to(..)` to write - and no way to
   send that type somewhere the document does not mention.
 - **A name template** (`"orders.{tenant}.placed"`) opens `to()`, which returns a builder with one
-  setter per placeholder. `publish()` appears only once every placeholder is bound, and an
-  unbound one rides in the builder's type, so the compile error names the segment. The address is
+  setter per placeholder. `publish()` compiles only once every placeholder is bound, and an
+  unbound one rides in the builder's type, so the compile error states that the address is
+  unfinished and names the segment that was forgotten. The address is
   rendered per publish, which is what computing a destination at run time costs; a fixed name
   keeps publishing from a `&'static str`.
 - **No `name` at all** means the call site names it: `.to("orders.archived")`, taking a `&str` or

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -65,14 +65,14 @@ pub use lifecycle::ConnectedSlot;
 pub use metadata::{HandlerMetadata, OutgoingMessageMetadata};
 pub use middleware::{BlanketLayer, HandlerExt, Identity, Layer, Stack, layers};
 pub use publish::{
-    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, CallCodec, ForBatch,
-    HeadersUnset, MapHeaders, MessageBody, MissingSegment, Outgoing, Publish, PublishAt,
-    PublishCodec, PublishContext, PublishDynLayer, PublishDynNext, PublishDynStack, PublishError,
-    PublishExt, PublishHeaders, PublishIdentity, PublishLayer, PublishNext, PublishPipeline,
-    PublishSink, PublishStack, PublishTransform, PublishTransformIdentity, PublishTransformStack,
-    RawBody, ReplyPublisher, ReplyWiring, ResolvedName, SatisfiesContract, SuppliedName,
-    TemplateAddress, TransactionPublishError, TransactionScope, Transactional, TypedHeaders,
-    TypedPublisher, TypedTransaction, for_batch,
+    BatchPublishTransform, BatchPublishTransformStack, BatchTransformIdentity, BoundSegment,
+    CallCodec, ForBatch, HeadersUnset, MapHeaders, MessageBody, MissingSegment, Outgoing, Publish,
+    PublishAt, PublishCodec, PublishContext, PublishDynLayer, PublishDynNext, PublishDynStack,
+    PublishError, PublishExt, PublishHeaders, PublishIdentity, PublishLayer, PublishNext,
+    PublishPipeline, PublishSink, PublishStack, PublishTransform, PublishTransformIdentity,
+    PublishTransformStack, RawBody, ReplyPublisher, ReplyWiring, ResolvedName, SatisfiesContract,
+    SuppliedName, TemplateAddress, TransactionPublishError, TransactionScope, Transactional,
+    TypedHeaders, TypedPublisher, TypedTransaction, for_batch,
 };
 pub use publish_source::{Bindable, Bound, BrokerRegistration};
 pub use publisher_registry::ErasedPublisher;

--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -347,6 +347,21 @@ impl<S> MissingSegment<S> {
     }
 }
 
+/// One address placeholder that carries a value, and so can be rendered into the destination.
+///
+/// The publish terminal of a generated address builder takes this witness once per placeholder,
+/// so an address with a placeholder still in its [`MissingSegment`] state is rejected by a bound
+/// the compiler can explain rather than by the terminal not existing. Implemented for the bound
+/// representation only; you never implement it by hand.
+#[diagnostic::on_unimplemented(
+    message = "this address still has an unbound placeholder",
+    note = "a name template opens one setter per placeholder, and the publish appears once \
+            every one of them is bound"
+)]
+pub trait BoundSegment: fmt::Display {}
+
+impl BoundSegment for String {}
+
 /// A publish whose destination is rendered by a generated address builder.
 ///
 /// The terminal a templated `to()` chain calls once every placeholder is bound; the rendered

--- a/src/runtime/publish/mod.rs
+++ b/src/runtime/publish/mod.rs
@@ -106,9 +106,9 @@ mod transaction;
 mod transform;
 
 pub use builder::{
-    HeadersUnset, MapHeaders, MessageBody, MissingSegment, Publish, PublishAt, PublishError,
-    PublishHeaders, RawBody, ResolvedName, SatisfiesContract, SuppliedName, TemplateAddress,
-    TypedHeaders,
+    BoundSegment, HeadersUnset, MapHeaders, MessageBody, MissingSegment, Publish, PublishAt,
+    PublishError, PublishHeaders, RawBody, ResolvedName, SatisfiesContract, SuppliedName,
+    TemplateAddress, TypedHeaders,
 };
 pub(crate) use builder::{message_of, raw_of};
 pub use ext::PublishExt;

--- a/tests/ui/publish_template_missing_headers.stderr
+++ b/tests/ui/publish_template_missing_headers.stderr
@@ -13,11 +13,11 @@ help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented 
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
    = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
-note: required by a bound in `To::<Cont, String>::publish`
+note: required by a bound in `To::<Cont, S0>::publish`
   --> tests/ui/publish_template_missing_headers.rs:15:10
    |
 15 | #[derive(Outgoing, Serialize)]
-   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0>::publish`
    = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the headers of this publish do not match the message's `WithHeaders<PlacedMeta>` contract
@@ -40,11 +40,11 @@ help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented 
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
    = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
-note: required by a bound in `To::<Cont, String>::publish`
+note: required by a bound in `To::<Cont, S0>::publish`
   --> tests/ui/publish_template_missing_headers.rs:15:10
    |
 15 | #[derive(Outgoing, Serialize)]
-   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0>::publish`
    = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the headers of this publish do not match the message's `WithHeaders<PlacedMeta>` contract
@@ -62,9 +62,9 @@ help: the trait `SatisfiesContract<WithHeaders<PlacedMeta>>` is not implemented 
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `NoHeaders`, found `WithHeaders<PlacedMeta>`
    = note: required for `ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>` to implement `PublishAt`
-note: required by a bound in `To::<Cont, String>::publish`
+note: required by a bound in `To::<Cont, S0>::publish`
   --> tests/ui/publish_template_missing_headers.rs:15:10
    |
 15 | #[derive(Outgoing, Serialize)]
-   |          ^^^^^^^^ required by this bound in `To::<Cont, String>::publish`
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0>::publish`
    = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/publish_unbound_segment.stderr
+++ b/tests/ui/publish_unbound_segment.stderr
@@ -1,25 +1,61 @@
-error[E0599]: no method named `publish` found for struct `To<ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>, String, MissingSegment<Region>>` in the current scope
+error[E0277]: this address still has an unbound placeholder
   --> tests/ui/publish_unbound_segment.rs:29:10
    |
-11 |   #[derive(Outgoing, Serialize)]
-   |            -------- method `publish` not found for this struct
-...
+29 |         .publish()
+   |          ^^^^^^^ the trait `BoundSegment` is not implemented for `MissingSegment<Region>`
+   |
+   = note: a name template opens one setter per placeholder, and the publish appears once every one of them is bound
+help: the trait `BoundSegment` is implemented for `String`
+  --> src/runtime/publish/builder.rs
+   |
+   | impl BoundSegment for String {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `To::<Cont, S0, S1>::publish`
+  --> tests/ui/publish_unbound_segment.rs:11:10
+   |
+11 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0, S1>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: this address still has an unbound placeholder
+  --> tests/ui/publish_unbound_segment.rs:25:13
+   |
 25 |       let _ = out
-   |  _____________-
+   |  _____________^
 26 | |         .message(&Placed { id: order.id })
 27 | |         .to()
 28 | |         .tenant("acme")
 29 | |         .publish()
-   | |         -^^^^^^^ method not found in `To<ruststream::runtime::Publish<&__RsOut0, MessageBody<'_, Placed>, &__RsOutCodec0, HeadersUnset, NameTemplate>, String, MissingSegment<Region>>`
-   | |_________|
+   | |__________________^ the trait `BoundSegment` is not implemented for `MissingSegment<Region>`
    |
+   = note: a name template opens one setter per placeholder, and the publish appears once every one of them is bound
+help: the trait `BoundSegment` is implemented for `String`
+  --> src/runtime/publish/builder.rs
    |
-   = note: the method was found for `To<Cont, String, String>`
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following traits define an item `publish`, perhaps you need to implement one of them:
-           candidate #1: `Publisher`
-           candidate #2: `Transaction`
-help: one of the expressions' fields has a method of the same name
+   | impl BoundSegment for String {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `To::<Cont, S0, S1>::publish`
+  --> tests/ui/publish_unbound_segment.rs:11:10
    |
-29 |         .cont.publish()
-   |          +++++
+11 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0, S1>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: this address still has an unbound placeholder
+  --> tests/ui/publish_unbound_segment.rs:30:10
+   |
+30 |         .await;
+   |          ^^^^^ the trait `BoundSegment` is not implemented for `MissingSegment<Region>`
+   |
+   = note: a name template opens one setter per placeholder, and the publish appears once every one of them is bound
+help: the trait `BoundSegment` is implemented for `String`
+  --> src/runtime/publish/builder.rs
+   |
+   | impl BoundSegment for String {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `To::<Cont, S0, S1>::publish`
+  --> tests/ui/publish_unbound_segment.rs:11:10
+   |
+11 | #[derive(Outgoing, Serialize)]
+   |          ^^^^^^^^ required by this bound in `To::<Cont, S0, S1>::publish`
+   = note: this error originates in the derive macro `Outgoing` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Description

Adds the witness trait over address-segment states and moves the generated terminal's bound onto
the method, so a publish with an unbound placeholder states what is missing instead of reporting a
method that does not exist. The stray suggestion to reach into the wrapper's field goes with it.

The trait carries `Display` as a supertrait rather than being an empty marker: the terminal renders
the bound segments into the address, and once those fields are generic that rendering needs a
bound. This is the one shape decision the issue did not settle.

Fixes #239

## Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`); the compile-fail snapshot covering this
      case is updated rather than added
