### PR TITLE
Correct the settlement defaults the broker-authors page teaches

### DIFF
--- a/docs/broker-authors/index.md
+++ b/docs/broker-authors/index.md
@@ -98,7 +98,11 @@ pub trait IncomingMessage: Send + Sync {
     async fn ack(self) -> Result<(), AckError>;
     async fn nack(self, requeue: bool) -> Result<(), AckError>;
 
-    // Defaulted: a plain nack(true). Override when the transport has native
+    // Defaulted: false. The runtime reads this first and never calls
+    // nack_after without it, so override the pair together.
+    fn supports_nack_after(&self) -> bool;
+
+    // Defaulted: AckError::Unsupported. Override when the transport has native
     // delayed redelivery (JetStream NAK with delay); handlers reach it through
     // HandlerOutcome::retry_after.
     async fn nack_after(self, delay: Duration) -> Result<(), AckError>;
@@ -109,8 +113,17 @@ pub trait IncomingMessage: Send + Sync {
 }
 ```
 
-A broker that overrides neither defaulted method still works with every runtime feature:
-`retry_after` falls back to an immediate requeue, and keyed lanes rotate keyless messages.
+Delayed redelivery is two methods, and `supports_nack_after` is the one the runtime asks:
+overriding `nack_after` alone leaves it at `false`, and the override is never called. The
+`nack_after` default answers `AckError::Unsupported` rather than quietly settling as a plain
+`nack(true)`, because a transport that cannot hold a message back should say so instead of turning
+a back-off into a redelivery storm.
+
+A broker that overrides none of the three still works with every runtime feature. Where there is no
+native delayed redelivery the runtime carries `retry_after` itself: it drops the delivery and
+re-publishes a copy to the same source after the delay, through the publisher the application wired
+with `BrokerScope::retry_via`, carrying an incremented retry-count header. Only with no such
+publisher does the delay degrade to an immediate requeue. Keyed lanes rotate keyless messages.
 
 ### `Publisher`
 

--- a/docs/ru/broker-authors/index.md
+++ b/docs/ru/broker-authors/index.md
@@ -102,7 +102,11 @@ pub trait IncomingMessage: Send + Sync {
     async fn ack(self) -> Result<(), AckError>;
     async fn nack(self, requeue: bool) -> Result<(), AckError>;
 
-    // Defaulted: a plain nack(true). Override when the transport has native
+    // Defaulted: false. The runtime reads this first and never calls
+    // nack_after without it, so override the pair together.
+    fn supports_nack_after(&self) -> bool;
+
+    // Defaulted: AckError::Unsupported. Override when the transport has native
     // delayed redelivery (JetStream NAK with delay); handlers reach it through
     // HandlerOutcome::retry_after.
     async fn nack_after(self, delay: Duration) -> Result<(), AckError>;
@@ -113,9 +117,18 @@ pub trait IncomingMessage: Send + Sync {
 }
 ```
 
-Брокер, который не переопределил ни одного из двух методов с реализацией по умолчанию, всё равно
-работает со всеми возможностями рантайма: `retry_after` сводится к немедленному возврату в очередь,
-а полосы воркеров по ключу раскладывают сообщения без ключа по кругу.
+Отложенная повторная доставка - это два метода, и рантайм спрашивает `supports_nack_after`:
+если переопределить только `nack_after`, гейт останется в `false` и переопределение никто не
+вызовет. По умолчанию `nack_after` отвечает `AckError::Unsupported`, а не завершает доставку тихим
+`nack(true)`: транспорт, который не умеет придержать сообщение, обязан сказать об этом, иначе
+пауза перед повтором превращается в шторм повторных доставок.
+
+Брокер, который не переопределил ни один из трёх методов с реализацией по умолчанию, всё равно
+работает со всеми возможностями рантайма. Там, где нативной отложенной доставки нет, `retry_after`
+несёт сам рантайм: он отбрасывает доставку и через задержку публикует копию в тот же источник -
+издателем, которого приложение подключило через `BrokerScope::retry_via`, - с увеличенным
+заголовком счётчика повторов. Только когда такого издателя нет, задержка вырождается в немедленный
+возврат в очередь. Полосы воркеров по ключу раскладывают сообщения без ключа по кругу.
 
 ### `Publisher`
 

--- a/docs/zh/broker-authors/index.md
+++ b/docs/zh/broker-authors/index.md
@@ -91,7 +91,11 @@ pub trait IncomingMessage: Send + Sync {
     async fn ack(self) -> Result<(), AckError>;
     async fn nack(self, requeue: bool) -> Result<(), AckError>;
 
-    // Defaulted: a plain nack(true). Override when the transport has native
+    // Defaulted: false. The runtime reads this first and never calls
+    // nack_after without it, so override the pair together.
+    fn supports_nack_after(&self) -> bool;
+
+    // Defaulted: AckError::Unsupported. Override when the transport has native
     // delayed redelivery (JetStream NAK with delay); handlers reach it through
     // HandlerOutcome::retry_after.
     async fn nack_after(self, delay: Duration) -> Result<(), AckError>;
@@ -102,8 +106,14 @@ pub trait IncomingMessage: Send + Sync {
 }
 ```
 
-这两个带默认实现的方法一个都不覆盖的 Broker，仍然能配合运行时的每一项功能：`retry_after` 退回为立即
-重新入队，按键分道则会轮转那些没有键的消息。
+延迟重投由两个方法组成，运行时问的是 `supports_nack_after`：只覆盖 `nack_after`，这道闸门仍然是
+`false`，覆盖的实现一次也不会被调用。`nack_after` 的默认实现返回 `AckError::Unsupported`，而不是
+悄悄按一次普通的 `nack(true)` 结算：传输压不住这条消息，就得说出来，否则一次退避就变成一场重投风暴。
+
+这三个带默认实现的方法一个都不覆盖的 Broker，仍然能配合运行时的每一项功能。没有原生延迟重投的地方，
+`retry_after` 由运行时自己扛：它丢弃这条投递，并在延迟之后把一份副本发布回同一个来源 - 走应用通过
+`BrokerScope::retry_via` 接上的那个发布者 - 并把重试计数消息头加一。只有在没有这个发布者时，延迟才
+退化为立即重新入队。按键分道则会轮转那些没有键的消息。
 
 ### `Publisher`
 


### PR DESCRIPTION
# Description

Two errors on the page a broker author reads before writing anything, plus one omission of the same
kind found while reading the section around them.

**`nack_after`'s default.** The `IncomingMessage` sketch annotated it as `// Defaulted: a plain
nack(true)`. It defaults to `AckError::Unsupported` (`src/message.rs:281`), and deliberately so: a
transport that cannot hold a message back reports that rather than silently turning a back-off into
an immediate redelivery. An author reading the page wrote a broker they believed requeued after the
delay. That is the misunderstanding the recent settlement work has been unwinding, and this is
where it was being taught.

**`supports_nack_after` was missing from the sketch.** The runtime reads it before it will call
`nack_after` at all (`src/runtime/dispatch.rs`), so a broker that overrides `nack_after` alone
leaves the gate at its `false` default and the override is never reached: native delayed redelivery
that quietly does not run. The sketch annotates the other two defaulted methods inline for teaching
and simply did not mention this one, so the page gave no way to find out. Added, annotated as the
gate it is.

**The stale fallback claim.** "A broker that overrides neither defaulted method still works with
every runtime feature: `retry_after` falls back to an immediate requeue" - the same sentence
corrected in three rustdoc spots in #303. The runtime drops the delivery and re-publishes a copy to
the same source after the delay, through the `BrokerScope::retry_via` publisher, with the
retry-count header incremented; an immediate requeue is only what is left when no such publisher is
wired.

## What else was checked

The whole page was read against the code, not only the two lines reported. Everything else holds:
the `Broker` / `ConnectedBroker` ladder, `Subscribe`, `Subscriber`, `Publisher` (including
`base_headers` defaulting to `None`), `PublishPolicy::pair`, `DefaultPublish`, `partition_key`
defaulting to `None`, the `BufferedSubscriber` 10 ms default, and the per-delivery and batch context
contracts all match the source. The settlement defaults above were the only drift.

The `TestableBroker` paragraph further down carries a fourth claim of this kind ("treats ack/nack as
effectively a no-op"), which #301 is already rewriting. Left untouched here so the two do not
collide.

## Note on overlap

#301 does touch `docs/broker-authors/index.md`, contrary to what I was told when this was scoped -
but at line ~613, in the `TestableBroker` section. This PR changes lines 93-120. Roughly 500 lines
apart, no conflict in either merge order. #302 and #303 do not touch the page.

Code comments inside the fence stay English in all three files, as everywhere else in the docs; the
prose around them is translated.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable
