### PR TITLE
Check a pull request whatever it is based on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base filter: a pull request stacked on another one has a branch for its base, and a filter
+  # naming `main` leaves it with no checks at all - which reads as a conflicting branch rather
+  # than as a workflow that declined to run.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,10 @@ on:
       - scripts/check_doc_parity.py
       - scripts/doc_glossary.toml
       - .github/workflows/docs.yml
+  # No base filter: a pull request stacked on another one has a branch for its base, and a filter
+  # naming `main` leaves it with no checks at all - which reads as a conflicting branch rather
+  # than as a workflow that declined to run.
   pull_request:
-    branches: [main]
     # `labeled` / `unlabeled` are here for the translation-parity job below: applying its
     # escape-hatch label has to re-run the check, or the label leaves a stale red run
     # blocking the merge.


### PR DESCRIPTION
# Description

Both workflows filtered `pull_request` on a base of `main`, so a pull request stacked on another
branch ran nothing. That is worse than it sounds: zero checks is the signature of a branch GitHub
cannot compute a merge ref for, so a stacked pull request reads as broken rather than as unchecked,
and the reviewer has no way to tell the two apart.

Dropping the base filter costs one extra run per stacked pull request and gives every one of them
the same gate as any other. The `push` filter stays on `main`, and the docs workflow keeps its
path filter.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings