### PR TITLE
fix: declare the dependency floors the library actually compiles against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2.86.5
+        with:
+          tool: cargo-hack
+
       # The full flag rather than -Z direct-minimal-versions: the narrow one leaves the assembled
       # graph unverified, and that is what a user builds. It costs the pinning list below.
       - name: Resolve minimal versions
@@ -229,6 +234,27 @@ jobs:
         run: |
           cargo check --locked --workspace --all-targets --all-features
           cargo test --locked --workspace --all-features --no-fail-fast
+
+      # Everything above still sees dev-dependencies, which raise shared floors before the library
+      # is built: the run proves the workspace resolves, not that the manifest is honest for a
+      # consumer. Drop them and resolve again, so the graph is the one a dependent gets. Runs last
+      # because it rewrites the manifests in place.
+      - name: Resolve minimal versions without dev-dependencies
+        run: |
+          cargo hack --remove-dev-deps
+          cargo +nightly update -Z minimal-versions
+
+      # tonic 0.14 declares `tower = "0.5"`, but `ServiceBuilder::new` only became const-callable
+      # in 0.5.1. Another too-loose third-party bound, masked above by a higher tower.
+      - name: Pin dependencies whose declared bounds are too loose (no dev-dependencies)
+        run: cargo update -p tower@0.5.0 --precise 0.5.1
+
+      # The library as a dependency, on the floor toolchain. No --locked: cargo-hack edits the
+      # manifests it checks.
+      - name: Check the library against its own declared floors
+        env:
+          RUSTUP_TOOLCHAIN: "1.88"
+        run: cargo hack check --workspace --no-dev-deps --all-features
 
   external-types:
     name: Public API surface

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,14 +299,19 @@ otel = [
 [dependencies]
 bytes = "1"
 futures = "0.3"
-serde = { version = "1", features = ["derive"] }
+# 1.0.69 is the real floor: the typed-headers deserializer names `BorrowedStrDeserializer` and
+# forwards the 128-bit methods, both of which arrived there.
+serde = { version = "1.0.69", features = ["derive"] }
 thiserror = "2"
 
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
+# 1.37 is the real floor: the app clones the health `watch::Sender`, and `Clone` on it landed there.
+tokio = { version = "1.37", features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 # 0.7.10 is the real floor: `TaskTracker`, which the runtime uses to join spawned handlers,
 # landed there, so nothing below it ever compiled here.
 tokio-util = { version = "0.7.10", features = ["rt"] }
-tracing = "0.1"
+# 0.1.29 is the real floor: it is the first release whose own `tracing-core` bound reaches 0.1.21,
+# where `Value` for `Option<T>` landed - the dispatch spans record optional fields.
+tracing = "0.1.29"
 
 # Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
 # release for release (a loose range let a partial `cargo update` pair a new core with an old
@@ -325,7 +330,8 @@ prometheus = { version = "0.14", default-features = false, optional = true }
 schemars = { version = "1", optional = true }
 serde_norway = { version = "0.9", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
-anyhow = { version = "1", optional = true }
+# 1.0.1 is the real floor: `bail!` with a formatted message does not compile against 1.0.0.
+anyhow = { version = "1.0.1", optional = true }
 # 0.3.5 is the real floor: earlier 0.3 releases lose the broker registrations to a plain GNU ld,
 # so the registry comes back empty and the harness reports no transport for a broker that did
 # register. Development setups on mold or lld happen to hide it.


### PR DESCRIPTION
# Description

The manifest declared dependency floors the library never compiled at. Dev-dependencies raised
serde, tokio and tracing before the library was built, so the Minimal versions job proved the
workspace resolves rather than that a consumer can build the crate; every downstream repo that
mirrored the job inherited a red leg it could not fix on its side.

Each offending bound is raised to the version that actually carries the item the code uses, found
by resolving with `-Z minimal-versions` against a graph reduced to what a consumer sees and
bisecting until the smallest compiling version was reached. The Minimal versions job gains a
second leg that strips dev-dependencies, resolves again, and checks the library on the floor
toolchain, so the mask cannot return.

Fixes #264

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [ ] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [ ] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [ ] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
