### PR TITLE
Release 0.7.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.7.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/ruststream-macros"]
 exclude = ["templates"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.0-rc.1"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -475,7 +475,7 @@ tracing = "0.1.29"
 # Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
 # release for release (a loose range let a partial `cargo update` pair a new core with an old
 # macros crate and fail to compile). Bumped by the same edit as [workspace.package].version.
-ruststream-macros = { version = "=0.7.0", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "=0.7.0-rc.1", path = "crates/ruststream-macros", optional = true }
 # 0.3.22 is the real floor, not 0.3: `tracing-opentelemetry` 0.33 requires `^0.3.22`, so the
 # `otel` feature never resolved anything lower, and the declared bound claimed years of releases
 # that were never built against.


### PR DESCRIPTION
# Description

Moves the workspace to `0.7.0-rc.1` so the 0.7 line can be published as a pre-release.

The surface is complete on `main` and its gates are green, but the twelve broker crates have only
ever compiled against a path dependency to this repository. Publishing a release candidate puts the
real artifact on crates.io, so each of them can resolve `ruststream` the way a user will - through
the registry, with the feature resolution and the packaged file set that only a published crate
exercises - before the line is declared stable.

One edit covers both crates: `ruststream-macros` inherits `[workspace.package].version`, and the
exact pin between them (`=0.7.0-rc.1`) follows it, so a partial `cargo update` still cannot pair a
new core with an old macros crate.

The release workflow needs no change: it strips the `v` prefix from the tag and compares the result
to the crate version, so `v0.7.0-rc.1` matches.

Two consequences worth stating, neither of them handled here:

- A pre-release does not satisfy the broker crates' `>=0.7.0, <0.8.0` requirement, because Cargo
  excludes pre-releases from a range that does not name one. Each broker branch has to point at
  `0.7.0-rc.1` explicitly to build against it.
- The install instructions in the README and the getting-started pages still say `version = "0.7"`,
  which is the requirement for the final release, not for this candidate. They are left as they
  are rather than churned twice.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

Neither the API nor the behaviour changes; only the version the workspace carries.

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)

`just check` and `just test` pass, and `cargo publish --dry-run -p ruststream-macros -p ruststream`
packages both crates at the new version.
