### PR TITLE
chore: guard the dependency and feature promises in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: cargo clippy
         if: matrix.toolchain == 'stable'
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
       # The same lint set six weeks early, and deliberately not a gate. A clippy release
       # adds lints, and the workspace warns on whole groups, so a new lint turns into a red
@@ -98,13 +98,13 @@ jobs:
       - name: cargo clippy (beta, advisory)
         if: matrix.toolchain == 'beta'
         continue-on-error: true
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
       - name: cargo check (no default features)
-        run: cargo check --workspace --no-default-features
+        run: cargo check --locked --workspace --no-default-features
 
       - name: cargo check (all features)
-        run: cargo check --workspace --all-targets --all-features
+        run: cargo check --locked --workspace --all-targets --all-features
 
       # The `DefaultCodec` fallback aliases (cbor, then msgpack) are cfg'd out whenever `json` is
       # on, so neither the all-features build nor the all-features tests ever compile them. Build
@@ -112,8 +112,8 @@ jobs:
       - name: cargo check (single-codec default fallbacks)
         if: matrix.toolchain == 'stable'
         run: |
-          cargo check --no-default-features --features cbor,memory,macros
-          cargo check --no-default-features --features msgpack,memory,macros
+          cargo check --locked --no-default-features --features cbor,memory,macros
+          cargo check --locked --no-default-features --features msgpack,memory,macros
 
       # The trybuild UI snapshots in tests/ui are rustc-version-sensitive, so they
       # run on stable only: RUN_UI_TESTS=1 opts the `ui` test in here, every other
@@ -130,7 +130,7 @@ jobs:
           RUN_SCAFFOLD_BUILD: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
         # --no-fail-fast: a failing target must not hide failures in the targets behind it;
         # the log then lists every red test, not just the first binary's.
-        run: cargo test --workspace --all-features --no-fail-fast
+        run: cargo test --locked --workspace --all-features --no-fail-fast
 
       # The suite above compiles every doc example with all features on, which hides an example
       # that names a feature-gated item without gating itself: it then fails for the user who
@@ -139,8 +139,8 @@ jobs:
       - name: cargo test --doc (feature edges)
         if: matrix.toolchain == 'stable'
         run: |
-          cargo test --workspace --doc
-          cargo test --workspace --doc --no-default-features
+          cargo test --locked --workspace --doc
+          cargo test --locked --workspace --doc --no-default-features
 
       # The crate-root missing_docs deny covers item docs; this gate catches what rustc
       # cannot: broken intra-doc links and redundant targets only rustdoc resolves.
@@ -148,7 +148,127 @@ jobs:
         if: matrix.toolchain == 'stable'
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --workspace --all-features --no-deps
+        run: cargo doc --locked --workspace --all-features --no-deps
+
+  features:
+    name: Each feature alone
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2.86.1
+        with:
+          tool: cargo-hack
+
+      # The whole public surface sits behind additive features, and the matrix above builds only
+      # the two ends of the range, so a feature that stops compiling on its own reaches a release
+      # and fails for the first user who enables it alone. This is a guard, not a fix: it finds
+      # nothing today, and that is the expected result.
+      #
+      # --no-dev-deps matters: with dev-dependencies in scope, a missing feature gate in the
+      # library is masked by a dependency that some test happens to pull in.
+      #
+      # --locked is deliberately absent here, and only here. --no-dev-deps rewrites the manifests
+      # in place, which makes cargo want to rewrite the lock file, and --locked forbids exactly
+      # that. Every other job in this workflow keeps the lock honest.
+      - name: cargo hack check (each feature)
+        run: cargo hack check --workspace --each-feature --no-dev-deps
+
+  minimal-versions:
+    name: Minimal versions
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install nightly (resolver only)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # A requirement in Cargo.toml is a lower bound and a claim that the crate works from that
+      # version up, and cargo resolving to the newest compatible release means the claim is never
+      # exercised. Resolve the other way instead.
+      #
+      # The full -Z minimal-versions is used rather than -Z direct-minimal-versions on purpose:
+      # the narrow flag checks only this crate's own bounds and leaves the assembled graph
+      # unverified, and it is the assembled graph a user builds. The cost is the pinning list
+      # below, which grows by a line whenever a third-party manifest declares a bound that is too
+      # loose. Each line names the dependency and why it had to move back up.
+      - name: Resolve minimal versions
+        run: cargo +nightly update -Z minimal-versions
+
+      # termcolor: trybuild 1.0.0 asks for `termcolor = "1.0"` but its banner code copies a `Color`
+      # out of a slice, and `Color` is only `Copy` from termcolor 1.0.4 on. A too-loose bound in a
+      # third-party manifest, not in ours. Remove this line if trybuild's floor here ever moves
+      # above 1.0.0.
+      - name: Pin dependencies whose declared bounds are too loose
+        run: cargo update -p termcolor --precise 1.0.4
+
+      # The compiler half of this check is still open. The intent is to build and test the minimum
+      # dependency set on the MSRV toolchain, so the worst case a user can assemble is exercised in
+      # one job. That cannot run green yet: ruststream-macros needs let-chains (1.88) while the
+      # workspace declares 1.85, and no job in this workflow noticed, because the checked-in
+      # rust-toolchain.toml overrides the toolchain dtolnay/rust-toolchain installs and every
+      # matrix entry really compiles on stable. Until the floor is either restored or moved, this
+      # job gates the dependency graph on stable and the compiler half stays unverified.
+      - name: Build and test against minimal versions
+        run: |
+          cargo check --locked --workspace --all-targets --all-features
+          cargo test --locked --workspace --all-features --no-fail-fast
+
+  external-types:
+    name: Public API surface
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # cargo-check-external-types reads rustdoc JSON, whose format is unstable, so it works only
+      # against the nightly it was built for. Pinned to a date rather than to `nightly` so the job
+      # does not break on an unrelated format change; move it forward when the tool's README names
+      # a newer one (it currently names this date), and expect to bump the tool in the same edit.
+      - name: Install nightly for rustdoc JSON
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-03-20
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-check-external-types
+        run: cargo install --locked cargo-check-external-types@0.5.0
+
+      # Which types from dependencies the public API is allowed to name, per the allow-list in
+      # Cargo.toml. Every entry there turns a version bump of that dependency into a breaking
+      # change for every broker crate downstream, so a new leak has to be argued for and added
+      # rather than discovered by a user's build after 1.0.
+      - name: cargo check-external-types
+        run: cargo +nightly-2026-03-20 check-external-types --all-features
 
   coverage:
     name: Coverage
@@ -184,7 +304,7 @@ jobs:
       # a human-readable table into the run's job summary, and an lcov file as a downloadable
       # artifact. `report` reuses the profile from `--no-report`, so neither re-runs the tests.
       - name: Run tests under coverage
-        run: cargo llvm-cov --no-report --workspace --all-features --no-fail-fast
+        run: cargo llvm-cov --locked --no-report --workspace --all-features --no-fail-fast
 
       # Line-coverage gate, sitting at the 95% DoD target. Raise it here and in the justfile
       # together if coverage climbs further. The summary is written before the gate's exit code
@@ -254,7 +374,7 @@ jobs:
       - name: cargo publish dry-run (no upload)
         env:
           CARGO_HTTP_MULTIPLEXING: "false"
-        run: cargo publish --dry-run -p ruststream-macros -p ruststream --all-features
+        run: cargo publish --locked --dry-run -p ruststream-macros -p ruststream --all-features
 
   security:
     name: Security scans
@@ -295,6 +415,8 @@ jobs:
       # change that breaks the template fails here, not a user's first `cargo build`. The rendered
       # project pins `ruststream` by version; until 0.5 is published, patch it to this checkout so
       # the scaffold builds against the local crate. Each broker repo mirrors this for its templates.
+      # No --locked: the scaffold is generated fresh and has no lock file, which is precisely the
+      # situation a user starts from.
       - name: Render and check templates/memory
         run: |
           cargo generate --path templates/memory --name smoke --destination "$RUNNER_TEMP" --vcs none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,23 +251,33 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+# 0.7.10 is the real floor: `TaskTracker`, which the runtime uses to join spawned handlers,
+# landed there, so nothing below it ever compiled here.
+tokio-util = { version = "0.7.10", features = ["rt"] }
 tracing = "0.1"
 
 # Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
 # release for release (a loose range let a partial `cargo update` pair a new core with an old
 # macros crate and fail to compile). Bumped by the same edit as [workspace.package].version.
 ruststream-macros = { version = "=0.6.3", path = "crates/ruststream-macros", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+# 0.3.22 is the real floor, not 0.3: `tracing-opentelemetry` 0.33 requires `^0.3.22`, so the
+# `otel` feature never resolved anything lower, and the declared bound claimed years of releases
+# that were never built against.
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"], optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "1", optional = true }
-ciborium = { version = "0.2", optional = true }
+# 0.2.1 is the real floor: the crate-root `into_writer`/`from_reader` re-exports the CBOR codec
+# calls arrived in that release.
+ciborium = { version = "0.2.1", optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 schemars = { version = "1", optional = true }
 serde_norway = { version = "0.9", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }
-inventory = { version = "0.3", optional = true }
+# 0.3.5 is the real floor: earlier 0.3 releases lose the broker registrations to a plain GNU ld,
+# so the registry comes back empty and the harness reports no transport for a broker that did
+# register. Development setups on mold or lld happen to hide it.
+inventory = { version = "0.3.5", optional = true }
 opentelemetry = { version = "0.32", default-features = false, features = ["trace", "metrics"], optional = true }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "metrics", "rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "metrics"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,44 @@ readme = "README.md"
 keywords = ["messaging", "async", "broker", "pubsub", "event-driven"]
 categories = ["asynchronous", "network-programming"]
 
+# The types from dependencies that the public API is allowed to name, checked by
+# `cargo check-external-types` in CI. Every entry here is a version bump of that dependency
+# turned into a breaking change for every broker crate downstream, so the list is the record of
+# which ones that trade was accepted for. Paths are the internal ones the tool reports (it reads
+# rustdoc JSON, not the re-export path), and a new leak is a compile error until it is either
+# removed from the surface or argued for and added here.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    # Re-exported from the crate root so `#[subscriber]` and friends resolve without a second
+    # dependency; the macro crate ships in lockstep with an exact pin.
+    "ruststream_macros::*",
+    # The message contract itself: a payload is whatever serde can carry, and the codecs are
+    # generic over it. `serde_core` is where serde 1.0.229 moved the traits.
+    "serde::*",
+    "serde_core::*",
+    # The payload container and the buffer handlers write into.
+    "bytes::bytes::Bytes",
+    "bytes::bytes_mut::BytesMut",
+    # A Subscriber is a Stream: that is the core design decision, not an accident.
+    "futures_core::stream::Stream",
+    # `tokio::spawn` handles surface their join failure through the app lifecycle.
+    "tokio::runtime::task::error::JoinError",
+    # Optional-feature surfaces: each is the integration point the feature exists for, so the
+    # foreign type is the API rather than an implementation detail leaking through it.
+    "inventory::Collect",
+    "schemars",
+    "serde_json::error::Error",
+    "serde_json::value::Value",
+    "serde_norway::error::Error",
+    "prometheus::errors::Error",
+    "prometheus::registry::Registry",
+    "tracing_subscriber::filter::directive::ParseError",
+    "opentelemetry_otlp::exporter::ExporterBuildError",
+    "opentelemetry_sdk::error::OTelSdkError",
+    "opentelemetry_sdk::metrics::meter_provider::SdkMeterProvider",
+    "opentelemetry_sdk::trace::provider::SdkTracerProvider",
+]
+
 [features]
 default = ["json"]
 memory = []


### PR DESCRIPTION
# Description

Adds three CI jobs (each feature built alone, minimal-versions resolve + build/test, public API
external-types check), passes `--locked` to every cargo invocation in `ci.yml`, and corrects the
four dependency bounds the minimal-versions run found to be below what the code calls into:
`tracing-subscriber` 0.3.22, `tokio-util` 0.7.10, `ciborium` 0.2.1, `inventory` 0.3.5.

The each-feature sweep is green over all 16 configurations, as expected for a guard. The
`inventory` floor is the interesting find: below 0.3.5 the broker registrations are dropped by a
plain GNU ld and the test harness reports no transport, which a local mold or lld setup hides.
Minimal versions also needs one pin, `termcolor 1.0.4`, because trybuild 1.0.0 declares a looser
bound than its code needs; the pin carries its reason inline. `check-external-types` reports 27
distinct external types in the public API, all deliberate (serde traits, `Bytes`, `Stream`, the
re-exported macros, the optional-feature integration types); they go into an allow-list so the gate
freezes the current state and rejects new ones rather than silencing the check.

Two things need a decision and are not addressed here. `rust-toolchain.toml` overrides the toolchain
`dtolnay/rust-toolchain` installs, so every entry of the toolchain matrix actually compiles on
stable and the MSRV is unverified; once it is honoured, `ruststream-macros` does not build on 1.85
(it uses let-chains, which need 1.88). That is why the minimal-versions job builds on stable rather
than on the floor, as the comment in the file records.

Fixes #246

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)