### PR TITLE
feat: let a publisher adapter keep the include site's codec

### DIFF
--- a/src/runtime/handle/outs.rs
+++ b/src/runtime/handle/outs.rs
@@ -88,7 +88,7 @@ use crate::runtime::inject::FromStartup;
 use crate::runtime::inject::{InjectCall, InjectDef};
 use crate::runtime::metadata::OutgoingMessageMetadata;
 use crate::runtime::publish::{
-    Admits, HeadersUnset, MessageBody, OutPipeline, PublishBuilder, PublishIdentity,
+    Admits, HeadersUnset, MessageBody, OutPipeline, PublishBuilder, PublishIdentity, PublishSink,
     TransactionScope, TypedTransaction, message_of,
 };
 use crate::runtime::router::IncludeDef;
@@ -254,6 +254,91 @@ impl<M: OutSlot, W: Publisher, E: Codec + Send + Sync, Pipe: OutPipeline, Body>
         T: OutgoingDestination + PublishedThrough<M>,
     {
         message_of(self, value, &self.codec)
+    }
+
+    /// Starts the same typed publish, but sends it through `sink` instead of straight through
+    /// the entry.
+    ///
+    /// This is what a broker's publisher adapter calls. An adapter that contributes something
+    /// per publish - an ordering key, a routing hint, a stamp - wraps the entry and becomes the
+    /// sink, and the codec has to keep coming from the entry: it is the include site's, the most
+    /// specific level that named one. Starting a fresh builder on the adapter instead would
+    /// resolve the crate default and silently encode those messages differently from every other
+    /// message the same registration sends.
+    ///
+    /// `sink` is normally `&adapter`, and the adapter publishes by delegating to the entry, so
+    /// the message still travels the slot's publish path and keeps its test-capture attribution.
+    /// The adapter's [`base_headers`](crate::Publisher::base_headers) are written underneath the
+    /// publish's own, which is how the per-publish contribution reaches the wire.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(all(feature = "memory", feature = "macros", feature = "json"))]
+    /// # mod demo {
+    /// use ruststream::runtime::{HandlerOutcome, Out};
+    /// use ruststream::{HeaderMap, Outgoing, OutgoingMessage, Publisher, subscriber};
+    /// use serde::Serialize;
+    /// # #[derive(serde::Deserialize)]
+    /// # struct Event { id: u64 }
+    ///
+    /// #[derive(Outgoing, Serialize)]
+    /// #[outgoing(name = "events.done")]
+    /// struct Done {
+    ///     id: u64,
+    /// }
+    ///
+    /// /// A broker adapter: every publish built on it carries one header of the broker's own.
+    /// struct Tagged<'a, P: ?Sized> {
+    ///     inner: &'a P,
+    ///     base: HeaderMap,
+    /// }
+    ///
+    /// impl<P: Publisher + ?Sized> Publisher for Tagged<'_, P> {
+    ///     type Error = P::Error;
+    ///
+    ///     fn publish(
+    ///         &self,
+    ///         msg: OutgoingMessage<'_>,
+    ///     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+    ///         self.inner.publish(msg)
+    ///     }
+    ///
+    ///     fn base_headers(&self) -> Option<&HeaderMap> {
+    ///         Some(&self.base)
+    ///     }
+    /// }
+    ///
+    /// #[subscriber("events")]
+    /// async fn on_event(event: &Event, Out(out): Out<impl Publisher>) -> HandlerOutcome {
+    ///     let mut base = HeaderMap::new();
+    ///     base.insert("lane", event.id.to_string());
+    ///     let tagged = Tagged { inner: out, base };
+    ///
+    ///     // Leaves through the adapter, encodes with the codec the include site named.
+    ///     if out
+    ///         .message_through(&tagged, &Done { id: event.id })
+    ///         .publish()
+    ///         .await
+    ///         .is_err()
+    ///     {
+    ///         return HandlerOutcome::retry();
+    ///     }
+    ///     HandlerOutcome::ack()
+    /// }
+    /// # }
+    /// ```
+    pub fn message_through<'a, S, T, Index>(
+        &'a self,
+        sink: S,
+        value: &'a T,
+    ) -> PublishBuilder<S, MessageBody<'a, T>, &'a E, HeadersUnset, T::Form>
+    where
+        S: PublishSink,
+        Body: ContainsMessage<T, Index>,
+        T: OutgoingDestination + PublishedThrough<M>,
+    {
+        message_of(sink, value, &self.codec)
     }
 }
 

--- a/tests/codecs.rs
+++ b/tests/codecs.rs
@@ -15,10 +15,13 @@
 
 mod common;
 
+use std::future::Future;
+
 use common::Order;
 use ruststream::codec::{CborCodec, MsgpackCodec};
 use ruststream::memory::prelude::*;
 use ruststream::testing::TestApp;
+use ruststream::{HeaderMap, OutgoingMessage};
 
 #[subscriber("orders-cbor")]
 async fn cbor_order(order: &Order) -> HandlerOutcome {
@@ -146,4 +149,85 @@ async fn a_slot_codec_outranks_the_surface_codec_for_that_slot() {
         .assert_called_once()
         .decoded_as::<Order>()
         .with_codec(&MsgpackCodec, &Order { id: 7 });
+}
+
+#[derive(OutSlot)]
+#[publishes(Order)]
+struct Keyed;
+
+/// The shape a broker ships for a per-publish setting of its own: it wraps the publisher, adds
+/// a header every message carries, and delegates the send.
+struct Tagged<'a, P: ?Sized> {
+    inner: &'a P,
+    base: HeaderMap,
+}
+
+impl<P: Publisher + ?Sized> Publisher for Tagged<'_, P> {
+    type Error = P::Error;
+
+    fn publish(
+        &self,
+        msg: OutgoingMessage<'_>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.publish(msg)
+    }
+
+    fn base_headers(&self) -> Option<&HeaderMap> {
+        Some(&self.base)
+    }
+}
+
+/// Publishes through the adapter rather than straight through the slot.
+#[subscriber("orders-adapter")]
+async fn tagged_mirror(order: &Order, Out(out): Out<impl Publisher, Keyed>) -> HandlerOutcome {
+    let mut base = HeaderMap::new();
+    base.insert("lane", order.id.to_string());
+    let tagged = Tagged { inner: out, base };
+
+    if out
+        .message_through(&tagged, order)
+        .to("orders-tagged")
+        .publish()
+        .await
+        .is_err()
+    {
+        return HandlerOutcome::retry();
+    }
+    HandlerOutcome::ack()
+}
+
+/// An adapter in the way does not move the publish off the codec ladder: the bytes are the
+/// slot's `cbor`, not the crate default, and the adapter's own header still reaches the wire.
+/// Starting a fresh builder on the adapter is what used to resolve the default instead.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_publish_through_an_adapter_keeps_the_mount_site_codec() {
+    let app = RustStream::new(AppInfo::new("adapter-codec", "0.1.0")).with_broker_codec(
+        MemoryBroker::new(),
+        MsgpackCodec,
+        |b| {
+            b.include(tagged_mirror)
+                .out(Keyed, Publish)
+                .codec(CborCodec)
+                .build();
+        },
+    );
+    let tb = TestApp::start(app).await.expect("startup failed");
+
+    tb.message(&Order { id: 7 })
+        .with_codec(MsgpackCodec)
+        .to("orders-adapter")
+        .publish()
+        .await
+        .expect("publish");
+
+    tb.out::<Keyed>()
+        .assert_called_once()
+        .decoded_as::<Order>()
+        .with_codec(&CborCodec, &Order { id: 7 })
+        .with_header("lane", "7");
+
+    tb.broker::<MemoryBroker>()
+        .published::<Order>("orders-tagged")
+        .assert_called_once()
+        .with_codec(&CborCodec, &Order { id: 7 });
 }


### PR DESCRIPTION
# Description

A broker that ships a per-publish setting of its own (an ordering key on Pub/Sub, a routing hint
elsewhere) has to wrap the publisher and become the sink for that publish. The wrapper is a bare
`Publisher`, so a builder started on it resolved the crate default codec, and those messages left
in a different format from every other message the same registration sends. Found on
`ruststream-gcp-pubsub`, where `with_ordering_key` silently moved a mount site's `cbor` publishes
onto json; the shape is the same for every broker that adapts a publisher.

`Slot::message_through(sink, value)` starts the entry's own typed publish and sends it through a
sink the caller names. The codec stays the entry's, the adapter's base headers still reach the
wire, and the message still travels the slot's publish path and keeps its test-capture
attribution.

I did not take the shape I first proposed - a trait on the sink that `PublishExt::message` asks -
because it is not expressible on stable. `Slot` is a `Publisher`, so a blanket impl for every
publisher and an override for the entry overlap, and coherence rejects the pair without
specialization. Making the trait required instead would compile-break all twelve broker crates for
no gain on the wire. `Codec` gains no `Default` or `Clone` bound: reconstructing a codec value from
its type would hide the same divergence one level deeper.

Nothing changes format today - this is purely additive and nothing called it before. A broker moves
its adapter onto it one crate at a time, and only the publishes that are already wrong change.

## Type of change

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (removing or renaming public API, changing a signature, tightening bounds, or
      raising the MSRV - a minor version bump pre-1.0)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
- [x] Public items carry a compiling `# Examples` doctest, and user-facing changes are reflected in
      `examples/` where applicable