### PR TITLE
docs: refresh the tutorial's code blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,17 @@ required-features = ["macros", "memory", "json"]
 [[example]]
 name = "tutorial"
 path = "examples/tutorial/main.rs"
-required-features = ["macros", "memory", "json"]
+required-features = ["macros", "memory", "json", "asyncapi"]
+
+[[example]]
+name = "tutorial_first_app"
+path = "examples/tutorial/first_app.rs"
+required-features = ["macros", "memory", "json", "asyncapi"]
+
+[[example]]
+name = "tutorial_reply_app"
+path = "examples/tutorial/reply_app.rs"
+required-features = ["macros", "memory", "json", "asyncapi"]
 
 [[example]]
 name = "subscribers"

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -28,10 +28,6 @@ A handler is an `async fn` whose first parameter is the decoded payload. The `#[
 turns it into a mountable definition named after the function.
 
 ```rust title="src/orders.rs"
-use ruststream::runtime::HandlerResult;
-use ruststream::subscriber;
-use serde::{Deserialize, Serialize};
-
 --8<-- "examples/tutorial/orders.rs:order"
 ```
 
@@ -39,17 +35,14 @@ A handler returns a [`HandlerResult`](../guides/subscribers.md#acking): `Ack`, o
 or requeues the message. Returning `()` or `Result<(), E>` also works - they convert into a result
 (`Ok` acks, `Err` drops).
 
+The `JsonSchema` derive is what puts the payload's schema in the AsyncAPI document of step 6, and
+the type's doc comment becomes the message description. It needs no dependency of its own: the
+`asyncapi` feature re-exports `schemars`.
+
 ## 3. Wire it into an app
 
 ```rust title="src/main.rs"
-mod orders;
-
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, RustStream};
-
-use crate::orders::handle;
-
---8<-- "examples/quickstart.rs:app"
+--8<-- "examples/tutorial/first_app.rs:app"
 ```
 
 The macro turns `handle` into a value named after the function, so you import and pass it directly.
@@ -74,14 +67,11 @@ To publish a reply, return the reply value and name the destination with `publis
 --8<-- "examples/tutorial/orders.rs:confirm"
 ```
 
-Mount it with plain `include`; the reply goes out through the broker's default publish policy
-under the default codec (chain `.publisher(..)` with a `TypedPublisher` stack to name a reply
-codec or add transforms):
+Mount it next to `handle`, with the same plain `include`; the reply goes out through the broker's
+default publish policy under the default codec:
 
-<!-- inline-rust: minimal mount fragment isolating the reply wiring; the full compiled program is examples/tutorial/main.rs:main, pulled in below -->
-```rust
-// inside with_broker(...), with `confirm` imported from the orders module
-b.include(confirm);
+```rust title="src/main.rs"
+--8<-- "examples/tutorial/reply_app.rs:reply"
 ```
 
 See [Publishing & replies](../guides/publishing.md) for the full picture, including publishing from
@@ -96,6 +86,12 @@ As handlers grow, keep them in their own module and collect them into a
 --8<-- "examples/tutorial/routes.rs:routes"
 ```
 
+A router holds no broker, so a registration cannot commit itself on drop the way the scope's
+builder does: it ends in an explicit terminal. `.publisher(..)` names the reply wiring - a publish
+policy is pure declaration, which is why the router still needs no broker - and `.mount()` takes
+the broker's own default publish policy, the explicit spelling of what step 4 got by default.
+[Routing](../guides/routing.md) covers the rest of the router surface.
+
 ```rust title="src/main.rs"
 --8<-- "examples/tutorial/main.rs:main"
 ```
@@ -106,9 +102,12 @@ As handlers grow, keep them in their own module and collect them into a
 cargo run -- asyncapi gen
 ```
 
-Every subscriber becomes a channel and a `receive` operation; payload types that derive
-`schemars::JsonSchema` also contribute schemas. The output flags (`-o`, `--yaml`) and the document
-itself are covered in [AsyncAPI](../guides/asyncapi.md).
+Every subscriber becomes a channel and a `receive` operation. `handle` and `confirm` share the
+`orders` channel and still get one operation each, because they open separate subscriptions; the
+reply adds a `send` operation on `confirmations`. Both payload types derive `schemars::JsonSchema`,
+so the document carries their schemas under `components.messages`, each with the type's doc comment
+as its description. The output flags (`-o`, `--yaml`) and the document itself are covered in
+[AsyncAPI](../guides/asyncapi.md).
 
 ## 7. Swap in a real broker
 
@@ -121,8 +120,9 @@ and codecs are unchanged. The available brokers and the side-by-side swap for ea
 !!! info "The complete service is a compiled example"
     Every snippet on this page is embedded from
     [`examples/tutorial`](https://github.com/powersemmi/ruststream/tree/main/examples/tutorial)
-    in the repository, which CI builds on every change. Run it yourself with
-    `cargo run --example tutorial --features macros,memory,json -- run`.
+    in the repository, which CI builds on every change: `first_app.rs` and `reply_app.rs` are the
+    service as steps 3 and 4 leave it, `main.rs` the finished one. Run it yourself with
+    `cargo run --example tutorial --features macros,memory,json,asyncapi -- run`.
 
 ## Next steps
 

--- a/docs/ru/getting-started/tutorial.md
+++ b/docs/ru/getting-started/tutorial.md
@@ -29,10 +29,6 @@ serde = { version = "1", features = ["derive"] }
 самой функции.
 
 ```rust title="src/orders.rs"
-use ruststream::runtime::HandlerResult;
-use ruststream::subscriber;
-use serde::{Deserialize, Serialize};
-
 --8<-- "examples/tutorial/orders.rs:order"
 ```
 
@@ -40,17 +36,14 @@ use serde::{Deserialize, Serialize};
 который отбрасывает сообщение или возвращает его в очередь. Подойдёт и `()`, и `Result<(), E>` - они
 преобразуются в результат (`Ok` подтверждает, `Err` отбрасывает).
 
+Именно вывод `JsonSchema` кладёт схему полезной нагрузки в AsyncAPI-документ из шага 6, а
+doc-комментарий типа становится описанием сообщения. Отдельная зависимость для этого не нужна: фича
+`asyncapi` реэкспортирует `schemars`.
+
 ## 3. Свяжите обработчик с приложением
 
 ```rust title="src/main.rs"
-mod orders;
-
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, RustStream};
-
-use crate::orders::handle;
-
---8<-- "examples/quickstart.rs:app"
+--8<-- "examples/tutorial/first_app.rs:app"
 ```
 
 Макрос превращает `handle` в значение с тем же именем, что у функции, поэтому его достаточно
@@ -76,14 +69,11 @@ cargo run -- run
 --8<-- "examples/tutorial/orders.rs:confirm"
 ```
 
-Монтируется он обычным `include`: ответ уходит через политику публикации брокера по умолчанию и
-кодируется кодеком по умолчанию (чтобы назвать кодек ответа или добавить преобразования, добавьте в
-цепочку `.publisher(..)` со стеком `TypedPublisher`):
+Смонтируйте его рядом с `handle` тем же обычным `include`: ответ уходит через политику публикации
+брокера по умолчанию и кодируется кодеком по умолчанию.
 
-<!-- inline-rust: minimal mount fragment isolating the reply wiring; the full compiled program is examples/tutorial/main.rs:main, pulled in below -->
-```rust
-// inside with_broker(...), with `confirm` imported from the orders module
-b.include(confirm);
+```rust title="src/main.rs"
+--8<-- "examples/tutorial/reply_app.rs:reply"
 ```
 
 Полная картина, включая публикацию изнутри обработчика, - в разделе
@@ -98,6 +88,12 @@ b.include(confirm);
 --8<-- "examples/tutorial/routes.rs:routes"
 ```
 
+Роутер не держит брокер, поэтому регистрация не фиксируется сама при сбросе, как это делает билдер
+области: она завершается явным терминалом. `.publisher(..)` задаёт связывание ответа - политика
+публикации остаётся чистой декларацией, поэтому роутеру по-прежнему не нужен брокер, - а `.mount()`
+берёт собственную политику публикации брокера по умолчанию, то есть явно записывает то, что шаг 4
+получал сам. Остальная поверхность роутера разобрана в разделе [Роутинг](../guides/routing.md).
+
 ```rust title="src/main.rs"
 --8<-- "examples/tutorial/main.rs:main"
 ```
@@ -108,9 +104,12 @@ b.include(confirm);
 cargo run -- asyncapi gen
 ```
 
-Каждый подписчик превращается в канал и операцию `receive`; типы полезной нагрузки, для которых
-выведен `schemars::JsonSchema`, добавляют ещё и схемы. Флаги вывода (`-o`, `--yaml`) и сам документ
-разобраны в [руководстве по AsyncAPI](../guides/asyncapi.md).
+Каждый подписчик превращается в канал и операцию `receive`. Обработчики `handle` и `confirm` делят
+канал `orders` и всё равно получают по своей операции, потому что открывают отдельные подписки;
+ответ добавляет операцию `send` на канале `confirmations`. Оба типа полезной нагрузки выводят
+`schemars::JsonSchema`, поэтому документ несёт их схемы в `components.messages`, и описанием каждой
+служит doc-комментарий типа. Флаги вывода (`-o`, `--yaml`) и сам документ разобраны в
+[руководстве по AsyncAPI](../guides/asyncapi.md).
 
 ## 7. Перейдите на настоящий брокер
 
@@ -123,8 +122,10 @@ cargo run -- asyncapi gen
 !!! info "Готовый сервис - это компилируемый пример"
     Каждый фрагмент на этой странице подтянут из
     [`examples/tutorial`](https://github.com/powersemmi/ruststream/tree/main/examples/tutorial)
-    в репозитории, который CI собирает при каждом изменении. Запустить его самостоятельно можно
-    командой `cargo run --example tutorial --features macros,memory,json -- run`.
+    в репозитории, который CI собирает при каждом изменении: `first_app.rs` и `reply_app.rs` - это
+    сервис в том виде, в каком его оставляют шаги 3 и 4, а `main.rs` - готовый. Запустить его
+    самостоятельно можно командой
+    `cargo run --example tutorial --features macros,memory,json,asyncapi -- run`.
 
 ## Что дальше
 

--- a/docs/zh/getting-started/tutorial.md
+++ b/docs/zh/getting-started/tutorial.md
@@ -27,10 +27,6 @@ serde = { version = "1", features = ["derive"] }
 定义，名字与函数同名。
 
 ```rust title="src/orders.rs"
-use ruststream::runtime::HandlerResult;
-use ruststream::subscriber;
-use serde::{Deserialize, Serialize};
-
 --8<-- "examples/tutorial/orders.rs:order"
 ```
 
@@ -38,17 +34,13 @@ use serde::{Deserialize, Serialize};
 重新入队该消息的 `nack`。返回 `()` 或 `Result<(), E>` 同样可行，它们会转换成一个结果（`Ok` 表示
 ack，`Err` 表示丢弃）。
 
+把载荷的 schema 放进第 6 步那份 AsyncAPI 文档的，正是 `JsonSchema` derive；类型的文档注释则成为该
+消息的描述。这不需要额外的依赖，因为 `asyncapi` 特性已经重导出了 `schemars`。
+
 ## 3. 接入应用
 
 ```rust title="src/main.rs"
-mod orders;
-
-use ruststream::memory::MemoryBroker;
-use ruststream::runtime::{AppInfo, RustStream};
-
-use crate::orders::handle;
-
---8<-- "examples/quickstart.rs:app"
+--8<-- "examples/tutorial/first_app.rs:app"
 ```
 
 宏把 `handle` 变成一个与函数同名的值，所以你直接导入它并原样传入即可。
@@ -73,13 +65,11 @@ cargo run -- run
 --8<-- "examples/tutorial/orders.rs:confirm"
 ```
 
-用普通的 `include` 挂载它即可；回复会经由 Broker 的默认发布策略发出，编码用的是默认编解码器（想为
-回复指定另一个编解码器或加上变换，就再链式调用 `.publisher(..)` 并传入一个 `TypedPublisher` 栈）：
+把它挂在 `handle` 旁边，用同一个普通的 `include` 即可：回复会经由 Broker 的默认发布策略发出，编码
+用的是默认编解码器。
 
-<!-- inline-rust: minimal mount fragment isolating the reply wiring; the full compiled program is examples/tutorial/main.rs:main, pulled in below -->
-```rust
-// inside with_broker(...), with `confirm` imported from the orders module
-b.include(confirm);
+```rust title="src/main.rs"
+--8<-- "examples/tutorial/reply_app.rs:reply"
 ```
 
 完整的图景（包括在处理器内部发布）参见[发布与回复](../guides/publishing.md)。
@@ -92,6 +82,11 @@ b.include(confirm);
 --8<-- "examples/tutorial/routes.rs:routes"
 ```
 
+路由器本身不持有 Broker，因此注册无法像作用域的构建器那样在丢弃时自动提交，它要以一个显式的终结调用
+收尾。`.publisher(..)` 指定回复的接线方式，发布策略仍然是纯粹的声明，所以路由器依旧不需要 Broker；
+`.mount()` 则采用 Broker 自带的默认发布策略，也就是把第 4 步自动拿到的那一份显式写出来。路由器的
+其余接口参见[路由](../guides/routing.md)。
+
 ```rust title="src/main.rs"
 --8<-- "examples/tutorial/main.rs:main"
 ```
@@ -102,8 +97,10 @@ b.include(confirm);
 cargo run -- asyncapi gen
 ```
 
-每个订阅者都会变成一个 channel 和一个 `receive` 操作；派生了 `schemars::JsonSchema` 的载荷类型还会
-贡献出 schema。输出相关的参数（`-o`、`--yaml`）以及文档本身，参见
+每个订阅者都会变成一个 channel 和一个 `receive` 操作。`handle` 和 `confirm` 共用 `orders` 这个
+channel，却各自拿到一个操作，因为它们开的是两条独立的订阅；回复则在 `confirmations` 上添加一个
+`send` 操作。两个载荷类型都 derive 了 `schemars::JsonSchema`，所以文档在 `components.messages` 下
+带上了它们的 schema，每一个的描述就是类型的文档注释。输出相关的参数（`-o`、`--yaml`）以及文档本身，参见
 [AsyncAPI](../guides/asyncapi.md)。
 
 ## 7. 换成真正的 Broker
@@ -116,8 +113,9 @@ cargo run -- asyncapi gen
 !!! info "完整的服务是一个会参与编译的示例"
     本页的每一段代码都嵌自仓库中的
     [`examples/tutorial`](https://github.com/powersemmi/ruststream/tree/main/examples/tutorial)，
-    CI 在每次改动时都会构建它。也可以用
-    `cargo run --example tutorial --features macros,memory,json -- run` 自己跑一遍。
+    CI 在每次改动时都会构建它：`first_app.rs` 和 `reply_app.rs` 分别是第 3 步和第 4 步结束时的服务，
+    `main.rs` 则是最终版本。也可以用
+    `cargo run --example tutorial --features macros,memory,json,asyncapi -- run` 自己跑一遍。
 
 ## 下一步
 

--- a/examples/tutorial/first_app.rs
+++ b/examples/tutorial/first_app.rs
@@ -1,0 +1,23 @@
+//! The tutorial's service at step 3: one handler mounted straight on the broker scope, before
+//! the reply of step 4 and the router of step 5 arrive.
+//!
+//! ```text
+//! cargo run --example tutorial_first_app --features macros,memory,json,asyncapi -- run
+//! ```
+
+// Step 3 mounts `handle` alone; the module's reply types stay unused until step 4.
+#[allow(dead_code)]
+// --8<-- [start:app]
+mod orders;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, RustStream};
+
+use crate::orders::handle;
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders-service", "0.1.0"))
+        .with_broker(MemoryBroker::new(), |b| b.include(handle))
+}
+// --8<-- [end:app]

--- a/examples/tutorial/orders.rs
+++ b/examples/tutorial/orders.rs
@@ -1,11 +1,13 @@
 //! The tutorial's message types and handlers.
 
+// --8<-- [start:order]
 use ruststream::runtime::HandlerResult;
+use ruststream::schemars::JsonSchema;
 use ruststream::subscriber;
 use serde::{Deserialize, Serialize};
 
-// --8<-- [start:order]
-#[derive(Debug, Deserialize)]
+/// An order placed by a customer.
+#[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct Order {
     pub(crate) id: u64,
     pub(crate) quantity: u32,
@@ -19,7 +21,8 @@ pub(crate) async fn handle(order: &Order) -> HandlerResult {
 // --8<-- [end:order]
 
 // --8<-- [start:confirm]
-#[derive(Debug, Serialize)]
+/// The service's answer to an order.
+#[derive(Debug, Serialize, JsonSchema)]
 pub(crate) struct Confirmation {
     pub(crate) id: u64,
     pub(crate) accepted: bool,

--- a/examples/tutorial/reply_app.rs
+++ b/examples/tutorial/reply_app.rs
@@ -1,0 +1,23 @@
+//! The tutorial's service at step 4: the reply handler mounted next to the plain one, still
+//! without the router of step 5.
+//!
+//! ```text
+//! cargo run --example tutorial_reply_app --features macros,memory,json,asyncapi -- run
+//! ```
+
+mod orders;
+
+use ruststream::memory::MemoryBroker;
+use ruststream::runtime::{AppInfo, RustStream};
+
+// --8<-- [start:reply]
+use crate::orders::{confirm, handle};
+
+#[ruststream::app]
+fn app() -> RustStream {
+    RustStream::new(AppInfo::new("orders-service", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+        b.include(handle);
+        b.include(confirm);
+    })
+}
+// --8<-- [end:reply]

--- a/examples/tutorial/routes.rs
+++ b/examples/tutorial/routes.rs
@@ -10,8 +10,8 @@ use crate::orders;
 pub(crate) fn orders() -> impl RouterDef<MemoryBroker> {
     let replies = TypedPublisher::new(MemoryPublish);
     Router::new()
+        .include(orders::handle)
         .include(orders::confirm)
         .publisher(replies)
-        .include(orders::handle)
 }
 // --8<-- [end:routes]


### PR DESCRIPTION
# Description

Every Rust block on the getting-started tutorial is now a region of `examples/tutorial/`. Two
staged binaries join it - `first_app.rs` (step 3) and `reply_app.rs` (step 4) - replacing a
snippet borrowed from `examples/quickstart.rs` and an inline mount fragment, and the imports
that framed the step 2 and step 3 blocks moved into the regions, so no block is assembled from
two sources any more. The tutorial's message types derive `JsonSchema` and carry doc comments.

Two findings from the block-by-block pass. Step 4 promised the default publish policy while
step 5 silently switched to a named `TypedPublisher`, with nothing on the page explaining why
the router needs an explicit terminal - step 5 now says so. Step 6 described a document with
one operation per subscriber; the example actually emits two `receive` operations on the shared
`orders` channel plus a `send` for the reply, and now that the payloads derive `JsonSchema`,
their schemas too - checked by generating the document, not by reading the code.

One deviation from the issue: the `Cargo.toml` block gets no `schemars` line. The page already
enables `asyncapi`, which re-exports `schemars`, and `docs/guides/asyncapi.md` states that no
direct dependency is needed. The README keeps its own line because its install block does not
enable `asyncapi`.

Fixes #216

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable