### PR TITLE
Carry the manual path in the prelude without the macros feature

### DIFF
--- a/.cursor/rules/advanced-usage.mdc
+++ b/.cursor/rules/advanced-usage.mdc
@@ -66,9 +66,11 @@ alwaysApply: false
   constructor, the body trait `Handle` with its input spellings `Message` and `Deserialized`, the
   reply traits `Serialized` / `ReplyShape`, the injections arena `Outs` / `Slot` / `Publish`, plus
   `FailurePolicies` / `FailurePolicy`, `Workers`, `Unnamed`, `Out`,
-  `DefaultSlot`, `RouterDef` and `nonzero!`). The lane machinery the impls name -
-  `Input`, `SoloDeserialized`, `SerializedReply` - stays an explicit
-  `use ruststream::runtime::{..}`.
+  `DefaultSlot`, `RouterDef` and `nonzero!`), and so do the spellings the hand-written impls
+  name: `Input` / `SoloDeserialized`, `MessageWire` / `SerializedWire`, `SerializedReply`,
+  `OutgoingDestination` with `CallerName` / `FixedName` / `NameTemplate`, `MessageHeaders` with
+  `NoHeaders` / `WithHeaders`, `PublishedThrough`, `OutMessages` / `OutgoingMessageMetadata`,
+  and `FromContext`. A service without the feature imports nothing beyond the glob.
 - Mount with `b.include(subscriber(source, body).build())` (the portable form: the source resolves
   at startup), or `b.handle(subscriber, handler, metadata)` when you already hold an open
   subscriber. Routers have the same `include` method, so grouping still works.
@@ -172,8 +174,6 @@ elements and coherence cannot split the two.
 
 ```rust
 use std::convert::Infallible;
-
-use ruststream::runtime::{Input, SoloDeserialized};
 
 struct Frame<'a>(&'a [u8]);
 
@@ -326,9 +326,6 @@ Without the `macros` feature the same impls are written by hand; the caller-name
 short ones, and then the value publishes like any declared message:
 
 ```rust
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutSlot, OutgoingDestination};
-use ruststream::runtime::{OutMessages, OutgoingMessageMetadata};
-
 impl OutgoingDestination for Receipt {
     type Form = CallerName; // FixedName / NameTemplate for a declared destination
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
       # compiled nowhere and rotted unnoticed. Those lanes are what must hold with no codec at
       # all: a `Deserialized` input in, a `Serialized` value out, through the same typed publish
       # entry a service always writes. `ui_codec_free` pins the errors the other side of that
-      # line produces, which exist only where no codec resolves.
+      # line produces, which exist only where no codec resolves. `lane_traits_without_macros`
+      # builds with `macros` off, where the derives are gone and the prelude alone has to carry
+      # every name the hand-written lane impls spell.
       - name: cargo test (reduced features)
         if: matrix.toolchain == 'stable'
         env:
@@ -139,6 +141,7 @@ jobs:
           cargo test --locked --no-default-features --features macros,memory,testing --test raw_subscriber
           cargo test --locked --no-default-features --features macros,memory,testing --test codec_free_lanes
           cargo test --locked --no-default-features --features macros,memory,testing --test ui_codec_free
+          cargo test --locked --no-default-features --features memory,testing --test lane_traits_without_macros
 
       # All-features hides a doc example that names a feature-gated item without gating itself.
       # Both ends of the range catch it.

--- a/examples/manual/ctx_extractor.rs
+++ b/examples/manual/ctx_extractor.rs
@@ -11,7 +11,6 @@
 
 use ruststream::memory::{MemoryBroker, MemoryMessage};
 use ruststream::prelude::*;
-use ruststream::runtime::FromContext;
 use ruststream::testing::TestApp;
 use ruststream::{BuildContext, ContextField};
 use serde::{Deserialize, Serialize};

--- a/examples/manual/custom_codec.rs
+++ b/examples/manual/custom_codec.rs
@@ -13,7 +13,6 @@ use bytes::BytesMut;
 use ruststream::codec::{CborCodec, Codec, CodecError, JsonCodec};
 use ruststream::memory::{MemoryBroker, MemoryPublisher};
 use ruststream::prelude::*;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/examples/manual/from_context.rs
+++ b/examples/manual/from_context.rs
@@ -15,7 +15,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use ruststream::memory::MemoryBroker;
 use ruststream::prelude::*;
-use ruststream::runtime::FromContext;
 use ruststream::testing::TestApp;
 use serde::{Deserialize, Serialize};
 

--- a/examples/manual/publishing.rs
+++ b/examples/manual/publishing.rs
@@ -13,22 +13,18 @@ use std::error::Error;
 use std::fmt::Display;
 use std::future::{Future, ready};
 
+use ruststream::TransactionalPublisher;
 use ruststream::codec::JsonCodec;
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::prelude::*;
 use ruststream::runtime::{
-    BoundSegment, MissingSegment, OutMessages, OutgoingMessageMetadata, PublishAt, PublishContext,
-    PublishError, PublishLayer, PublishNext, PublishPipeline, PublishTransform, PublishedThrough,
-    TemplateAddress, Transactional,
+    BoundSegment, MissingSegment, PublishAt, PublishContext, PublishError, PublishLayer,
+    PublishNext, PublishPipeline, PublishTransform, TemplateAddress, Transactional,
 };
 // The derive and the pipeline's message type share the name in different namespaces: the derive
 // is the macro `ruststream::Outgoing`, the value flowing through a publish transform is the type
 // `ruststream::runtime::Outgoing`.
 use ruststream::runtime::Outgoing;
-use ruststream::{
-    CallerName, FixedName, MessageHeaders, NameTemplate, NoHeaders, OutgoingDestination,
-    TransactionalPublisher,
-};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/examples/manual/seek.rs
+++ b/examples/manual/seek.rs
@@ -11,9 +11,9 @@ use std::error::Error;
 use std::future::{Future, ready};
 use std::time::Duration;
 
+use ruststream::Seeker;
 use ruststream::memory::{MemoryBroker, MemoryContext, MemoryPosition, MemorySource, SeekHandle};
 use ruststream::prelude::*;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination, Seeker};
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 

--- a/examples/manual/subscribers.rs
+++ b/examples/manual/subscribers.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 
 use ruststream::memory::{MemoryBroker, MemorySource};
 use ruststream::prelude::*;
-use ruststream::runtime::{Input, SoloDeserialized};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/examples/manual/typed_headers.rs
+++ b/examples/manual/typed_headers.rs
@@ -15,15 +15,9 @@ use std::future::{Future, ready};
 
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::prelude::*;
-use ruststream::runtime::{
-    ContainsMessage, Input, MessageWire, OutMessages, OutgoingMessageMetadata, PublishedThrough,
-    SerializedWire, SlotPos, SoloDeserialized,
-};
+use ruststream::runtime::{ContainsMessage, SlotPos};
 use ruststream::schemars::{JsonSchema, schema_for};
 use ruststream::testing::TestApp;
-use ruststream::{
-    CallerName, FixedName, MessageHeaders, NoHeaders, OutgoingDestination, WithHeaders,
-};
 use serde::{Deserialize, Serialize};
 
 /// The schema a declaration contributes to the document. The derives reach it through an autoref

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,17 @@
 //! context, the extractor parameters, the subscriber settings a mount site fills in, and the
 //! publishing types a handler reaches for. What a handler publishes it publishes through the
 //! builder, so the outgoing message type is not here; see the note on the re-export below.
+//!
+//! The manual path is a first-class citizen of the glob: every impl a derive would have written
+//! is spelled with names from here, so a service without the `macros` feature imports nothing
+//! else. That covers the two lanes (`Deserialized` with its [`Input`] spelling over
+//! [`SoloDeserialized`]; `Serialized` with [`MessageWire`] over [`SerializedWire`] for a typed
+//! publish and [`ReplyShape`] over [`SerializedReply`] for the reply position), the outgoing
+//! declaration ([`OutgoingDestination`] with its three forms, [`MessageHeaders`] with its two
+//! contracts), the slot vocabulary ([`OutSlot`], [`PublishedThrough`], [`OutMessages`] with the
+//! [`OutgoingMessageMetadata`] a dictionary reports), the state projection ([`FromRef`]) and
+//! the extractor binding ([`FromContext`]).
+//!
 //! Brokers, codecs and the optional feature modules (`asyncapi`, `metrics`, `logging`, `otel`,
 //! `testing`) stay explicit imports.
 //!
@@ -22,24 +33,29 @@
 //! ```
 
 pub use crate::runtime::{
-    App, AppInfo, Context, Ctx, DefaultSlot, Deserialized, FailurePolicies, FailurePolicy, FromRef,
-    Handle, HandlerOutcome, Headers, Message, Out, Outs, Publish, PublishExt, ReplyShape, Router,
-    RouterDef, RunningApp, RustStream, Serialized, Slot, State, SubscriberSettings, TypedPublisher,
-    Workers, subscriber,
+    App, AppInfo, Context, Ctx, DefaultSlot, Deserialized, FailurePolicies, FailurePolicy,
+    FromContext, FromRef, Handle, HandlerOutcome, Headers, Input, Message, MessageWire, Out,
+    OutMessages, OutgoingMessageMetadata, Outs, Publish, PublishExt, PublishedThrough, ReplyShape,
+    Router, RouterDef, RunningApp, RustStream, Serialized, SerializedReply, SerializedWire, Slot,
+    SoloDeserialized, State, SubscriberSettings, TypedPublisher, Workers, subscriber,
 };
 // `OutgoingMessage` is absent: a service on this crate publishes through the builder, which
 // assembles the message itself. What still needs one - a publish transform, a middleware, or a
 // broker crate used on its own without this one - names it explicitly.
 pub use crate::{
-    Broker, HeaderMap, IncomingMessage, MessageInfo, Name, OutSlot, PublishPolicy, Publisher,
-    Unnamed,
+    Broker, CallerName, FixedName, HeaderMap, IncomingMessage, MessageHeaders, MessageInfo, Name,
+    NameTemplate, NoHeaders, OutSlot, OutgoingDestination, PublishPolicy, Publisher, Unnamed,
+    WithHeaders,
 };
 // The counting macro every `workers(..)` chain writes.
 pub use crate::nonzero;
 
-// The derives sharing a name with their trait (`MessageInfo`, `OutSlot`, `FromRef`,
-// `Deserialized`, `Serialized`) come in with the re-exports above. `Outgoing` is the exception:
-// the derive lives at the crate root while the publish pipeline's message type of the same name
-// lives in `runtime`, so a service that writes a publish transform imports that one explicitly.
+// The derives sharing a name with their trait come in two ways. `MessageInfo` and `OutSlot`
+// carry both halves at the crate root, so the re-exports above bring the derive along. The
+// others keep the trait in `runtime` and only the derive at the root, so the derive is imported
+// here on its own - never the trait, which would collide with the `runtime` import above.
+// `Outgoing` is the exception: the derive lives at the crate root while the publish pipeline's
+// message type of the same name lives in `runtime`, so a service that writes a publish
+// transform imports that one explicitly.
 #[cfg(feature = "macros")]
-pub use crate::{Deserialized, FromRef, Outgoing, Serialized, app, subscriber};
+pub use crate::{Deserialized, FromRef, OutMessages, Outgoing, Serialized, app, subscriber};

--- a/src/runtime/extract.rs
+++ b/src/runtime/extract.rs
@@ -42,7 +42,7 @@ use super::handler::HandlerOutcome;
 /// # Examples
 ///
 /// ```
-/// use ruststream::runtime::{Context, FromContext, HandlerOutcome};
+/// use ruststream::prelude::*;
 ///
 /// // A custom extractor: reject the delivery unless a header is present.
 /// struct RequireToken(Vec<u8>);
@@ -86,7 +86,7 @@ pub trait FromContext<C = (), S = ()>: Sized {
 /// # Examples
 ///
 /// ```
-/// use ruststream::runtime::FromRef;
+/// use ruststream::prelude::*;
 ///
 /// #[derive(Clone)]
 /// struct Db;

--- a/src/runtime/handle/axis.rs
+++ b/src/runtime/handle/axis.rs
@@ -89,7 +89,7 @@ impl<H, P> Message<H, P> {
 /// comes for free - `&[Frame<'_>]` bodies mount off the same two impls:
 ///
 /// ```
-/// use ruststream::runtime::{Deserialized, Input, SoloDeserialized};
+/// use ruststream::prelude::*;
 ///
 /// struct Frame<'a>(&'a [u8]);
 ///

--- a/src/runtime/handle/outs.rs
+++ b/src/runtime/handle/outs.rs
@@ -9,13 +9,12 @@
 //! # #[cfg(all(feature = "memory", feature = "json"))]
 //! # mod demo {
 //! use ruststream::prelude::*;
-//! use ruststream::runtime::{Outs, Publish, PublishedThrough, Slot};
 //! # #[derive(serde::Deserialize, schemars::JsonSchema)]
 //! # struct Order { id: u64 }
 //! # #[derive(serde::Serialize, schemars::JsonSchema)]
 //! # struct Event { id: u64 }
-//! # impl ruststream::OutgoingDestination for Event { type Form = ruststream::CallerName; }
-//! # impl ruststream::MessageHeaders for Event { type Contract = ruststream::NoHeaders; }
+//! # impl OutgoingDestination for Event { type Form = CallerName; }
+//! # impl MessageHeaders for Event { type Contract = NoHeaders; }
 //! # struct Primary;
 //! # impl OutSlot for Primary { const NAME: &'static str = "Primary"; }
 //! # impl PublishedThrough<Primary> for Event {}

--- a/src/runtime/publish/builder.rs
+++ b/src/runtime/publish/builder.rs
@@ -186,9 +186,7 @@ impl<H> SatisfiesContract<WithHeaders<H>> for TypedHeaders<'_, H> {}
 /// [`ReplyShape`](crate::runtime::ReplyShape) for the reply position.
 ///
 /// ```
-/// use ruststream::runtime::{
-///     MessageWire, ReplyShape, Serialized, SerializedReply, SerializedWire,
-/// };
+/// use ruststream::prelude::*;
 ///
 /// struct Export(Vec<u8>);
 ///

--- a/src/runtime/slot.rs
+++ b/src/runtime/slot.rs
@@ -38,7 +38,7 @@ use crate::{
 /// # Examples
 ///
 /// ```
-/// use ruststream::runtime::OutSlot;
+/// use ruststream::prelude::*;
 ///
 /// #[derive(Clone, Copy, Debug)]
 /// struct Encoded;
@@ -72,7 +72,7 @@ pub trait OutSlot: 'static {
 /// # Examples
 ///
 /// ```
-/// use ruststream::runtime::{DefaultSlot, OutSlot};
+/// use ruststream::prelude::*;
 ///
 /// assert_eq!(<DefaultSlot as OutSlot>::NAME, "default");
 /// ```
@@ -98,7 +98,7 @@ impl OutSlot for DefaultSlot {
 /// # Examples
 ///
 /// ```
-/// use ruststream::runtime::{OutSlot, PublishedThrough};
+/// use ruststream::prelude::*;
 ///
 /// struct Progress;
 ///
@@ -301,7 +301,7 @@ impl_contains_message! {
 /// ```
 /// # #[cfg(all(feature = "macros", feature = "json"))]
 /// # mod demo {
-/// use ruststream::{OutMessages, Outgoing};
+/// use ruststream::prelude::*;
 /// use serde::Serialize;
 ///
 /// #[derive(Outgoing, Serialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -8,7 +8,7 @@
 /// # Examples
 ///
 /// ```
-/// use ruststream::MessageInfo;
+/// use ruststream::prelude::*;
 ///
 /// struct Order;
 /// impl MessageInfo for Order {
@@ -39,7 +39,7 @@ pub trait MessageInfo {
 /// # Examples
 ///
 /// ```
-/// use ruststream::{MessageHeaders, WithHeaders};
+/// use ruststream::prelude::*;
 ///
 /// struct ChunkMeta {
 ///     task_id: u64,
@@ -119,7 +119,7 @@ impl<H> HeadersContract for WithHeaders<H> {}
 /// # Examples
 ///
 /// ```
-/// use ruststream::{FixedName, OutgoingDestination};
+/// use ruststream::prelude::*;
 ///
 /// struct OrderDone;
 ///

--- a/tests/lane_traits_without_macros.rs
+++ b/tests/lane_traits_without_macros.rs
@@ -1,0 +1,132 @@
+//! The manual path with the `macros` feature off, imported from the prelude alone: the lane
+//! impls the derives would have written, spelled exactly as the traits' own rustdoc shows them,
+//! mounted as a service on the in-memory broker. The `macros` glob re-exports are gated, so
+//! this build is the one where a lane spelling missing from the prelude has nowhere else to
+//! come from; the file builds with no codec feature either, since neither lane needs one.
+#![cfg(all(not(feature = "macros"), feature = "memory", feature = "testing"))]
+
+use std::convert::Infallible;
+
+use ruststream::memory::{MemoryBroker, MemoryPublish};
+use ruststream::prelude::*;
+use ruststream::testing::TestApp;
+
+/// Deliberately not valid JSON (or UTF-8): a decode step anywhere on the path would fail it.
+const FRAME: &[u8] = b"\x00\x01raw \xffbytes";
+
+/// `#[derive(Deserialized)]` by hand, as the trait's rustdoc spells it: the construction that
+/// borrows the delivery's bytes, and the input spelling that routes `&Frame<'_>` onto the
+/// codec-free lane.
+struct Frame<'a>(&'a [u8]);
+
+impl Deserialized for Frame<'_> {
+    type Output<'a> = Frame<'a>;
+    type Error = Infallible;
+
+    fn from_payload(payload: &[u8]) -> Result<Frame<'_>, Self::Error> {
+        Ok(Frame(payload))
+    }
+}
+
+impl Input for Frame<'_> {
+    type Axis = SoloDeserialized<Frame<'static>>;
+}
+
+/// `#[derive(Serialized)]` by hand, as the trait's rustdoc spells it: the bytes, the wire
+/// spelling for a typed publish, and the shape for the reply position.
+struct Export(Vec<u8>);
+
+impl Serialized for Export {
+    fn bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl MessageWire for Export {
+    type Wire = SerializedWire;
+}
+
+impl ReplyShape for Export {
+    type Body = Self;
+    type Headers = ();
+    type Wire = SerializedReply;
+}
+
+// `#[derive(Outgoing)]` by hand on the same type, so the test client injects it through the
+// typed entry: no name declared, so each call site names its destination.
+impl OutgoingDestination for Export {
+    type Form = CallerName;
+}
+
+impl MessageHeaders for Export {
+    type Contract = NoHeaders;
+}
+
+/// The reply form: bytes in, bytes out, both on the user's own lane.
+struct Relay;
+
+impl<'p> Handle<Frame<'p>, Export> for Relay {
+    async fn handle(
+        &self,
+        frame: &Frame<'p>,
+        _outs: &(),
+        _ctx: &mut Context<'_>,
+    ) -> Result<Export, HandlerOutcome> {
+        let mut reply = frame.0.to_vec();
+        reply.reverse();
+        Ok(Export(reply))
+    }
+}
+
+/// The far end of the relay, so the round trip is observable as a delivery.
+struct Absorb;
+
+impl<'p> Handle<Frame<'p>> for Absorb {
+    async fn handle(
+        &self,
+        frame: &Frame<'p>,
+        _outs: &(),
+        _ctx: &mut Context<'_>,
+    ) -> Result<(), HandlerOutcome> {
+        let _ = frame.0.len();
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_prelude_carries_the_hand_written_lanes() {
+    let app =
+        RustStream::new(AppInfo::new("lanes", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(
+                subscriber("frames", Relay)
+                    .reply()
+                    .to("exports")
+                    .publisher(MemoryPublish)
+                    .build(),
+            );
+            b.include(subscriber("exports", Absorb).build());
+        });
+
+    let tb = TestApp::start(app).await.expect("harness start");
+    tb.broker::<MemoryBroker>()
+        .message(&Export(FRAME.to_vec()))
+        .to("frames")
+        .publish()
+        .await
+        .expect("publish");
+
+    let mut reversed = FRAME.to_vec();
+    reversed.reverse();
+    tb.broker::<MemoryBroker>()
+        .subscriber("frames")
+        .assert_called_once()
+        .with_raw(FRAME)
+        .settled(HandlerOutcome::ack());
+    tb.broker::<MemoryBroker>()
+        .subscriber("exports")
+        .assert_called_once()
+        .with_raw(&reversed)
+        .settled(HandlerOutcome::ack());
+
+    tb.shutdown().await.expect("graceful shutdown");
+}

--- a/tests/manual_app_start.rs
+++ b/tests/manual_app_start.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 
 use ruststream::memory::MemoryBroker;
 use ruststream::prelude::*;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 use tokio::time::timeout;

--- a/tests/manual_doc_testing_memory.rs
+++ b/tests/manual_doc_testing_memory.rs
@@ -8,7 +8,6 @@
 use std::future::{Future, ready};
 
 use ruststream::prelude::*;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/tests/manual_matrix.rs
+++ b/tests/manual_matrix.rs
@@ -11,9 +11,7 @@ use std::future::{Future, ready};
 
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::prelude::*;
-use ruststream::runtime::PublishedThrough;
 use ruststream::testing::TestApp;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]

--- a/tests/manual_out_injection.rs
+++ b/tests/manual_out_injection.rs
@@ -12,7 +12,6 @@ use common::{connected, expect_id};
 
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::prelude::*;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use serde::{Deserialize, Serialize};
 
 /// What crosses the two brokers. Declared here rather than taken from `common`, whose own

--- a/tests/manual_out_slots.rs
+++ b/tests/manual_out_slots.rs
@@ -10,13 +10,10 @@
 
 use std::convert::Infallible;
 
+use ruststream::PairError;
 use ruststream::memory::{ConnectedMemoryBroker, MemoryBroker, MemoryPublish, MemoryPublisher};
 use ruststream::prelude::*;
-use ruststream::runtime::{Input, MessageWire, PublishedThrough, SerializedWire, SoloDeserialized};
 use ruststream::testing::TestApp;
-use ruststream::{
-    CallerName, FixedName, MessageHeaders, NoHeaders, OutgoingDestination, PairError,
-};
 use serde::{Deserialize, Serialize};
 
 // `#[derive(Deserialized)]` by hand: the payload view the slot-publishing body takes, and the

--- a/tests/manual_raw_subscriber.rs
+++ b/tests/manual_raw_subscriber.rs
@@ -15,9 +15,7 @@ use std::sync::Mutex;
 
 use ruststream::memory::{MemoryBroker, MemoryPublish};
 use ruststream::prelude::*;
-use ruststream::runtime::{Input, MessageWire, SerializedReply, SerializedWire, SoloDeserialized};
 use ruststream::testing::TestApp;
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 
 /// Deliberately not valid JSON (or UTF-8): a decode step anywhere on the path would fail it.
 const FRAME: &[u8] = b"\x00\x01raw \xffbytes";

--- a/tests/manual_testing_harness.rs
+++ b/tests/manual_testing_harness.rs
@@ -14,7 +14,6 @@ use ruststream::memory::MemoryBroker;
 use ruststream::prelude::*;
 use ruststream::runtime::PublishError;
 use ruststream::testing::{TestApp, TestError};
-use ruststream::{CallerName, MessageHeaders, NoHeaders, OutgoingDestination};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, schemars::JsonSchema)]


### PR DESCRIPTION
# Description

A service without the `macros` feature writes by hand what the derives write, and those impls
name types the prelude did not carry: the `Input` spelling over `SoloDeserialized` for a
`Deserialized` type; `MessageWire` over `SerializedWire` and `SerializedReply` for a `Serialized`
one; the `OutgoingDestination` forms (`CallerName`, `FixedName`, `NameTemplate`) and the
`MessageHeaders` contracts (`NoHeaders`, `WithHeaders`) of an outgoing declaration; the slot
dictionary (`PublishedThrough`, `OutMessages` with the `OutgoingMessageMetadata` it reports);
and the `FromContext` binding behind an extractor parameter. Each was one more
`use ruststream::runtime::{..}` or `use ruststream::{..}` line, so the manual path could not be
written from the glob the docs present as the one import a service makes.

The prelude now carries those names, taken from where they live: the traits and wire markers
from `runtime`, the declaration vocabulary from the crate root. The crate root gains no
re-export, and a derive sharing its trait's name keeps coming in under the `macros` feature only,
so the trait namespace is imported exactly once. The rustdoc examples showing the hand-written
form import from the prelude, the manual tests and examples drop the imports the glob now covers,
and the `.cursor` rules describe the same surface.

A new test pins it: with `macros` off and no codec feature, it spells both lanes exactly as the
traits' rustdoc does, imports nothing from the crate but the glob and the in-memory broker, and
mounts them as a service. The reduced-feature CI leg runs it.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
