### PR TITLE
Let the batch forms carry the broker's page context

### DIFF
--- a/src/runtime/app/include/forms_batch.rs
+++ b/src/runtime/app/include/forms_batch.rs
@@ -5,7 +5,10 @@ use serde::Serialize;
 // The typed default-reply commits build a `TypedPublisher`, so the codec import is gated.
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::codec::DefaultCodec;
-use crate::{BatchSubscriber, Broker, Connected, PublishPolicy, Subscriber, SubscriptionSource};
+use crate::{
+    BatchSubscriber, Broker, BuildBatchContext, Connected, PublishPolicy, Subscriber,
+    SubscriptionSource,
+};
 #[cfg(any(feature = "json", feature = "cbor", feature = "msgpack"))]
 use crate::{DefaultPublish, Publisher};
 
@@ -48,6 +51,10 @@ macro_rules! impl_batch_inject_out_commit {
             SourceMessage<B, Bound::Source>: Send + 'static,
             Bound::Input: DecodeWith<DefMountCodec<Def, <Bound as BatchInjectDef>::Input, C>>,
             Bound::Injections: FromStartup<B, SourceSubscriber<B, Bound::Source>, Extra>
+                + Send
+                + Sync
+                + 'static,
+            Bound::Context: BuildBatchContext<SourceMessage<B, Bound::Source>>
                 + Send
                 + Sync
                 + 'static,
@@ -114,6 +121,7 @@ where
         + Sync
         + 'static,
     Def::Reply: Serialize + Send + Sync + 'static,
+    Def::Context: BuildBatchContext<SourceMessage<B, Def::Source>> + Send + Sync + 'static,
     <<B::Connected as DefaultPublish>::Policy as PublishPolicy<Connected<B>>>::Live:
         Publisher + 'static,
     Pipeline: PublishPipeline + Clone + Send + 'static,
@@ -143,8 +151,9 @@ where
         + Sync
         + 'static,
     Def::Reply: Serialize + Send + Sync + 'static,
+    Def::Context: BuildBatchContext<SourceMessage<B, Def::Source>> + Send + Sync + 'static,
     Source: PublishPolicy<Connected<B>, Live = BatchReply> + Send + 'static,
-    BatchReply: ReplyPublisher + 'static,
+    BatchReply: ReplyPublisher<Def::Context> + 'static,
     Pipeline: PublishPipeline + Clone + Send + 'static,
     State: Send + Sync + 'static,
 {
@@ -224,8 +233,12 @@ macro_rules! impl_batch_publishing_out_commit {
                 + Sync
                 + 'static,
             Bound::Reply: Serialize + Send + Sync + 'static,
+            Bound::Context: BuildBatchContext<SourceMessage<B, Bound::Source>>
+                + Send
+                + Sync
+                + 'static,
             Source: PublishPolicy<Connected<B>, Live = BatchReply> + Send + 'static,
-            BatchReply: ReplyPublisher + 'static,
+            BatchReply: ReplyPublisher<Bound::Context> + 'static,
             Extra: Send + Sync + 'static,
             Pipeline: PublishPipeline + Clone + Send + 'static,
             State: Send + Sync + 'static,

--- a/src/runtime/app/scope.rs
+++ b/src/runtime/app/scope.rs
@@ -421,6 +421,10 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
         Def: BatchInjectCall<State> + 'static,
         Def::Input: DecodeWith<DecodeCodec>,
         Def::Injections: FromStartup<B, Source::Subscriber, Extra> + Send + Sync + 'static,
+        Def::Context: crate::BuildBatchContext<<Source::Subscriber as Subscriber>::Message>
+            + Send
+            + Sync
+            + 'static,
         Extra: Send + Sync + 'static,
         DecodeCodec: Send + Sync + 'static,
         State: Send + Sync + 'static,
@@ -429,8 +433,7 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
         let meta = batch_inject_metadata(source.name().to_owned(), &def);
         let policies = def.failure_policies();
         let workers = def.workers();
-        // The injected batch forms keep the unit batch context for now; see `BatchDef::Context`.
-        self.sink.push_injected_batch::<_, _, _, _, ()>(
+        self.sink.push_injected_batch::<_, _, _, _, Def::Context>(
             source,
             async move |connected: Arc<Connected<B>>, subscriber| {
                 let injections = Def::Injections::resolve(extra, connected.as_ref(), &subscriber)
@@ -476,10 +479,14 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
         Def::Input: DecodeWith<DecodeCodec>,
         Def::Injections: FromStartup<B, Source::Subscriber, OutExtra> + Send + Sync + 'static,
         Def::Reply: Serialize + Send + Sync + 'static,
+        Def::Context: crate::BuildBatchContext<<Source::Subscriber as Subscriber>::Message>
+            + Send
+            + Sync
+            + 'static,
         // The reply side: the source pairs at startup into a batch reply wiring (plain or
-        // transactional).
+        // transactional) that reads the page's context while publishing each reply.
         ReplySource: PublishPolicy<Connected<B>, Live = BatchReply> + Send + 'static,
-        BatchReply: ReplyPublisher + 'static,
+        BatchReply: ReplyPublisher<Def::Context> + 'static,
         OutExtra: Send + Sync + 'static,
         DecodeCodec: Send + Sync + 'static,
         Pipeline: PublishPipeline + Clone + Send + 'static,
@@ -490,9 +497,7 @@ impl<B: Broker + 'static, Layers, SC, State, Pipeline> BrokerScope<B, Layers, SC
         let policies = def.failure_policies();
         let workers = def.workers();
         let pipeline = self.pipeline.clone();
-        // The batch publishing forms keep the unit batch context for now; see
-        // `BatchDef::Context`.
-        self.sink.push_injected_batch::<_, _, _, _, ()>(
+        self.sink.push_injected_batch::<_, _, _, _, Def::Context>(
             source,
             async move |connected: Arc<Connected<B>>, subscriber| {
                 let publisher = reply

--- a/src/runtime/batch_inject.rs
+++ b/src/runtime/batch_inject.rs
@@ -33,6 +33,10 @@ pub trait BatchInjectDef: Send + Sync {
     /// The tuple of startup-injected parameters ([`Out`](super::Out), ...).
     type Injections;
 
+    /// The broker's typed subscription-scoped context the page's handler reads by key (`()` when
+    /// the handler names none); see [`BatchDef::Context`](super::BatchDef::Context).
+    type Context;
+
     /// Builds the subscription source (fresh each call).
     fn source(&self) -> Self::Source;
 
@@ -91,7 +95,7 @@ pub trait BatchInjectCall<S>: BatchInjectDef {
         &self,
         batch: &[<Self::Input as InputKind>::Owned],
         injections: &Self::Injections,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, Self::Context, S>,
     ) -> impl Future<Output = BatchResult> + Send;
 }
 
@@ -125,20 +129,20 @@ impl<Def: BatchInjectDef, DecodeCodec> std::fmt::Debug for BatchInjectHandler<De
     }
 }
 
-// The injected batch forms keep the unit batch context for now; see `BatchDef::Context`.
-impl<Msg, Def, DecodeCodec, State> BatchHandler<Msg, (), State>
+impl<Msg, Def, DecodeCodec, State> BatchHandler<Msg, Def::Context, State>
     for BatchInjectHandler<Def, DecodeCodec>
 where
     Msg: IncomingMessage,
     Def: BatchInjectCall<State>,
     Def::Input: DecodeWith<DecodeCodec>,
     Def::Injections: Send + Sync,
+    Def::Context: Send + Sync,
     DecodeCodec: Send + Sync,
     State: Send + Sync,
 {
-    async fn handle_batch(&self, batch: Vec<Msg>, ctx: &mut Context<'_, (), State>) {
+    async fn handle_batch(&self, batch: Vec<Msg>, ctx: &mut Context<'_, Def::Context, State>) {
         let subscription = ctx.name().to_owned();
-        let (values, accepted) = decode_batch::<Msg, Def::Input, DecodeCodec, (), State>(
+        let (values, accepted) = decode_batch::<Msg, Def::Input, DecodeCodec, Def::Context, State>(
             batch,
             &self.codec,
             self.decode,
@@ -191,6 +195,7 @@ mod tests {
         type Input = Decoded<u32>;
         type Source = Name;
         type Injections = u32;
+        type Context = ();
 
         fn source(&self) -> Self::Source {
             Name::new("scale")

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -42,6 +42,13 @@ pub trait BatchPublishingDef: Send + Sync {
     /// [`InjectDef::Injections`](super::InjectDef::Injections).
     type Injections;
 
+    /// The broker's typed subscription-scoped context the page's handler reads by key (`()` when
+    /// the handler names none), exactly as on [`BatchDef::Context`](super::BatchDef::Context):
+    /// built once per page from its first delivery, so a replying page body reaches the
+    /// subscription's handles (a reposition handle, a consumer-group name) the same way a
+    /// settling one does.
+    type Context;
+
     /// The reply element type; each entry of the returned `Vec` is encoded and published.
     type Reply;
 
@@ -122,7 +129,7 @@ pub trait BatchPublishingCall<S>: BatchPublishingDef {
         &self,
         batch: &[<Self::Input as InputKind>::Owned],
         injections: &Self::Injections,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, Self::Context, S>,
     ) -> impl Future<Output = Result<Vec<Self::Reply>, BatchResult>> + Send;
 }
 
@@ -170,23 +177,24 @@ impl<D: BatchPublishingDef, C, R, PP> std::fmt::Debug for BatchPublishingHandler
     }
 }
 
-// The batch publishing forms keep the unit batch context for now; see `BatchDef::Context`.
-impl<M, D, C, R, PP, S> BatchHandler<M, (), S> for BatchPublishingHandler<D, C, R, PP>
+impl<M, D, C, R, PP, S> BatchHandler<M, D::Context, S> for BatchPublishingHandler<D, C, R, PP>
 where
     M: IncomingMessage,
     D: BatchPublishingCall<S>,
     D::Input: DecodeWith<C>,
     D::Injections: Send + Sync,
     D::Reply: Serialize + Send + Sync,
+    D::Context: Send + Sync,
     C: Send + Sync,
-    R: ReplyPublisher,
+    R: ReplyPublisher<D::Context>,
     PP: PublishPipeline,
     S: Send + Sync,
 {
-    async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_, (), S>) {
+    async fn handle_batch(&self, batch: Vec<M>, ctx: &mut Context<'_, D::Context, S>) {
         let subscription = ctx.name().to_owned();
         let (values, accepted) =
-            decode_batch::<M, D::Input, C, (), S>(batch, &self.codec, self.decode, ctx).await;
+            decode_batch::<M, D::Input, C, D::Context, S>(batch, &self.codec, self.decode, ctx)
+                .await;
         if accepted.is_empty() {
             return;
         }

--- a/src/runtime/batch_publishing/tests.rs
+++ b/src/runtime/batch_publishing/tests.rs
@@ -46,6 +46,7 @@ impl Confirm {
 impl BatchPublishingDef for Confirm {
     type Input = Decoded<u32>;
     type Injections = ();
+    type Context = ();
     type Reply = u32;
     type Source = Name;
 

--- a/src/runtime/handle/matrix_tests.rs
+++ b/src/runtime/handle/matrix_tests.rs
@@ -14,11 +14,14 @@ use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::codec::JsonCodec;
-use crate::memory::{ConnectedMemoryBroker, MemoryBroker, MemoryPublish, MemoryPublisher};
+use crate::memory::{
+    ConnectedMemoryBroker, MemoryBatchContext, MemoryBroker, MemoryPosition, MemoryPublish,
+    MemoryPublisher, SeekHandle,
+};
 use crate::nonzero;
 use crate::runtime::batch::{BatchDef, BatchResult, SliceHandler};
 use crate::runtime::batch_inject::BatchInjectDef;
-use crate::runtime::batch_publishing::BatchPublishingDef;
+use crate::runtime::batch_publishing::{BatchPublishingCall, BatchPublishingDef};
 use crate::runtime::context::Context;
 use crate::runtime::dispatch::Delivery;
 use crate::runtime::failure::{ErrorShutdown, FailurePolicy};
@@ -31,8 +34,10 @@ use crate::runtime::{
     Deserialized, Handle, Input, Message, Outs, Router, Slot, SoloDeserialized, TypedPublisher,
     subscriber,
 };
+use crate::testkit::batch::{publish_payloads, pull_batch};
 use crate::{
-    Broker, HeaderMap, Name, OutSlot, OutgoingMessage, PairError, PublishPolicy, Publisher, Unnamed,
+    Broker, BuildBatchContext, HeaderMap, Name, OutSlot, OutgoingMessage, PairError, PublishPolicy,
+    Publisher, Seeker, Unnamed,
 };
 
 use super::eager::{construct, settle_page};
@@ -157,6 +162,29 @@ impl Handle<Order, Confirmation> for Confirm {
         _ctx: &mut Context<'_>,
     ) -> impl Future<Output = Result<Confirmation, HandlerOutcome>> {
         ready(Ok(Confirmation { id: order.id }))
+    }
+}
+
+/// One confirmation per element, produced while the body reads the broker's page context: the
+/// cell where the reply axis and the context axis are named together.
+struct ConfirmPagesInContext;
+
+impl Handle<[Order], Vec<Confirmation>, (), MemoryBatchContext> for ConfirmPagesInContext {
+    async fn handle(
+        &self,
+        page: &[Order],
+        _outs: &(),
+        ctx: &mut Context<'_, MemoryBatchContext>,
+    ) -> Result<Vec<Confirmation>, Vec<HandlerOutcome>> {
+        if ctx
+            .context(SeekHandle)
+            .seek(MemoryPosition::end())
+            .await
+            .is_err()
+        {
+            return Err(page.iter().map(|_| HandlerOutcome::retry()).collect());
+        }
+        Ok(confirmations(page))
     }
 }
 
@@ -487,6 +515,36 @@ fn a_page_reply_attaches_a_transactional_publisher() {
             .publisher(TypedPublisher::new(MemoryPublish).transactional())
             .build(),
     );
+}
+
+/// A replying page body reaches the broker's subscription-scoped context: the page's own
+/// definition is driven with the context the runtime builds off the page's first delivery, and
+/// the reposition handle it carries is live there.
+#[tokio::test]
+async fn a_replying_page_reads_the_brokers_page_context() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("orders");
+    publish_payloads(&broker, "orders", &[br#"{"id":1}"#, br#"{"id":2}"#]).await;
+    let page = pull_batch(&mut sub).await;
+    let cx = <MemoryBatchContext as BuildBatchContext<_>>::build(&page[0]);
+
+    let def = definition_of(
+        subscriber("orders", ConfirmPagesInContext)
+            .reply()
+            .to("confirmations")
+            .build(),
+    );
+
+    let state = ();
+    let delivery = Delivery::empty();
+    let headers = HeaderMap::new();
+    let mut ctx = Context::new("orders", &headers, &state, cx, &delivery);
+    let replies = BatchPublishingCall::<()>::call(&def, &orders(2), &(), &mut ctx)
+        .await
+        .expect("the page answers once its reposition is accepted");
+
+    let ids: Vec<u64> = replies.iter().map(|reply| reply.id).collect();
+    assert_eq!(ids, [1, 2], "one reply per element, in page order");
 }
 
 // ------------------------------------------------------------------------- the page contract

--- a/src/runtime/handle/outs.rs
+++ b/src/runtime/handle/outs.rs
@@ -655,9 +655,10 @@ where
     }
 }
 
-impl<A, H, Doc, E> BatchInjectDef for Sealed<HandleValue<A, (), Outs<E>, (), H, Doc>>
+impl<A, C, H, Doc, E> BatchInjectDef for Sealed<HandleValue<A, (), Outs<E>, C, H, Doc>>
 where
     A: PagedAxis,
+    C: Send + Sync,
     H: Send + Sync,
     Doc: AxisDocs<A> + Send + Sync,
     E: EntryMarkers + Send + Sync,
@@ -665,6 +666,7 @@ where
     type Input = A::Kind;
     type Source = Unnamed<Name>;
     type Injections = Outs<E>;
+    type Context = C;
 
     fn source(&self) -> Unnamed<Name> {
         Unnamed::new()
@@ -703,42 +705,45 @@ where
     }
 }
 
-impl<T, S, H, Doc, E> BatchInjectCall<S> for Sealed<HandleValue<Page<T>, (), Outs<E>, (), H, Doc>>
+impl<T, C, S, H, Doc, E> BatchInjectCall<S> for Sealed<HandleValue<Page<T>, (), Outs<E>, C, H, Doc>>
 where
-    Self: BatchInjectDef<Input = <Page<T> as Axis>::Kind, Injections = Outs<E>>,
+    Self: BatchInjectDef<Input = <Page<T> as Axis>::Kind, Injections = Outs<E>, Context = C>,
     [T]: Input<Axis = Page<T>>,
     T: Send + Sync + 'static,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[T], (), Outs<E>, (), S>,
+    H: Handle<[T], (), Outs<E>, C, S>,
     E: Send + Sync,
 {
     async fn call(
         &self,
         batch: &[T],
         injections: &Outs<E>,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> BatchResult {
         let verdict = self.0.body.handle(batch, injections, ctx).await;
         settle_page(verdict, batch.len(), ctx.name())
     }
 }
 
-impl<Hd, P, S, H, Doc, E> BatchInjectCall<S>
-    for Sealed<HandleValue<PagePair<Hd, P>, (), Outs<E>, (), H, Doc>>
+impl<Hd, P, C, S, H, Doc, E> BatchInjectCall<S>
+    for Sealed<HandleValue<PagePair<Hd, P>, (), Outs<E>, C, H, Doc>>
 where
-    Self: BatchInjectDef<Input = <PagePair<Hd, P> as Axis>::Kind, Injections = Outs<E>>,
+    Self:
+        BatchInjectDef<Input = <PagePair<Hd, P> as Axis>::Kind, Injections = Outs<E>, Context = C>,
     [Message<Hd, P>]: Input<Axis = PagePair<Hd, P>>,
     Hd: Send + Sync + 'static,
     P: Send + Sync + 'static,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[Message<Hd, P>], (), Outs<E>, (), S>,
+    H: Handle<[Message<Hd, P>], (), Outs<E>, C, S>,
     E: Send + Sync,
 {
     async fn call(
         &self,
         batch: &[Message<Hd, P>],
         injections: &Outs<E>,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> BatchResult {
         let verdict = self.0.body.handle(batch, injections, ctx).await;
         settle_page(verdict, batch.len(), ctx.name())

--- a/src/runtime/handle/parity_tests.rs
+++ b/src/runtime/handle/parity_tests.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::Seeker;
 use crate::codec::JsonCodec;
 use crate::memory::{
-    MemoryBroker, MemoryContext, MemoryPublish, MemoryPublisher, MemorySource, Position, SeekHandle,
+    MemoryBatchContext, MemoryBroker, MemoryContext, MemoryPosition, MemoryPublish,
+    MemoryPublisher, MemorySource, Position, SeekHandle,
 };
 use crate::nonzero;
 use crate::runtime::{
@@ -229,6 +230,55 @@ impl Handle<[Order], Vec<Confirmation>> for ConfirmPages {
         ready(Ok(page
             .iter()
             .map(|order| Confirmation { id: order.id })
+            .collect()))
+    }
+}
+
+/// A page that answers and reads the broker's subscription-scoped context in one body: the
+/// reply axis and the context axis are independent, so naming one must not close the other.
+struct ConfirmPagesInContext;
+
+impl Handle<[Order], Vec<Confirmation>, (), MemoryBatchContext> for ConfirmPagesInContext {
+    async fn handle(
+        &self,
+        page: &[Order],
+        _outs: &(),
+        ctx: &mut Context<'_, MemoryBatchContext>,
+    ) -> Result<Vec<Confirmation>, Vec<HandlerOutcome>> {
+        if ctx
+            .context(SeekHandle)
+            .seek(MemoryPosition::end())
+            .await
+            .is_err()
+        {
+            // The per-element failure side of the page reply verdict, on the context axis.
+            return Err(page.iter().map(|_| HandlerOutcome::retry()).collect());
+        }
+        Ok(page
+            .iter()
+            .map(|order| Confirmation { id: order.id })
+            .collect())
+    }
+}
+
+/// The same cell on the pair page: typed element headers and a broker page context together.
+struct HeaderedPageInContext;
+
+impl Handle<[Message<Meta, Order>], Vec<Confirmation>, (), MemoryBatchContext>
+    for HeaderedPageInContext
+{
+    fn handle(
+        &self,
+        page: &[Message<Meta, Order>],
+        _outs: &(),
+        ctx: &mut Context<'_, MemoryBatchContext>,
+    ) -> impl Future<Output = Result<Vec<Confirmation>, Vec<HandlerOutcome>>> {
+        let _ = ctx.context(SeekHandle);
+        ready(Ok(page
+            .iter()
+            .map(|element| Confirmation {
+                id: element.body.id,
+            })
             .collect()))
     }
 }
@@ -459,6 +509,28 @@ fn reply_axes() -> impl RouterDef<MemoryBroker> {
                 .to("confirmations")
                 .build(),
         )
+        .include(
+            subscriber("orders", ConfirmPagesInContext)
+                .reply()
+                .to("confirmations")
+                .build(),
+        )
+        .include(
+            subscriber("orders", HeaderedPageInContext)
+                .reply()
+                .to("confirmations")
+                .publisher(TypedPublisher::new(MemoryPublish))
+                .build(),
+        )
+        // The client-side buffer turns any subscriber into a page source, so the reply and the
+        // broker page context must survive that wrapping too.
+        .include(
+            subscriber("orders", ConfirmPagesInContext)
+                .reply()
+                .to("confirmations")
+                .buffered(nonzero!(4), std::time::Duration::from_millis(5))
+                .build(),
+        )
 }
 
 #[test]
@@ -501,6 +573,52 @@ where
     ) -> impl Future<Output = Result<Vec<Confirmation>, Vec<HandlerOutcome>>> {
         let _ = outs;
         ready(Ok(page.iter().map(|o| Confirmation { id: o.id }).collect()))
+    }
+}
+
+/// The three-axis page cell: an answer, an injections arena and the broker's page context in
+/// one signature.
+struct PageGatewayInContext;
+
+impl<W, E> Handle<[Order], Vec<Confirmation>, Outs<(Slot<Analytics, W, E>,)>, MemoryBatchContext>
+    for PageGatewayInContext
+where
+    Slot<Analytics, W, E>: Publish,
+    W: Send + Sync,
+    E: Send + Sync,
+{
+    fn handle(
+        &self,
+        page: &[Order],
+        outs: &Outs<(Slot<Analytics, W, E>,)>,
+        ctx: &mut Context<'_, MemoryBatchContext>,
+    ) -> impl Future<Output = Result<Vec<Confirmation>, Vec<HandlerOutcome>>> {
+        let _ = (outs, ctx.context(SeekHandle));
+        ready(Ok(page
+            .iter()
+            .map(|order| Confirmation { id: order.id })
+            .collect()))
+    }
+}
+
+/// The same arena on a settling page, so the context axis is open with and without a reply.
+struct PageMirrorInContext;
+
+impl<W, E> Handle<[Order], (), Outs<(Slot<Analytics, W, E>,)>, MemoryBatchContext>
+    for PageMirrorInContext
+where
+    Slot<Analytics, W, E>: Publish,
+    W: Send + Sync,
+    E: Send + Sync,
+{
+    fn handle(
+        &self,
+        page: &[Order],
+        outs: &Outs<(Slot<Analytics, W, E>,)>,
+        ctx: &mut Context<'_, MemoryBatchContext>,
+    ) -> impl Future<Output = Result<(), Vec<HandlerOutcome>>> {
+        let _ = (page.len(), outs, ctx.context(SeekHandle));
+        ready(Ok(()))
     }
 }
 
@@ -573,6 +691,17 @@ fn slot_axes() -> impl RouterDef<MemoryBroker> {
                 .publisher(MemoryPublish)
                 .build(),
         )
+        .out(Analytics, MemoryPublish)
+        .build()
+        .include(
+            subscriber("orders", PageGatewayInContext)
+                .reply()
+                .to("confirmations")
+                .build(),
+        )
+        .out(Analytics, MemoryPublish)
+        .build()
+        .include(subscriber("orders", PageMirrorInContext).build())
         .out(Analytics, MemoryPublish)
         .build()
 }
@@ -652,6 +781,20 @@ async fn a_subscriber_dispatches_end_to_end() {
                     .build(),
             );
             b.include(subscriber("frames", RawEcho).reply().to("echoes").build());
+            b.include(
+                subscriber("orders", ConfirmPagesInContext)
+                    .reply()
+                    .to("confirmations")
+                    .build(),
+            );
+            b.include(
+                subscriber("orders", PageGatewayInContext)
+                    .reply()
+                    .to("confirmations")
+                    .build(),
+            )
+            .out(Analytics, MemoryPublish)
+            .build();
             b.include(
                 subscriber("orders", Confirm)
                     .reply()

--- a/src/runtime/handle/reply.rs
+++ b/src/runtime/handle/reply.rs
@@ -416,11 +416,12 @@ where
 
 // ------------------------------------------------------------------------- the page reply def
 
-impl<A, R, H, Doc, Dest, Attach> BatchPublishingDef
-    for Sealed<ReplyValue<HandleValue<A, Vec<R>, (), (), H, Doc>, Dest, Attach>>
+impl<A, R, C, H, Doc, Dest, Attach> BatchPublishingDef
+    for Sealed<ReplyValue<HandleValue<A, Vec<R>, (), C, H, Doc>, Dest, Attach>>
 where
     A: PagedAxis,
     R: ReplyShape<Wire: WireDocs<R, Doc>>,
+    C: Send + Sync,
     H: Send + Sync,
     Doc: AxisDocs<A> + Send + Sync,
     Dest: ReplyDest<R>,
@@ -428,6 +429,7 @@ where
 {
     type Input = A::Kind;
     type Injections = ();
+    type Context = C;
     type Reply = R;
     type Source = Unnamed<Name>;
 
@@ -509,43 +511,50 @@ pub(super) fn page_reply_verdict<R>(
     }
 }
 
-impl<T, R, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
-    for Sealed<ReplyValue<HandleValue<Page<T>, Vec<R>, (), (), H, Doc>, Dest, Attach>>
+impl<T, R, C, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
+    for Sealed<ReplyValue<HandleValue<Page<T>, Vec<R>, (), C, H, Doc>, Dest, Attach>>
 where
-    Self: BatchPublishingDef<Input = <Page<T> as Axis>::Kind, Injections = (), Reply = R>,
+    Self: BatchPublishingDef<Input = <Page<T> as Axis>::Kind, Injections = (), Context = C, Reply = R>,
     [T]: Input<Axis = Page<T>>,
     T: Send + Sync + 'static,
     R: ReplyShape,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[T], Vec<R>, (), (), S>,
+    H: Handle<[T], Vec<R>, (), C, S>,
 {
     async fn call(
         &self,
         batch: &[T],
         _injections: &(),
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> Result<Vec<R>, BatchResult> {
         let verdict = self.0.value.body.handle(batch, &(), ctx).await;
         page_reply_verdict(verdict, batch.len(), ctx.name())
     }
 }
 
-impl<Hd, P, R, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
-    for Sealed<ReplyValue<HandleValue<PagePair<Hd, P>, Vec<R>, (), (), H, Doc>, Dest, Attach>>
+impl<Hd, P, R, C, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
+    for Sealed<ReplyValue<HandleValue<PagePair<Hd, P>, Vec<R>, (), C, H, Doc>, Dest, Attach>>
 where
-    Self: BatchPublishingDef<Input = <PagePair<Hd, P> as Axis>::Kind, Injections = (), Reply = R>,
+    Self: BatchPublishingDef<
+            Input = <PagePair<Hd, P> as Axis>::Kind,
+            Injections = (),
+            Context = C,
+            Reply = R,
+        >,
     [Message<Hd, P>]: Input<Axis = PagePair<Hd, P>>,
     Hd: Send + Sync + 'static,
     P: Send + Sync + 'static,
     R: ReplyShape,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[Message<Hd, P>], Vec<R>, (), (), S>,
+    H: Handle<[Message<Hd, P>], Vec<R>, (), C, S>,
 {
     async fn call(
         &self,
         batch: &[Message<Hd, P>],
         _injections: &(),
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> Result<Vec<R>, BatchResult> {
         let verdict = self.0.value.body.handle(batch, &(), ctx).await;
         page_reply_verdict(verdict, batch.len(), ctx.name())

--- a/src/runtime/handle/reply_slots.rs
+++ b/src/runtime/handle/reply_slots.rs
@@ -249,12 +249,13 @@ where
 
 // ------------------------------------------------------------------------- the page reply def
 
-impl<A, R, E, H, Doc, Dest, Attach> BatchPublishingDef
-    for Sealed<ReplyValue<HandleValue<A, Vec<R>, Outs<E>, (), H, Doc>, Dest, Attach>>
+impl<A, R, E, C, H, Doc, Dest, Attach> BatchPublishingDef
+    for Sealed<ReplyValue<HandleValue<A, Vec<R>, Outs<E>, C, H, Doc>, Dest, Attach>>
 where
     A: PagedAxis,
     R: ReplyShape<Wire: WireDocs<R, Doc>>,
     E: EntryMarkers + Send + Sync,
+    C: Send + Sync,
     H: Send + Sync,
     Doc: AxisDocs<A> + Send + Sync,
     Dest: ReplyDest<R>,
@@ -262,6 +263,7 @@ where
 {
     type Input = A::Kind;
     type Injections = Outs<E>;
+    type Context = C;
     type Reply = R;
     type Source = Unnamed<Name>;
 
@@ -318,45 +320,57 @@ where
     }
 }
 
-impl<T, R, E, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
-    for Sealed<ReplyValue<HandleValue<Page<T>, Vec<R>, Outs<E>, (), H, Doc>, Dest, Attach>>
+impl<T, R, E, C, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
+    for Sealed<ReplyValue<HandleValue<Page<T>, Vec<R>, Outs<E>, C, H, Doc>, Dest, Attach>>
 where
-    Self: BatchPublishingDef<Input = <Page<T> as Axis>::Kind, Injections = Outs<E>, Reply = R>,
+    Self: BatchPublishingDef<
+            Input = <Page<T> as Axis>::Kind,
+            Injections = Outs<E>,
+            Context = C,
+            Reply = R,
+        >,
     [T]: Input<Axis = Page<T>>,
     T: Send + Sync + 'static,
     R: ReplyShape,
     E: Send + Sync,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[T], Vec<R>, Outs<E>, (), S>,
+    H: Handle<[T], Vec<R>, Outs<E>, C, S>,
 {
     async fn call(
         &self,
         batch: &[T],
         injections: &Outs<E>,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> Result<Vec<R>, BatchResult> {
         let verdict = self.0.value.body.handle(batch, injections, ctx).await;
         page_reply_verdict(verdict, batch.len(), ctx.name())
     }
 }
 
-impl<Hd, P, R, E, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
-    for Sealed<ReplyValue<HandleValue<PagePair<Hd, P>, Vec<R>, Outs<E>, (), H, Doc>, Dest, Attach>>
+impl<Hd, P, R, E, C, S, H, Doc, Dest, Attach> BatchPublishingCall<S>
+    for Sealed<ReplyValue<HandleValue<PagePair<Hd, P>, Vec<R>, Outs<E>, C, H, Doc>, Dest, Attach>>
 where
-    Self: BatchPublishingDef<Input = <PagePair<Hd, P> as Axis>::Kind, Injections = Outs<E>, Reply = R>,
+    Self: BatchPublishingDef<
+            Input = <PagePair<Hd, P> as Axis>::Kind,
+            Injections = Outs<E>,
+            Context = C,
+            Reply = R,
+        >,
     [Message<Hd, P>]: Input<Axis = PagePair<Hd, P>>,
     Hd: Send + Sync + 'static,
     P: Send + Sync + 'static,
     R: ReplyShape,
     E: Send + Sync,
+    C: Send + Sync,
     S: Send + Sync,
-    H: Handle<[Message<Hd, P>], Vec<R>, Outs<E>, (), S>,
+    H: Handle<[Message<Hd, P>], Vec<R>, Outs<E>, C, S>,
 {
     async fn call(
         &self,
         batch: &[Message<Hd, P>],
         injections: &Outs<E>,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, C, S>,
     ) -> Result<Vec<R>, BatchResult> {
         let verdict = self.0.value.body.handle(batch, injections, ctx).await;
         page_reply_verdict(verdict, batch.len(), ctx.name())

--- a/src/runtime/router/routes_inject.rs
+++ b/src/runtime/router/routes_inject.rs
@@ -9,7 +9,9 @@
 use std::fmt;
 use std::sync::Arc;
 
-use crate::{BatchSubscriber, Broker, BuildContext, Connected, SubscriptionSource};
+use crate::{
+    BatchSubscriber, Broker, BuildBatchContext, BuildContext, Connected, SubscriptionSource,
+};
 
 use crate::runtime::batch_inject::{BatchInjectCall, BatchInjectHandler};
 use crate::runtime::dispatch::{Workers, spawn_dispatch_workers};
@@ -161,6 +163,7 @@ where
     Def: BatchInjectCall<State> + 'static,
     Def::Input: DecodeWith<DecodeCodec>,
     Def::Injections: FromStartup<B, Source::Subscriber, Extra> + Send + Sync + 'static,
+    Def::Context: BuildBatchContext<SourceMessage<B, Source>> + Send + Sync + 'static,
     DecodeCodec: Send + Sync + 'static,
     Extra: Send + Sync + 'static,
 {
@@ -179,8 +182,7 @@ where
             policies,
             workers,
         } = self;
-        // The injected batch forms keep the unit batch context for now; see `BatchDef::Context`.
-        sink.push_injected_batch::<_, _, _, _, ()>(
+        sink.push_injected_batch::<_, _, _, _, Def::Context>(
             source,
             async move |connected: Arc<Connected<B>>, subscriber| {
                 let injections = Def::Injections::resolve(extra, connected.as_ref(), &subscriber)

--- a/src/runtime/router/routes_publish.rs
+++ b/src/runtime/router/routes_publish.rs
@@ -14,7 +14,8 @@ use serde::Serialize;
 
 use crate::codec::Codec;
 use crate::{
-    BatchSubscriber, Broker, BuildContext, Connected, PublishPolicy, Publisher, SubscriptionSource,
+    BatchSubscriber, Broker, BuildBatchContext, BuildContext, Connected, PublishPolicy, Publisher,
+    SubscriptionSource,
 };
 
 use crate::runtime::batch_publishing::{BatchPublishingCall, BatchPublishingHandler};
@@ -297,12 +298,13 @@ where
     Def::Input: DecodeWith<DecodeCodec>,
     Def::Injections: FromStartup<B, Source::Subscriber, Extra> + Send + Sync + 'static,
     Def::Reply: Serialize + Send + Sync + 'static,
+    Def::Context: BuildBatchContext<SourceMessage<B, Source>> + Send + Sync + 'static,
     DecodeCodec: Send + Sync + 'static,
     Extra: Send + Sync + 'static,
     // The reply side: the source pairs at startup into a batch reply wiring (plain or
-    // transactional).
+    // transactional) that reads the page's context while publishing each reply.
     ReplySource: PublishPolicy<Connected<B>, Live = BatchReply> + Send + 'static,
-    BatchReply: ReplyPublisher + 'static,
+    BatchReply: ReplyPublisher<Def::Context> + 'static,
 {
     fn mount_one<G, PP>(self, _global: &G, pipeline: &PP, sink: &mut RouterSink<B, State>)
     where
@@ -323,9 +325,7 @@ where
             policies,
             workers,
         } = self;
-        // The batch publishing forms keep the unit batch context for now; see
-        // `BatchDef::Context`.
-        sink.push_injected_batch::<_, _, _, _, ()>(
+        sink.push_injected_batch::<_, _, _, _, Def::Context>(
             source,
             async move |connected: Arc<Connected<B>>, subscriber| {
                 let publisher = publisher

--- a/src/runtime/settings/forward.rs
+++ b/src/runtime/settings/forward.rs
@@ -193,6 +193,7 @@ where
     type Input = <Def as BatchInjectDef>::Input;
     type Source = Src;
     type Injections = <Def as BatchInjectDef>::Injections;
+    type Context = <Def as BatchInjectDef>::Context;
 
     forward_common!(BatchInjectDef);
     forward_outgoing!(BatchInjectDef);
@@ -209,7 +210,7 @@ where
         &self,
         batch: &[<<Def as BatchInjectDef>::Input as InputKind>::Owned],
         injections: &<Def as BatchInjectDef>::Injections,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, <Def as BatchInjectDef>::Context, S>,
     ) -> impl Future<Output = BatchResult> + Send {
         self.def.call(batch, injections, ctx)
     }
@@ -224,6 +225,7 @@ where
 {
     type Input = <Def as BatchPublishingDef>::Input;
     type Injections = <Def as BatchPublishingDef>::Injections;
+    type Context = <Def as BatchPublishingDef>::Context;
     type Reply = <Def as BatchPublishingDef>::Reply;
     type Source = Src;
 
@@ -246,7 +248,7 @@ where
         &self,
         batch: &[<<Def as BatchPublishingDef>::Input as InputKind>::Owned],
         injections: &<Def as BatchPublishingDef>::Injections,
-        ctx: &mut Context<'_, (), S>,
+        ctx: &mut Context<'_, <Def as BatchPublishingDef>::Context, S>,
     ) -> impl Future<Output = Result<Vec<<Def as BatchPublishingDef>::Reply>, BatchResult>> + Send
     {
         self.def.call(batch, injections, ctx)

--- a/tests/page_reply_context.rs
+++ b/tests/page_reply_context.rs
@@ -1,0 +1,147 @@
+//! A page that answers and reads the broker's subscription-scoped context in one body.
+//!
+//! The reply axis and the context axis are independent: naming the broker's batch context
+//! (`MemoryBatchContext` here) must leave the `publish(..)` clause intact, and the reposition
+//! handle the context carries must be live while the replies are produced.
+#![cfg(all(
+    feature = "memory",
+    feature = "macros",
+    feature = "json",
+    feature = "testing"
+))]
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use ruststream::Seeker;
+use ruststream::memory::{MemoryBatchContext, MemoryBroker, MemoryPosition, SeekHandle};
+use ruststream::prelude::*;
+use ruststream::testing::TestApp;
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct Order {
+    id: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+struct Digest {
+    id: u64,
+}
+
+/// The producer's cursor contract: an element carrying `resume_at` asks the consumer to
+/// reposition the subscription to that log position once the page is settled.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct Cursor {
+    resume_at: Option<u64>,
+}
+
+/// One digest per order, produced while the body holds the broker's page context.
+#[subscriber("orders", publish("digests"))]
+async fn digest(page: &[Order], ctx: &mut Context<'_, MemoryBatchContext>) -> Vec<Digest> {
+    // Reading the key is what proves the page context reached a replying body; the handle it
+    // yields is the subscription's own.
+    let _seeker = ctx.context(SeekHandle);
+    page.iter().map(|order| Digest { id: order.id }).collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_replying_page_reads_the_brokers_page_context() {
+    let app =
+        RustStream::new(AppInfo::new("digests", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(digest);
+        });
+    let tb = TestApp::start(app).await.expect("harness start");
+
+    tb.broker::<MemoryBroker>()
+        .publish("orders", &Order { id: 7 })
+        .await
+        .expect("publish");
+
+    tb.broker::<MemoryBroker>()
+        .published::<Digest>("digests")
+        .assert_called_once()
+        .with(&Digest { id: 7 });
+    tb.broker::<MemoryBroker>()
+        .subscriber("orders")
+        .assert_called_once()
+        .settled(HandlerOutcome::ack());
+
+    tb.shutdown().await.expect("graceful shutdown");
+}
+
+/// The same body, repositioning the subscription through the page context before it answers:
+/// where to resume rides the elements' own header contract, since a page context carries no
+/// per-delivery data.
+#[subscriber("replay.orders", publish("replay.digests"))]
+async fn replay_digest(
+    page: &[Message<Cursor, Order>],
+    ctx: &mut Context<'_, MemoryBatchContext>,
+) -> Result<Vec<Digest>, HandlerOutcome> {
+    let target = page
+        .iter()
+        .find_map(|element| element.headers.resume_at)
+        .map(|sequence| usize::try_from(sequence).expect("test positions are small"));
+    if let Some(sequence) = target
+        && ctx
+            .context(SeekHandle)
+            .seek(MemoryPosition::sequence(sequence))
+            .await
+            .is_err()
+    {
+        return Err(HandlerOutcome::retry());
+    }
+    Ok(page
+        .iter()
+        .map(|element| Digest {
+            id: element.body.id,
+        })
+        .collect())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_replying_page_repositions_through_the_page_context() {
+    let app =
+        RustStream::new(AppInfo::new("replay", "0.1.0")).with_broker(MemoryBroker::new(), |b| {
+            b.include(replay_digest);
+        });
+    let tb = TestApp::start(app).await.expect("harness start");
+
+    // The first order lands at log position 0 and asks the consumer to resume at position 1,
+    // the slot the next publish takes: the reposition is real, and it neither loses nor
+    // duplicates anything.
+    tb.broker::<MemoryBroker>()
+        .publish_with_headers(
+            "replay.orders",
+            &Order { id: 1 },
+            &Cursor { resume_at: Some(1) },
+        )
+        .await
+        .expect("publish");
+    tb.broker::<MemoryBroker>()
+        .publish_with_headers(
+            "replay.orders",
+            &Order { id: 2 },
+            &Cursor { resume_at: None },
+        )
+        .await
+        .expect("publish");
+    tb.settle().await.expect("settle");
+
+    // A failed reposition would settle the page as a retry, so the acks are what say the handle
+    // the page context carries was live.
+    tb.broker::<MemoryBroker>()
+        .subscriber("replay.orders")
+        .assert_called(2)
+        .settled(HandlerOutcome::ack());
+    let published = tb
+        .broker::<MemoryBroker>()
+        .published::<Digest>("replay.digests");
+    let ids: Vec<u64> = published.decoded().iter().map(|reply| reply.id).collect();
+    assert_eq!(
+        ids,
+        [1, 2],
+        "the subscription must resume at the named position, answering each order once",
+    );
+
+    tb.shutdown().await.expect("graceful shutdown");
+}


### PR DESCRIPTION
# Description

A page body that both answers through the reply clause and names the broker's subscription-scoped
context did not compile, while the same body without a reply did:

```rust
#[subscriber("orders", publish("digests"))]
async fn digest(page: &[Order], ctx: &mut Context<'_, MemoryBatchContext>) -> Vec<Digest> { .. }
```

The batch definition traits behind the reply and the injections forms carried no context axis at
all and spelled the unit type into their call signature, so naming a broker page context closed the
`publish(..)` clause and vice versa. The single-message definitions have carried that axis since
the typed-context work, so this was a gap in the batch half only, and it hit the manual path
identically (`Handle<[Order], Digest, (), MemoryBatchContext>` mounted through
`subscriber(..).reply().to(..).build()`).

The batch definitions now carry the context axis their single-message counterparts already have,
and the mounts thread it from the definition to the dispatch loop, so the runtime builds the page
context off the page's first delivery exactly as it does for a settling page. The reply publisher
was already generic over the context it reads while publishing, so nothing new is checked at run
time: the combination is either well-typed or it is a compile error naming the missing bound.

The forms that were pinned the same way are fixed together, since they are one axis and not four:
the plain page reply, the pair page reply, a reply with `Out` slots, an `Out` arena without a
reply, and the client-side buffered source under any of them.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

The definition traits are crate-internal (their modules are private and nothing re-exports them),
so the added associated type is not a public-API change; the change lands inside the unreleased
0.7 line either way.

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable

## Tests

- The parity suite gains the missing cells, so a lost combination fails the build again: a page
  reply reading the page context, the pair-page form of it, the three-axis cell (reply, arena and
  context together), the arena-without-reply cell, and the buffered source under a page reply.
- The matrix suite drives one of them against a context the runtime built off a real delivery, so
  the handle the context carries is exercised rather than only typed.
- A new integration suite runs both shapes end to end on the in-memory broker through the test
  harness: a replying page reading the page context, and one repositioning the subscription through
  it before answering.

The docs already described the page context as available to any page body, so the fix makes the
existing text true rather than needing new text.
