### PR TITLE
chore: raise the MSRV to 1.88 and make the matrix select its toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Three toolchains, each answering a different question, which is the shape axum
-        # and tokio both settled on: the floor is what the MSRV promise rests on, stable is
-        # what users build with, and beta is the early warning for a compiler or lint change
-        # before it reaches stable. The minor versions in between were dropped: they only ran
-        # `cargo check`, and code that fails to build on 1.90 fails on 1.85 as well, so they
-        # cost a dozen runners to restate what the floor already proves.
-        toolchain: [stable, beta, "1.85"]
+        # The floor, what users build with, and the early warning. Releases in between add
+        # nothing: what fails on a later one fails on the floor too.
+        toolchain: [stable, beta, "1.88"]
+    # Installing a toolchain does not select it: `rust-toolchain.toml` outranks the rustup
+    # default the install action sets. RUSTUP_TOOLCHAIN outranks the file.
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -90,11 +90,8 @@ jobs:
         if: matrix.toolchain == 'stable'
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
-      # The same lint set six weeks early, and deliberately not a gate. A clippy release
-      # adds lints, and the workspace warns on whole groups, so a new lint turns into a red
-      # build the day it reaches stable, with no warning. Running it here surfaces the lint
-      # while it is still in beta, in a step that reports without blocking, so the fix lands
-      # on its own schedule instead of on the release's.
+      # Advisory, not a gate: surfaces a lint added by the next clippy release six weeks
+      # before it turns the build red.
       - name: cargo clippy (beta, advisory)
         if: matrix.toolchain == 'beta'
         continue-on-error: true
@@ -115,15 +112,8 @@ jobs:
           cargo check --locked --no-default-features --features cbor,memory,macros
           cargo check --locked --no-default-features --features msgpack,memory,macros
 
-      # The trybuild UI snapshots in tests/ui are rustc-version-sensitive, so they
-      # run on stable only: RUN_UI_TESTS=1 opts the `ui` test in here, every other
-      # run (the beta and 1.85 jobs, the coverage job, a local `cargo test`) leaves it
-      # unset and the test skips itself. Beta is excluded for exactly that reason: its
-      # rustc renders diagnostics that stable has not shipped yet, so the snapshots
-      # would fail there on wording months before the wording is real. RUN_SCAFFOLD_BUILD=1
-      # opts in the heavy `ruststream new` compile-check the same way (a nested `cargo build`
-      # of the rendered memory template), so template rot fails CI instead of a user's
-      # first build.
+      # Stable only: the UI snapshots record rustc's exact wording, and beta renders wording
+      # stable has not shipped. Unset elsewhere, the two tests skip themselves.
       - name: cargo test
         env:
           RUN_UI_TESTS: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
@@ -132,10 +122,8 @@ jobs:
         # the log then lists every red test, not just the first binary's.
         run: cargo test --locked --workspace --all-features --no-fail-fast
 
-      # The suite above compiles every doc example with all features on, which hides an example
-      # that names a feature-gated item without gating itself: it then fails for the user who
-      # installs the crate with defaults, or with none. Run the doc examples at both ends of the
-      # feature range so that gap fails here instead.
+      # All-features hides a doc example that names a feature-gated item without gating itself.
+      # Both ends of the range catch it.
       - name: cargo test --doc (feature edges)
         if: matrix.toolchain == 'stable'
         run: |
@@ -171,17 +159,9 @@ jobs:
         with:
           tool: cargo-hack
 
-      # The whole public surface sits behind additive features, and the matrix above builds only
-      # the two ends of the range, so a feature that stops compiling on its own reaches a release
-      # and fails for the first user who enables it alone. This is a guard, not a fix: it finds
-      # nothing today, and that is the expected result.
-      #
-      # --no-dev-deps matters: with dev-dependencies in scope, a missing feature gate in the
-      # library is masked by a dependency that some test happens to pull in.
-      #
-      # --locked is deliberately absent here, and only here. --no-dev-deps rewrites the manifests
-      # in place, which makes cargo want to rewrite the lock file, and --locked forbids exactly
-      # that. Every other job in this workflow keeps the lock honest.
+      # --no-dev-deps: a dev-dependency in scope masks a missing feature gate in the library.
+      # It also rewrites the manifests in place, which is why this is the one job without
+      # --locked.
       - name: cargo hack check (each feature)
         run: cargo hack check --workspace --each-feature --no-dev-deps
 
@@ -201,36 +181,31 @@ jobs:
       - name: Install nightly (resolver only)
         uses: dtolnay/rust-toolchain@nightly
 
+      # The floor, for the build step below. Keep the version in step with
+      # `rust-version` in the workspace manifest.
+      - name: Install the MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # A requirement in Cargo.toml is a lower bound and a claim that the crate works from that
-      # version up, and cargo resolving to the newest compatible release means the claim is never
-      # exercised. Resolve the other way instead.
-      #
-      # The full -Z minimal-versions is used rather than -Z direct-minimal-versions on purpose:
-      # the narrow flag checks only this crate's own bounds and leaves the assembled graph
-      # unverified, and it is the assembled graph a user builds. The cost is the pinning list
-      # below, which grows by a line whenever a third-party manifest declares a bound that is too
-      # loose. Each line names the dependency and why it had to move back up.
+      # The full flag rather than -Z direct-minimal-versions: the narrow one leaves the assembled
+      # graph unverified, and that is what a user builds. It costs the pinning list below.
       - name: Resolve minimal versions
         run: cargo +nightly update -Z minimal-versions
 
-      # termcolor: trybuild 1.0.0 asks for `termcolor = "1.0"` but its banner code copies a `Color`
-      # out of a slice, and `Color` is only `Copy` from termcolor 1.0.4 on. A too-loose bound in a
-      # third-party manifest, not in ours. Remove this line if trybuild's floor here ever moves
-      # above 1.0.0.
+      # trybuild 1.0.0 declares `termcolor = "1.0"` but needs `Color: Copy`, added in 1.0.4.
+      # A too-loose bound in a third-party manifest; drop this when trybuild's floor moves.
       - name: Pin dependencies whose declared bounds are too loose
         run: cargo update -p termcolor --precise 1.0.4
 
-      # The compiler half of this check is still open. The intent is to build and test the minimum
-      # dependency set on the MSRV toolchain, so the worst case a user can assemble is exercised in
-      # one job. That cannot run green yet: ruststream-macros needs let-chains (1.88) while the
-      # workspace declares 1.85, and no job in this workflow noticed, because the checked-in
-      # rust-toolchain.toml overrides the toolchain dtolnay/rust-toolchain installs and every
-      # matrix entry really compiles on stable. Until the floor is either restored or moved, this
-      # job gates the dependency graph on stable and the compiler half stays unverified.
+      # Minimum dependencies on the minimum compiler: the worst case a user can assemble.
+      # Resolution above needs nightly, so only this step drops to the floor.
       - name: Build and test against minimal versions
+        env:
+          RUSTUP_TOOLCHAIN: "1.88"
         run: |
           cargo check --locked --workspace --all-targets --all-features
           cargo test --locked --workspace --all-features --no-fail-fast
@@ -248,10 +223,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # cargo-check-external-types reads rustdoc JSON, whose format is unstable, so it works only
-      # against the nightly it was built for. Pinned to a date rather than to `nightly` so the job
-      # does not break on an unrelated format change; move it forward when the tool's README names
-      # a newer one (it currently names this date), and expect to bump the tool in the same edit.
+      # The tool reads rustdoc JSON, whose format is unstable, so it works only against the
+      # nightly it was built for. Move this date and the tool version together.
       - name: Install nightly for rustdoc JSON
         uses: dtolnay/rust-toolchain@master
         with:
@@ -263,10 +236,8 @@ jobs:
       - name: Install cargo-check-external-types
         run: cargo install --locked cargo-check-external-types@0.5.0
 
-      # Which types from dependencies the public API is allowed to name, per the allow-list in
-      # Cargo.toml. Every entry there turns a version bump of that dependency into a breaking
-      # change for every broker crate downstream, so a new leak has to be argued for and added
-      # rather than discovered by a user's build after 1.0.
+      # Allow-list in Cargo.toml. Every entry makes a version bump of that dependency breaking
+      # for every broker crate downstream, so a new leak is added deliberately or not at all.
       - name: cargo check-external-types
         run: cargo +nightly-2026-03-20 check-external-types --all-features
 
@@ -293,10 +264,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # The cache restores llvm-cov-target from previous runs, and stale instrumented
-      # artifacts double-count files in the report (a file can show more measured lines than
-      # it physically has, cratering the total). Clear the coverage state while keeping the
-      # dependency cache.
+      # Stale instrumented artifacts from the cache double-count files and crater the total.
       - name: Clean stale coverage artifacts
         run: cargo llvm-cov clean --workspace
 
@@ -334,11 +302,8 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
-      # Feeds the README coverage badge. Coveralls accepts the default GITHUB_TOKEN for public
-      # repositories, so no extra secret is required; uploaded even when the gate fails so the
-      # badge reflects reality rather than the last green run. The upload is advisory: a
-      # Coveralls outage must not fail the pipeline (the enforced coverage gate is the
-      # fail-under step above).
+      # Uploaded even when the gate fails, so the badge shows reality. Advisory: a Coveralls
+      # outage must not fail the pipeline.
       - name: Upload to Coveralls
         if: always()
         uses: coverallsapp/github-action@v2
@@ -363,14 +328,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # Package the published artifacts without uploading. Both packages in one invocation
-      # (multi-package packaging, stable since cargo 1.90): packaging strips the path from the
-      # lockstep `ruststream-macros` dependency, and between a version bump and the release that
-      # version does not exist on crates.io, so packaging ruststream alone cannot resolve it. The
-      # multi-package form resolves in-workspace dependencies through a local overlay instead.
-      #
-      # CARGO_HTTP_MULTIPLEXING=false works around recurring "[16] Error in the HTTP2 framing
-      # layer" curl failures on the runners when this job re-downloads registry deps.
+      # Both packages in one invocation: packaging strips the path from the lockstep
+      # `ruststream-macros` dependency, and between a version bump and the release that version
+      # is not on crates.io yet, so packaging ruststream alone cannot resolve it.
+      # CARGO_HTTP_MULTIPLEXING=false works around HTTP2 framing failures on the runners.
       - name: cargo publish dry-run (no upload)
         env:
           CARGO_HTTP_MULTIPLEXING: "false"
@@ -411,12 +372,9 @@ jobs:
         with:
           tool: cargo-generate
 
-      # The template-contract drift check: render the in-memory scaffold and compile it, so an API
-      # change that breaks the template fails here, not a user's first `cargo build`. The rendered
-      # project pins `ruststream` by version; until 0.5 is published, patch it to this checkout so
-      # the scaffold builds against the local crate. Each broker repo mirrors this for its templates.
-      # No --locked: the scaffold is generated fresh and has no lock file, which is precisely the
-      # situation a user starts from.
+      # Renders the scaffold and compiles it, so template drift fails here and not on a user's
+      # first build. The rendered project is patched to this checkout. No --locked: a fresh
+      # scaffold has no lock file, which is the situation a user starts from.
       - name: Render and check templates/memory
         run: |
           cargo generate --path templates/memory --name smoke --destination "$RUNNER_TEMP" --vcs none

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,10 +59,8 @@ jobs:
 
   translation-parity:
     name: Translation parity
-    # A change to what a page says belongs in every language that page exists in. The way out
-    # is this label, and it is for an edit confined to one language: spelling, grammar, or a
-    # word choice that was already right elsewhere. It suppresses this job only - the site
-    # still has to build and the translated pages still have to match their originals.
+    # The label is for an edit confined to one language: spelling, grammar, or a word choice
+    # that was already right elsewhere. It suppresses this job only.
     if: >-
       github.event_name == 'pull_request'
       && !contains(github.event.pull_request.labels.*.name, 'docs-single-language')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["templates"]
 [workspace.package]
 version = "0.6.3"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/powersemmi/ruststream"
 authors = ["RustStream contributors"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://crates.io/crates/ruststream"><img src="https://img.shields.io/crates/v/ruststream.svg" alt="crates.io"></a>
   <a href="https://crates.io/crates/ruststream"><img src="https://img.shields.io/crates/dr/ruststream" alt="Recent downloads"></a>
   <a href="https://docs.rs/ruststream"><img src="https://img.shields.io/docsrs/ruststream" alt="docs.rs"></a>
-  <img src="https://img.shields.io/badge/MSRV-1.85-blue.svg" alt="MSRV 1.85">
+  <img src="https://img.shields.io/badge/MSRV-1.88-blue.svg" alt="MSRV 1.88">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/unsafe-none-success.svg" alt="100% safe Rust">
   <a href="https://t.me/ruststream_community"><img src="https://img.shields.io/badge/-Telegram-blue?logo=telegram&label=News" alt="Telegram news channel"></a>
@@ -229,9 +229,9 @@ Concrete brokers live in their own crates and pull `ruststream` from crates.io.
 
 ## Minimum supported Rust version
 
-The MSRV is **1.85** (edition 2024, native `async fn in trait`). CI builds and tests the crate on
-the floor and on current stable, and builds it on beta; Rust's stability guarantee carries the
-releases in between, so any floor at or above 1.85 works.
+The MSRV is **1.88**, edition 2024. CI builds and tests the crate on the floor and on current
+stable, and builds it on beta; Rust's stability guarantee carries the releases in between, so any
+floor at or above 1.88 works.
 
 The policy:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,10 +13,9 @@ serde = { version = "1", features = ["derive"] }
 `Serialize`.
 
 !!! note "Edition and MSRV"
-    RustStream targets **edition 2024** and a minimum supported Rust version of **1.85** (native
-    `async fn in trait`). Set `edition = "2024"` in your `Cargo.toml`. CI builds and tests the
-    crate on the floor and on current stable, and builds it on beta, so any floor at or above
-    1.85 works.
+    RustStream targets **edition 2024** and a minimum supported Rust version of **1.88**. Set
+    `edition = "2024"` in your `Cargo.toml`. CI builds and tests the crate on the floor and on
+    current stable, and builds it on beta, so any floor at or above 1.88 works.
     Broker crates may require a newer toolchain than the core when their underlying clients do;
     check the broker crate's own `rust-version`.
 

--- a/examples/typed_headers.rs
+++ b/examples/typed_headers.rs
@@ -119,7 +119,7 @@ struct StatusReply {
 #[subscriber("jobs.status-requests", publish("jobs.status"))]
 async fn status(req: &StatusRequest) -> StatusReply {
     StatusReply {
-        done: req.task_id % 2 == 0,
+        done: req.task_id.is_multiple_of(2),
     }
 }
 // --8<-- [end:reply]

--- a/src/memory/capability/tests.rs
+++ b/src/memory/capability/tests.rs
@@ -574,10 +574,10 @@ async fn seek_wakes_a_parked_stream() {
         let mut parked_tx = Some(parked_tx);
         std::future::poll_fn(move |cx| {
             let polled = stream.as_mut().poll_next(cx);
-            if polled.is_pending() {
-                if let Some(tx) = parked_tx.take() {
-                    let _ = tx.send(());
-                }
+            if polled.is_pending()
+                && let Some(tx) = parked_tx.take()
+            {
+                let _ = tx.send(());
             }
             polled
         })

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -196,10 +196,11 @@ impl MemoryState {
                 // (`_inbox.`) are excluded: their reply is consumed by the requester, not a dispatch
                 // loop, so it carries no coordinator and is never decremented.
                 #[cfg(feature = "testing")]
-                if sent.is_ok() && !delivery.name.starts_with("_inbox.") {
-                    if let Some(coordinator) = self.coordinator.get() {
-                        coordinator.enqueued();
-                    }
+                if sent.is_ok()
+                    && !delivery.name.starts_with("_inbox.")
+                    && let Some(coordinator) = self.coordinator.get()
+                {
+                    coordinator.enqueued();
                 }
                 #[cfg(not(feature = "testing"))]
                 let _ = sent;
@@ -817,10 +818,10 @@ impl IncomingMessage for MemoryMessage {
             // The requeue bypasses `fanout`, so count the re-enqueue here to balance this message's
             // `Drop` decrement. The redelivered copy is consumed (and decremented) in turn.
             #[cfg(feature = "testing")]
-            if sent.is_ok() {
-                if let Some(coordinator) = &self.coordinator {
-                    coordinator.enqueued();
-                }
+            if sent.is_ok()
+                && let Some(coordinator) = &self.coordinator
+            {
+                coordinator.enqueued();
             }
             #[cfg(not(feature = "testing"))]
             let _ = sent;

--- a/src/otel/export.rs
+++ b/src/otel/export.rs
@@ -581,11 +581,11 @@ impl PublishLayer for OtelPublishLayer {
         next: PublishNext<'a, N, P>,
     ) -> impl Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
     {
-        if self.stamp_publish_time {
-            if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                out.headers_mut()
-                    .insert(PUBLISH_TIME_HEADER, now.as_millis().to_string());
-            }
+        if self.stamp_publish_time
+            && let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH)
+        {
+            out.headers_mut()
+                .insert(PUBLISH_TIME_HEADER, now.as_millis().to_string());
         }
         let name = out.name().to_owned();
         #[allow(clippy::cast_possible_truncation)] // Payloads beyond u64 bytes do not exist.

--- a/tests/out_injection.rs
+++ b/tests/out_injection.rs
@@ -24,7 +24,7 @@ struct Event {
 /// the injected publisher exists for.
 #[subscriber("out.in")]
 async fn forward(event: &Event, Out(out): Out<impl Publisher>) -> HandlerResult {
-    let dest = if event.id % 2 == 0 {
+    let dest = if event.id.is_multiple_of(2) {
         "out.even"
     } else {
         "out.odd"

--- a/tests/out_slots.rs
+++ b/tests/out_slots.rs
@@ -178,7 +178,7 @@ trait ShardLanes {
 
 impl ShardLanes for LaneRouter {
     fn lane(&self, shard: u64) -> (&MemoryPublisher, &'static str) {
-        let dest = if shard % 2 == 0 {
+        let dest = if shard.is_multiple_of(2) {
             "slots.lane.even"
         } else {
             "slots.lane.odd"


### PR DESCRIPTION
# Description

Raises the MSRV to 1.88 and makes the toolchain matrix actually use the toolchain it names.

The matrix never did: `dtolnay/rust-toolchain` sets the rustup default, and the checked-in
`rust-toolchain.toml` overrides it, so every leg compiled on stable. `RUSTUP_TOOLCHAIN` outranks
the file and is what makes the floor a gate.

With the toolchain selected for real, `ruststream-macros` does not build on 1.85: 24 let-chains,
stable since 1.88. The core crate does build on 1.85, so the published floor was wrong for anyone
enabling `macros`. Raising it is the honest fix rather than rewriting the let-chains.

The minimal-versions job now builds and tests on the floor too, closing the half #249 left open
while the floor could not be trusted.

Also trims the workflow comments to what is not evident from the commands.

## Type of change

- [x] Breaking change (a fix or feature that changes existing behaviour)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally, including a full build on the new floor
