### PR TITLE
Build the scaffold against the version the workspace carries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,16 @@ jobs:
           # package discovery never parses its placeholder name. Assert that cargo-generate did
           # drop the suffix, otherwise the append below would quietly write a manifest of its own.
           test -f "$RUNNER_TEMP/smoke/Cargo.toml"
+          # `[patch]` redirects where a crate comes from, not what the manifest asks for, and
+          # Cargo keeps pre-releases out of a range that does not name one. So while the
+          # workspace is on a pre-release the scaffold's own `0.7` would reject this checkout.
+          # Point the rendered copy at the version actually being built; the template keeps the
+          # requirement a user writes for the release it targets.
+          VERSION=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "ruststream") | .version')
+          sed -i "s|^ruststream = { version = \"[^\"]*\"|ruststream = { version = \"$VERSION\"|" \
+            "$RUNNER_TEMP/smoke/Cargo.toml"
+          grep -q "version = \"$VERSION\"" "$RUNNER_TEMP/smoke/Cargo.toml"
           {
             echo ""
             echo "[patch.crates-io]"


### PR DESCRIPTION
# Description

The scaffold job has been failing on `main` since the workspace moved to a pre-release version.

`[patch.crates-io]` redirects where a crate comes from, not what a manifest asks for, and Cargo
keeps pre-releases out of a version range that does not name one. The rendered scaffold asks for
`ruststream = "0.7"`, so it rejects the very checkout the job exists to test, and the failure says
nothing about template drift - the thing the job is meant to catch.

The rendered copy now takes the version actually being built, read from `cargo metadata`, before
the patch section is appended. The template itself keeps `"0.7"`: that is the requirement a user
writes for the release it targets, and it should not churn twice around a release candidate.

Verified by rendering the scaffold locally with `cargo-generate`, applying the same two steps, and
building it against this checkout at `0.7.0-rc.1`.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

CI only; no library code and no template content changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

The job this changes is the check itself, so the proof is the job going green on this PR.
