### PR TITLE
fix(ci): fail the run when the UI snapshots are skipped instead of checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,13 @@ jobs:
           cargo check --locked --no-default-features --features msgpack,memory,macros
 
       # Stable only: the UI snapshots record rustc's exact wording, and beta renders wording
-      # stable has not shipped. Unset elsewhere, the two tests skip themselves.
+      # stable has not shipped. Unset elsewhere, the two tests skip themselves. REQUIRE_UI_TESTS
+      # makes a skip a failure wherever the opt-in is set, so losing the opt-in turns this job red
+      # instead of leaving a green run in which the compile-fail cases checked nothing.
       - name: cargo test
         env:
           RUN_UI_TESTS: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
-          RUN_SCAFFOLD_BUILD: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
+          REQUIRE_UI_TESTS: ${{ matrix.toolchain == 'stable' && '1' || '0' }}
         # --no-fail-fast: a failing target must not hide failures in the targets behind it;
         # the log then lists every red test, not just the first binary's.
         run: cargo test --locked --workspace --all-features --no-fail-fast
@@ -135,6 +137,7 @@ jobs:
         if: matrix.toolchain == 'stable'
         env:
           RUN_UI_TESTS: '1'
+          REQUIRE_UI_TESTS: '1'
         run: |
           cargo test --locked --no-default-features --lib
           cargo check --locked --workspace --no-default-features --features testing,memory,macros

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -4,18 +4,39 @@
 //! macros a misuse and pins the compile error against a `.stderr` snapshot, so a regression in a
 //! macro's diagnostics (a reworded or dropped message, a shifted span) fails the build.
 //!
-//! The snapshots are rustc-version-sensitive, and CI builds a 1.85..stable matrix, so they are
+//! The snapshots are rustc-version-sensitive, and CI builds a floor..stable matrix, so they are
 //! pinned to a single toolchain: the run sets `RUN_UI_TESTS=1` (only the stable `cargo test` job
-//! does), and every other run - the 1.85 job, a local `cargo test` without the flag - skips. To
+//! does), and every other run - the floor job, a local `cargo test` without the flag - skips. To
 //! refresh the snapshots after an intentional message change, run on stable:
 //!
 //! ```text
 //! TRYBUILD=overwrite RUN_UI_TESTS=1 cargo test --test ui --features macros,memory,json
 //! ```
 
+/// Whether this run skips the snapshots, and whether skipping them is allowed.
+///
+/// `RUN_UI_TESTS=1` opts in. `REQUIRE_UI_TESTS=1` says a skip is not acceptable in this run: CI
+/// sets it wherever it sets the opt-in, so dropping or misspelling the opt-in turns the job red
+/// instead of leaving a green run that checked nothing. Both unset is the local default, where
+/// the snapshots stay opt-in because they record one toolchain's exact wording.
+///
+/// # Panics
+///
+/// Panics when a run that requires the snapshots is not set up to run them.
+fn skip_snapshots() -> bool {
+    let opted_in = std::env::var("RUN_UI_TESTS").as_deref() == Ok("1");
+    let required = std::env::var("REQUIRE_UI_TESTS").as_deref() == Ok("1");
+    assert!(
+        opted_in || !required,
+        "REQUIRE_UI_TESTS=1 but RUN_UI_TESTS is not 1: this run would have skipped the UI \
+         snapshots and reported success"
+    );
+    !opted_in
+}
+
 #[test]
 fn ui() {
-    if std::env::var("RUN_UI_TESTS").as_deref() != Ok("1") {
+    if skip_snapshots() {
         eprintln!("skipping trybuild UI tests; set RUN_UI_TESTS=1 (stable toolchain) to run them");
         return;
     }

--- a/tests/ui_codec_free.rs
+++ b/tests/ui_codec_free.rs
@@ -14,9 +14,27 @@
     not(any(feature = "json", feature = "cbor", feature = "msgpack"))
 ))]
 
+/// Whether this run skips the snapshots, and whether skipping them is allowed. The counterpart of
+/// the guard in `tests/ui.rs`; each test binary carries its own, because this one compiles only
+/// where no codec feature resolves.
+///
+/// # Panics
+///
+/// Panics when a run that requires the snapshots is not set up to run them.
+fn skip_snapshots() -> bool {
+    let opted_in = std::env::var("RUN_UI_TESTS").as_deref() == Ok("1");
+    let required = std::env::var("REQUIRE_UI_TESTS").as_deref() == Ok("1");
+    assert!(
+        opted_in || !required,
+        "REQUIRE_UI_TESTS=1 but RUN_UI_TESTS is not 1: this run would have skipped the UI \
+         snapshots and reported success"
+    );
+    !opted_in
+}
+
 #[test]
 fn ui_codec_free() {
-    if std::env::var("RUN_UI_TESTS").as_deref() != Ok("1") {
+    if skip_snapshots() {
         eprintln!("skipping trybuild UI tests; set RUN_UI_TESTS=1 (stable toolchain) to run them");
         return;
     }


### PR DESCRIPTION
# Description

Audited every gated test and every CI job for the shape found twice this week: a check whose green
proves less than it claims. Two defects, both here.

Both trybuild suites decide at run time whether to do any work, and a run that decides not to
prints a line to stderr and reports success. Nothing anywhere records that they ran, so the opt-in
could be dropped, misspelled or moved to the wrong step and 64 compile-fail cases would quietly
stop being checked. `REQUIRE_UI_TESTS` says a skip is a failure in this run; CI sets it wherever it
sets the opt-in. Verified all four ways: unset locally still skips and passes, the required-but-not-
enabled run fails with the reason, and the two CI settings run the cases in twenty seconds rather
than none.

`RUN_SCAFFOLD_BUILD` is removed. Nothing in the repository has read it since the `ruststream new`
subcommand was dropped: the test went with the subcommand, the variable stayed, and so did a
comment claiming it opted in a scaffold compile-check that never ran. The templates job covers that
ground now.

Everything else checked and found sound, recorded here so the next reader does not repeat it. The
minimal-versions leg resolves twice, with and without dev-dependencies, and builds on the floor
toolchain; its two pins raise third-party floors that the crates themselves declare too loosely,
each with the condition for dropping it, and neither is a bound this workspace owns. The coverage
gate propagates its exit code through the summary rather than around it, and the UI suites skipping
there can only depress the number. The public API surface check and the package dry-run both run
the real thing. No test in the crate is `#[ignore]`, and after this change no test decides at run
time whether to do its work without saying so.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] I have added tests that validate my fix or new feature
- [x] New and existing tests pass locally (`just test`)
