### PR TITLE
Route a batch retry_after through the delayed-redelivery fallback

### DIFF
--- a/src/runtime/batch.rs
+++ b/src/runtime/batch.rs
@@ -20,13 +20,12 @@ use opentelemetry::{KeyValue, global};
 // reach decoding through `DecodeWith`.
 #[cfg(test)]
 use serde::de::DeserializeOwned;
-use tokio_util::task::TaskTracker;
 use tracing::{error, warn};
 
 use crate::IncomingMessage;
 
 use super::context::Context;
-use super::dispatch::Workers;
+use super::dispatch::{Delivery, Workers, settle_outcome};
 use super::failure::{FailurePolicies, FailurePolicy};
 use super::handle::Deserialized;
 use super::handler::{HandlerOutcome, HandlerResult};
@@ -375,9 +374,9 @@ where
         if accepted.is_empty() {
             return;
         }
-        let tasks = ctx.tasks().clone();
+        let delivery = ctx.delivery();
         let result = self.inner.handle_slice(&values, ctx).await;
-        settle_batch(accepted, result, &subscription, &tasks).await;
+        settle_batch(accepted, result, &subscription, delivery).await;
     }
 }
 
@@ -434,7 +433,7 @@ where
         if batch.is_empty() {
             return;
         }
-        let tasks = ctx.tasks().clone();
+        let delivery = ctx.delivery();
         // The constructed values borrow the deliveries' payloads, so the deliveries stay owned
         // by `batch` and the values are dropped before anything settles. Rejections are settled
         // after the batch runs, which keeps the accepted values contiguous with no second pass.
@@ -468,7 +467,7 @@ where
             self.inner.handle_slice(&values, ctx).await
         };
         drop(values);
-        settle_split_batch(batch, rejected, result, &subscription, &tasks).await;
+        settle_split_batch(batch, rejected, result, &subscription, delivery).await;
     }
 }
 
@@ -480,10 +479,10 @@ async fn settle_split_batch<M: IncomingMessage>(
     rejected: Vec<(usize, HandlerResult)>,
     result: BatchResult,
     subscription: &str,
-    tasks: &TaskTracker,
+    delivery: &Delivery,
 ) {
     if rejected.is_empty() {
-        return settle_batch(batch, result, subscription, tasks).await;
+        return settle_batch(batch, result, subscription, delivery).await;
     }
     let accepted_len = batch.len() - rejected.len();
     let per_element = match result {
@@ -509,16 +508,16 @@ async fn settle_split_batch<M: IncomingMessage>(
     for (index, msg) in batch.into_iter().enumerate() {
         if rejected.peek().is_some_and(|(at, _)| *at == index) {
             let (_, outcome) = rejected.next().expect("peeked");
-            settle(msg, outcome, subscription).await;
+            settle_outcome(msg, outcome, subscription, delivery).await;
             continue;
         }
         let mut result = accepted_results
             .next()
             .unwrap_or_else(HandlerOutcome::retry);
         let after = result.take_after();
-        settle(msg, result.outcome(), subscription).await;
+        settle_outcome(msg, result.outcome(), subscription, delivery).await;
         if let Some(after) = after {
-            tasks.spawn(after);
+            delivery.tasks.spawn(after);
         }
     }
 }
@@ -529,7 +528,7 @@ pub(crate) async fn settle_batch<M: IncomingMessage>(
     accepted: Vec<M>,
     result: BatchResult,
     subscription: &str,
-    tasks: &TaskTracker,
+    delivery: &Delivery,
 ) {
     // Every batch form funnels its batch through here, which is the one place that knows both
     // the deliveries and the settlements they got; the harness reads the batch off it.
@@ -542,13 +541,13 @@ pub(crate) async fn settle_batch<M: IncomingMessage>(
             for msg in accepted {
                 #[cfg(feature = "testing")]
                 batch.settled(status);
-                settle(msg, status, subscription).await;
+                settle_outcome(msg, status, subscription, delivery).await;
             }
             // The one uniform continuation runs after the whole batch is settled, on the
             // tracked set so a graceful shutdown drains it (at-most-once, like the
             // per-element ones below).
             if let Some(after) = after {
-                tasks.spawn(after);
+                delivery.tasks.spawn(after);
             }
         }
         BatchResult::PerElement(results) => {
@@ -569,12 +568,12 @@ pub(crate) async fn settle_batch<M: IncomingMessage>(
                 let after = result.take_after();
                 #[cfg(feature = "testing")]
                 batch.settled(result.outcome());
-                settle(msg, result.outcome(), subscription).await;
+                settle_outcome(msg, result.outcome(), subscription, delivery).await;
                 // The continuation runs after this element is settled, on the tracked set so a
                 // graceful shutdown drains it. At-most-once: a lost or panicking continuation
                 // never redelivers the already-settled message.
                 if let Some(after) = after {
-                    tasks.spawn(after);
+                    delivery.tasks.spawn(after);
                 }
             }
         }
@@ -680,6 +679,9 @@ where
     S: Send + Sync,
 {
     let subscription = ctx.name().to_owned();
+    // Taken before the loop: the settle below awaits, and a borrow of `ctx` held across it would
+    // demand `Context: Sync` (see the signature's note).
+    let delivery = ctx.delivery();
     let mut values = Vec::with_capacity(batch.len());
     let mut accepted = Vec::with_capacity(batch.len());
     for msg in batch {
@@ -697,7 +699,7 @@ where
                     "codec decode failed",
                 );
                 let outcome = rejection(&err, "batch decode failed", decode, ctx);
-                settle(msg, outcome, &subscription).await;
+                settle_outcome(msg, outcome, &subscription, delivery).await;
             }
         }
     }
@@ -726,23 +728,6 @@ fn rejection<C, S>(
             HandlerResult::drop()
         }
         other => other.settlement().unwrap_or_else(HandlerResult::drop),
-    }
-}
-
-/// Applies one settlement to one delivery's own `ack` / `nack`.
-pub(crate) async fn settle<M: IncomingMessage>(msg: M, result: HandlerResult, subscription: &str) {
-    let ack_result = match result {
-        HandlerResult::Ack => msg.ack().await,
-        HandlerResult::Nack { requeue } => msg.nack(requeue).await,
-        HandlerResult::NackAfter { delay } => msg.nack_after(delay).await,
-    };
-    if let Err(err) = ack_result {
-        warn!(
-            target: "ruststream::dispatch",
-            subscription = %subscription,
-            error = %err,
-            "ack / nack failed",
-        );
     }
 }
 

--- a/src/runtime/batch/tests.rs
+++ b/src/runtime/batch/tests.rs
@@ -1,16 +1,19 @@
 use std::future::ready;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
 
+use bytes::Bytes;
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
-use super::super::dispatch::Delivery;
+use super::super::dispatch::{Delivery, RETRY_COUNT_HEADER};
 use super::super::failure::ErrorShutdown;
 use super::super::input::Decoded;
 use super::*;
 use crate::codec::JsonCodec;
-use crate::memory::{ConnectedMemoryBroker, MemoryBroker, MemoryMessage};
+use crate::memory::{ConnectedMemoryBroker, MemoryBroker, MemoryMessage, MemorySubscriber};
 use crate::testkit::batch::{publish_numbers, publish_payloads, pull_batch};
 #[cfg(feature = "logging")]
 use crate::testkit::log_capture;
@@ -141,7 +144,7 @@ async fn per_element_outcomes_carry_delays() {
         let outcomes: Vec<HandlerOutcome> = batch
             .iter()
             .map(|n| match n {
-                1 => HandlerOutcome::retry_after(std::time::Duration::from_secs(5)),
+                1 => HandlerOutcome::retry_after(Duration::from_secs(5)),
                 _ => HandlerOutcome::ack(),
             })
             .collect();
@@ -157,7 +160,7 @@ async fn per_element_outcomes_carry_delays() {
 
     let mut stream = std::pin::pin!(sub.stream());
     assert!(futures::poll!(stream.next()).is_pending());
-    tokio::time::advance(std::time::Duration::from_secs(5)).await;
+    tokio::time::advance(Duration::from_secs(5)).await;
     tokio::task::yield_now().await;
 
     let redelivered = stream.next().await.unwrap().unwrap();
@@ -371,7 +374,7 @@ async fn a_refused_ack_does_not_abort_the_batch() {
         batch,
         BatchResult::Uniform(HandlerOutcome::ack()),
         "refusing",
-        &TaskTracker::new(),
+        &Delivery::empty(),
     )
     .await;
 
@@ -395,7 +398,7 @@ async fn outcome_count_mismatch_is_logged_with_both_counts() {
         batch,
         BatchResult::PerElement(vec![HandlerOutcome::ack()]),
         "short-batch",
-        &TaskTracker::new(),
+        &Delivery::empty(),
     )
     .await;
     drop(guard);
@@ -437,7 +440,7 @@ async fn decode_and_ack_failures_are_logged_with_their_subscription() {
         vec![UnsettleableMessage(Arc::new(AtomicUsize::new(0)))],
         BatchResult::Uniform(HandlerOutcome::ack()),
         "diag-batch",
-        &TaskTracker::new(),
+        &Delivery::empty(),
     )
     .await;
     drop(guard);
@@ -558,5 +561,221 @@ async fn a_failed_construction_is_settled_and_the_rest_reach_the_batch() {
     assert_eq!(
         seen.lock().unwrap().as_slice(),
         [b"one".to_vec(), b"two".to_vec()],
+    );
+}
+
+/// A delivery with no native delayed redelivery: `supports_nack_after` stays at the trait default
+/// (`false`), which is what nearly every broker ships, so a `retry_after` settlement has to take
+/// the runtime's broker-agnostic fallback. The memory broker's own message answers `true` and
+/// would settle natively, hiding the fallback these tests are about.
+struct PlainMessage {
+    payload: Bytes,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl PlainMessage {
+    /// One delivery per payload, all counting their drops into `dropped`.
+    fn batch(payloads: &[&'static [u8]], dropped: &Arc<AtomicUsize>) -> Vec<Self> {
+        payloads
+            .iter()
+            .map(|payload| Self {
+                payload: Bytes::from_static(payload),
+                dropped: Arc::clone(dropped),
+            })
+            .collect()
+    }
+}
+
+impl IncomingMessage for PlainMessage {
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    fn headers(&self) -> &HeaderMap {
+        static EMPTY: OnceLock<HeaderMap> = OnceLock::new();
+        EMPTY.get_or_init(HeaderMap::new)
+    }
+
+    fn ack(self) -> impl Future<Output = Result<(), AckError>> {
+        ready(Ok(()))
+    }
+
+    fn nack(self, requeue: bool) -> impl Future<Output = Result<(), AckError>> {
+        if !requeue {
+            self.dropped.fetch_add(1, Ordering::SeqCst);
+        }
+        ready(Ok(()))
+    }
+}
+
+/// The delay every fallback test defers by. Its only requirement is being far enough from zero
+/// that the paused clock has to move for the deferred copy to land.
+const DEFER: Duration = Duration::from_secs(30);
+
+/// Reads the `expected` deferred copies the fallback re-published, as (payload, retry count)
+/// pairs sorted by payload, and asserts nothing else was published.
+///
+/// The clock is paused, so it advances only when the runtime runs dry - which is exactly when the
+/// deferred task is parked on its timer. The outer timeout is another such timer, far past the
+/// fallback's, so a lost copy fails the test instead of hanging it.
+async fn deferred_copies(
+    sub: &mut MemorySubscriber,
+    expected: usize,
+) -> Vec<(Vec<u8>, Option<String>)> {
+    let mut stream = std::pin::pin!(sub.stream());
+    let mut copies = Vec::with_capacity(expected);
+    for _ in 0..expected {
+        let msg = tokio::time::timeout(DEFER * 100, stream.next())
+            .await
+            .expect("the deferred re-publish is the only retry an unsettled delivery gets")
+            .expect("the subscriber outlives the deferred publish")
+            .expect("the memory broker delivers what it accepted");
+        copies.push((
+            msg.payload().to_vec(),
+            msg.headers().get_str(RETRY_COUNT_HEADER).map(str::to_owned),
+        ));
+    }
+    assert!(futures::poll!(stream.next()).is_pending());
+    copies.sort();
+    copies
+}
+
+/// A uniform `retry_after` over a batch of deliveries without native delayed redelivery: every
+/// element is dropped and re-published after the delay, rather than settled with an unsupported
+/// `nack_after` and lost. Covers the uniform arm of `settle_batch`.
+#[tokio::test(start_paused = true)]
+async fn a_uniform_batch_retry_after_defers_a_republish() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("orders");
+    let delivery = Delivery::detached(Some(Arc::new(broker.publisher())), TaskTracker::new());
+
+    let handler = typed_batch(JsonCodec, |_batch: &[u32], _ctx: &mut Context| async {
+        HandlerOutcome::retry_after(DEFER)
+    });
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let state = ();
+    let headers = HeaderMap::new();
+    let mut ctx = Context::new("orders", &headers, &state, (), &delivery);
+    handler
+        .handle_batch(PlainMessage::batch(&[b"1", b"2"], &dropped), &mut ctx)
+        .await;
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        deferred_copies(&mut sub, 2).await,
+        [
+            (b"1".to_vec(), Some("1".to_owned())),
+            (b"2".to_vec(), Some("1".to_owned())),
+        ],
+    );
+}
+
+/// A per-element `retry_after` next to an ack: only the deferred element comes back, and only
+/// after the delay. Covers the per-element arm of `settle_batch`.
+#[tokio::test(start_paused = true)]
+async fn a_per_element_batch_retry_after_defers_only_its_own_element() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("orders");
+    let delivery = Delivery::detached(Some(Arc::new(broker.publisher())), TaskTracker::new());
+
+    let handler = typed_batch(JsonCodec, |_batch: &[u32], _ctx: &mut Context| async {
+        vec![HandlerOutcome::retry_after(DEFER), HandlerOutcome::ack()]
+    });
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let state = ();
+    let headers = HeaderMap::new();
+    let mut ctx = Context::new("orders", &headers, &state, (), &delivery);
+    handler
+        .handle_batch(PlainMessage::batch(&[b"1", b"2"], &dropped), &mut ctx)
+        .await;
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        deferred_copies(&mut sub, 1).await,
+        [(b"1".to_vec(), Some("1".to_owned()))],
+    );
+}
+
+/// An element the codec could not decode, under a `retry_after` decode policy: the rejection is
+/// deferred rather than dropped on the floor. Covers the decode-rejection settle in
+/// `decode_batch`.
+#[tokio::test(start_paused = true)]
+async fn a_deferred_decode_rejection_is_republished() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("orders");
+    let delivery = Delivery::detached(Some(Arc::new(broker.publisher())), TaskTracker::new());
+
+    let handler = typed_batch(JsonCodec, |_batch: &[u32], _ctx: &mut Context| async {
+        HandlerOutcome::ack()
+    })
+    .with_decode(FailurePolicy::RetryAfter(DEFER));
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let state = ();
+    let headers = HeaderMap::new();
+    let mut ctx = Context::new("orders", &headers, &state, (), &delivery);
+    handler
+        .handle_batch(
+            PlainMessage::batch(&[b"not json", b"1"], &dropped),
+            &mut ctx,
+        )
+        .await;
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        deferred_copies(&mut sub, 1).await,
+        [(b"not json".to_vec(), Some("1".to_owned()))],
+    );
+}
+
+/// A batch handler over self-constructed payload views that defers every element it is given,
+/// for the split-batch test below.
+struct DeferFrames;
+
+impl<'p> SliceHandler<Frame<'p>> for DeferFrames {
+    fn handle_slice(
+        &self,
+        batch: &[Frame<'p>],
+        _ctx: &mut Context<'_>,
+    ) -> impl Future<Output = BatchResult> {
+        ready(BatchResult::PerElement(
+            batch
+                .iter()
+                .map(|_| HandlerOutcome::retry_after(DEFER))
+                .collect(),
+        ))
+    }
+}
+
+/// A batch whose rejected element was deferred past the handler call, with both the rejection and
+/// the handler's own outcome asking for `retry_after`: each takes the fallback on its own. Covers
+/// both settles in `settle_split_batch` - the rejected index and the accepted remainder.
+#[tokio::test(start_paused = true)]
+async fn a_split_batch_defers_the_rejected_and_the_accepted_alike() {
+    let broker = MemoryBroker::new();
+    let mut sub = broker.subscribe("orders");
+    let delivery = Delivery::detached(Some(Arc::new(broker.publisher())), TaskTracker::new());
+
+    // The middle element is empty, which `Frame` refuses to construct from.
+    let handler = DeserializedBatch::<_, Frame<'static>, _>::over(DeferFrames)
+        .with_decode(FailurePolicy::RetryAfter(DEFER));
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let state = ();
+    let headers = HeaderMap::new();
+    let mut ctx = Context::new("orders", &headers, &state, (), &delivery);
+    handler
+        .handle_batch(
+            PlainMessage::batch(&[b"one", b"", b"two"], &dropped),
+            &mut ctx,
+        )
+        .await;
+
+    assert_eq!(dropped.load(Ordering::SeqCst), 3);
+    assert_eq!(
+        deferred_copies(&mut sub, 3).await,
+        [
+            (Vec::new(), Some("1".to_owned())),
+            (b"one".to_vec(), Some("1".to_owned())),
+            (b"two".to_vec(), Some("1".to_owned())),
+        ],
     );
 }

--- a/src/runtime/batch_inject.rs
+++ b/src/runtime/batch_inject.rs
@@ -152,9 +152,9 @@ where
         if accepted.is_empty() {
             return;
         }
-        let tasks = ctx.tasks().clone();
+        let delivery = ctx.delivery();
         let result = self.def.call(&values, &self.injections, ctx).await;
-        settle_batch(accepted, result, &subscription, &tasks).await;
+        settle_batch(accepted, result, &subscription, delivery).await;
     }
 }
 

--- a/src/runtime/batch_publishing.rs
+++ b/src/runtime/batch_publishing.rs
@@ -223,8 +223,7 @@ where
             }
             Err(result) => result,
         };
-        let tasks = ctx.tasks().clone();
-        settle_batch(accepted, result, &subscription, &tasks).await;
+        settle_batch(accepted, result, &subscription, ctx.delivery()).await;
     }
 }
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -461,12 +461,15 @@ impl<'a, C, S> Context<'a, C, S> {
         runnable
     }
 
-    /// Returns the app-wide task tracker for post-settle [`HandlerResult::and_after`]
-    /// continuations. The dispatcher spawns each element's continuation onto it after settling,
-    /// and the single-message path uses it the same way, so a graceful shutdown drains in-flight
-    /// continuations.
-    pub(crate) fn tasks(&self) -> &tokio_util::task::TaskTracker {
-        &self.delivery.tasks
+    /// Returns the scope's delivery context: the task tracker post-settle
+    /// [`HandlerResult::and_after`] continuations are spawned onto, and the publisher the
+    /// `retry_after` fallback re-publishes through.
+    ///
+    /// Borrowed for the scope's lifetime rather than the context's, so the batch path can settle
+    /// through it after handing `&mut self` to the handler - and so no borrow of the context is
+    /// held across an await, which would demand `Context: Sync`.
+    pub(crate) fn delivery(&self) -> &'a Delivery {
+        self.delivery
     }
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -775,7 +775,11 @@ fn harness_scope(delivery: &Delivery) -> Option<HarnessScope> {
 }
 
 /// Settles one delivery by `outcome`, logging an ack / nack failure without propagating it.
-async fn settle_outcome<M: IncomingMessage>(
+///
+/// The single place a settlement reaches the broker, single-message and batch paths alike: a
+/// second one would be free to answer a [`NackAfter`](HandlerResult::NackAfter) differently, and
+/// the delay fallback below is exactly the part that is easy to leave out.
+pub(crate) async fn settle_outcome<M: IncomingMessage>(
     msg: M,
     outcome: HandlerResult,
     name: &str,

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -48,8 +48,10 @@ pub enum FailurePolicy {
     /// yet available, a schema not yet propagated).
     Retry,
     /// Requeue the message, but ask the broker to redeliver no sooner than the given delay:
-    /// `nack_after(..)`. For brokers without native delayed redelivery this degrades to an
-    /// immediate requeue.
+    /// `nack_after(..)`. A broker without native delayed redelivery takes the runtime's deferred
+    /// re-publish instead, and degrades to an immediate requeue only with no
+    /// [`retry_via`](super::BrokerScope::retry_via) publisher wired - see
+    /// [`HandlerOutcome::retry_after`](super::HandlerOutcome::retry_after).
     RetryAfter(Duration),
     /// Acknowledge the failed message to move past it: `ack`. A deliberate poison-message escape
     /// hatch - it advances past a message that could not be processed. This is not success; the

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -24,9 +24,11 @@ pub(crate) enum HandlerResult {
     /// Negatively acknowledge the message, asking the broker to redeliver it no sooner than
     /// `delay` from now.
     ///
-    /// The delay is a hint, honoured by brokers with native delayed redelivery (`JetStream`
-    /// `NAK` with delay); brokers without it fall back to an immediate requeue (see
-    /// [`IncomingMessage::nack_after`](crate::IncomingMessage::nack_after)).
+    /// A broker with native delayed redelivery (`JetStream` `NAK` with delay) honours the delay
+    /// itself, through [`IncomingMessage::nack_after`](crate::IncomingMessage::nack_after); on one
+    /// without, the runtime drops the delivery and re-publishes a copy to its own source after
+    /// the delay. Only with no [`retry_via`](super::BrokerScope::retry_via) publisher wired does
+    /// the delay degrade to an immediate requeue.
     NackAfter {
         /// How long the broker should wait before redelivering.
         delay: Duration,
@@ -122,9 +124,14 @@ impl HandlerOutcome {
     /// Redeliver, but not before `delay` has passed - the not-ready-yet case (a dependency has
     /// not arrived, an upstream is rate-limited), where an immediate redelivery would just spin.
     ///
-    /// The delay is a hint, honoured by brokers with native delayed redelivery (`JetStream`
-    /// `NAK` with delay); brokers without it fall back to an immediate requeue (see
-    /// [`IncomingMessage::nack_after`](crate::IncomingMessage::nack_after)).
+    /// A broker with native delayed redelivery (`JetStream` `NAK` with delay) honours the delay
+    /// itself, through [`IncomingMessage::nack_after`](crate::IncomingMessage::nack_after); on one
+    /// without, the runtime drops the delivery and re-publishes a copy to its own source after
+    /// the delay, through the publisher [`retry_via`](super::BrokerScope::retry_via) wired, with
+    /// the [`RETRY_COUNT_HEADER`](super::RETRY_COUNT_HEADER) incremented. That copy is
+    /// at-most-once over the delay window: it rides a detached task, so a process that exits
+    /// before the timer fires loses it. Only with no such publisher does the delay degrade to an
+    /// immediate requeue.
     pub const fn retry_after(delay: Duration) -> Self {
         Self {
             outcome: HandlerResult::retry_after(delay),


### PR DESCRIPTION
# Description

The batch settle path applied a `NackAfter` by calling `nack_after` on the delivery, while the
single-message path first checks `supports_nack_after` and otherwise runs the broker-agnostic
fallback (drop the original, re-publish a copy to its own source after the delay).
`supports_nack_after` defaults to `false`, which is what nearly every broker ships, so the batch
call returned `AckError::Unsupported`, the runtime logged `ack / nack failed`, and the retry was
gone: no deferred copy, no requeue, nothing. A `HandlerOutcome::retry_after` from a batch handler
was silently dropped on almost every broker.

The two settles were otherwise the same function, and that is what let them drift: a second place
to answer a settlement is free to answer it differently, and the delay fallback is exactly the part
that is easy to leave out. There is one place now. The batch path threads the scope's `Delivery`
(which carries the retry publisher) where it threaded only its task tracker, and calls the
dispatcher's `settle_outcome` at all five of its settle sites: the uniform and per-element arms of
`settle_batch`, both arms of `settle_split_batch`, and the decode rejection in `decode_batch`.
`Context::delivery` replaces `Context::tasks` and hands the delivery out for the scope's lifetime
rather than the context's, so the batch path can take it before lending `&mut Context` to the
handler without holding a borrow across an await.

Four tests cover the five sites; all four fail on `main`, each with the original never dropped and
no deferred copy ever published:

| test | site |
|---|---|
| `a_uniform_batch_retry_after_defers_a_republish` | `settle_batch`, uniform arm |
| `a_per_element_batch_retry_after_defers_only_its_own_element` | `settle_batch`, per-element arm |
| `a_split_batch_defers_the_rejected_and_the_accepted_alike` | `settle_split_batch`, rejected index and accepted remainder |
| `a_deferred_decode_rejection_is_republished` | `decode_batch`, decode rejection under a `retry_after` decode policy |

Three doc comments (`HandlerResult::NackAfter`, `HandlerOutcome::retry_after`,
`FailurePolicy::RetryAfter`) still said a broker without native delayed redelivery falls back to an
immediate requeue. That stopped being true when the deferred re-publish landed: an immediate
requeue is only what is left when no `retry_via` publisher is wired. Second commit, doc only.

No signature outside the crate changed: `settle_batch`, `settle_split_batch`, `decode_batch`,
`settle_outcome` and `Context` are all `pub(crate)`.

### Relation to #302

Same bug one level up, and the fixes compose rather than overlap. #302 makes the shared fallback
tolerate `Unsupported` from the drop and still schedule the deferred copy; this PR makes the batch
path reach that fallback at all. Routing both paths through one function is what makes #302's
decisions apply to batches for free, so this branch does not restate them.

The two touch `src/runtime/dispatch.rs` in different places: #302 rewrites `settle_nack_after`'s
body and doc, this PR only adds `pub(crate)` and three doc lines to `settle_outcome` above it.
Either order merges; if git does flag the adjacency, the later branch keeps both hunks.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
