### PR TITLE
chore: bring the Cursor rules up to the 0.7 documentation

### DIFF
--- a/.cursor/rules/advanced-usage.mdc
+++ b/.cursor/rules/advanced-usage.mdc
@@ -7,31 +7,32 @@ alwaysApply: false
 - Everything the attribute macros produce can be written by hand. `macros` is a convenience
   feature, not a layer: `#[subscriber]` expands into calls on the same public runtime API, so a
   service without it loses no capability that does not come *from* a declaration.
-- What the attribute emits for `async fn handle(order: &Order) -> HandlerOutcome` is, in order: a
-  unit struct named after the function, an `impl Handler` whose `async fn handle` carries the body,
-  and the `Declared` + `SubscriberDef` impls that let `include` mount it. Every one of those traits
-  is public, so **how far you write it out is a choice, not a limit**.
-- So a handler is a named type implementing `Handle<In, R, O, C, S>`, whose `async fn handle(&self,
-  input: &In, outs: &O, ctx: &mut Context<'_, C, S>)` is an ordinary async method. What a closure
-  would capture becomes a field on that type - a closure is not a `Handle`, the body is always a
-  named type.
-- **Level one** - stop at the body trait and mount with
-  `b.include(subscriber(source, body).build())`. There is one body trait and one constructor:
-  every axis of the form matrix is a defaulted parameter the impl pins, so the signature decides
-  the form and nothing else names it. `In` is the input spelling (`T` decoded, `F<'_>` a type that
-  deserializes itself from the bytes, `Message<H, P>` a decoded payload next to its typed header
-  contract, and `[T]` / `[F<'_>]` / `[Message<H, P>]` for a batch of each), `R` the reply type
-  (`()` declares none), `O` the injections arena (`()` declares none), `C` the broker's typed
-  context - per delivery on the single forms, the broker's subscription-scoped batch context
-  (`BuildBatchContext`, built once per batch) on the batch ones - and `S` the application state the
-  body reads with `ctx.state()`. What the signature does
-  not carry rides the chain: the declarative settings (`.name`, `.workers`, `.workers_by_key`,
-  `.on_failure`, `.batch`, `.start_at`, `.codec`), the reply declaration (`.reply()`,
-  `.to(dest)` - never a publisher, which is the mount site's `.out(Reply, policy)`) and the
-  document controls
-  (`.describe(..)`, `.undocumented()`); `.build()` seals the chain and `include` mounts it. Nothing
-  else to implement; the registration metadata is derived from the source and the body's input
-  type.
+- What the attribute emits for `async fn handle(order: &Order) -> HandlerOutcome` is a unit struct
+  named after the function, an `impl Handle` carrying the body, and a `Declared` impl that builds
+  the same sealed definition the `subscriber(..) .. .build()` chain produces. So the attribute is
+  sugar over the manual path's own vocabulary, and what it writes you can write.
+- A handler is a named type implementing `Handle<In, R, O, C, S>`, whose `fn handle(&self, input:
+  &In, outs: &O, ctx: &mut Context<'_, C, S>) -> impl Future<Output = Verdict<In, R>> + Send` is an
+  ordinary method. What a closure would capture becomes a field on that type - a closure is not a
+  `Handle`, the body is always a named type. A body with nothing to await returns `ready(..)`
+  rather than being `async fn`; clippy's `unused_async_trait_impl` reports the other spelling.
+- There is one body trait and one constructor. Every axis of the form matrix is a defaulted
+  parameter the impl pins, so the signature decides the form and nothing else names it. `In` is the
+  input spelling (`T` decoded, `F<'_>` a type that deserializes itself from the bytes,
+  `Message<H, P>` a decoded payload next to its typed header contract, and `[T]` / `[F<'_>]` /
+  `[Message<H, P>]` for a batch of each), `R` the reply type (`()` declares none), `O` the
+  injections arena (`()` declares none), `C` the broker's typed context - per delivery on the
+  single forms, the broker's subscription-scoped batch context (`BuildBatchContext`, built once per
+  batch) on the batch ones - and `S` the application state the body reads with `ctx.state()`. What
+  the signature does not carry rides the chain: the declarative settings (`.name`, `.workers`,
+  `.workers_by_key`, `.on_failure`, `.batch`, `.start_at`, `.codec`), the reply declaration
+  (`.reply()`, `.to(dest)` - never a publisher, which is the mount site's `.out(Reply, policy)`)
+  and the document controls (`.describe(..)`, `.undocumented()`); `.build()` seals the chain and
+  `include` mounts it. The registration metadata comes off the source and the body's input type.
+- That constructor is the only way in. The definition traits behind it (`SubscriberDef`, the batch
+  and publishing defs) are crate-internal machinery, not an extension point: a service cannot write
+  a definition type of its own, and a custom source, custom metadata or computed settings go on the
+  chain instead. `IncludeDef` and `Declared` stay public because `include` dispatches on them.
 - The return shape is computed from the same two axes, so an illegal combination has no type to be
   written in and each shape has exactly one accepted spelling: `Result<(), HandlerOutcome>` for a
   single message with no reply (`Ok(())` acks), `Result<Reply, HandlerOutcome>` for a single one
@@ -41,26 +42,16 @@ alwaysApply: false
   whole-batch uniform outcome; a continuation is not a shape of its own either - return
   `Err(HandlerOutcome::ack().and_after(..))`. The batch vector settles element-wise and is
   batch-length by contract; a mismatch panics under the `on_failure(panic = ..)` policy.
-- **Level two** - implement `SubscriberDef` plus `Declared`, and `b.include(def)` works on your own
-  type with the whole mount surface: the settings builder (`.name`, `.workers`, `.on_failure`,
-  `.batch`), `.out(marker, policy)` per publish position and `.build()`. The settings live on
-  `Declared::Settings`, which must be a `SubscriberBuilder` - `SubscriberBuilder::new(def, source)`
-  is public for exactly this. Implementing `IncludeDef` alone routes through the blanket
-  `impl<T: IncludeDef> Declared for T`, whose `Settings = Self`: that serves the codec-free forms, but a
-  decoded one resolves its codec through the builder, so a bare definition does not mount there -
-  and the steps (`NameStep`, `WorkersStep`, `FailureStep`, `BatchStep`) are implemented for
-  `SubscriberBuilder`, not for a bare definition, so that route has no settings surface either. A
-  batch definition must also implement `BatchSized`, which is how the mount reads back the size
-  `.batch(n)` named.
 - The derives are equally reproducible, and reading their expansion is the fastest way to get one
-  right: `#[derive(Outgoing)]` writes `OutgoingDestination` plus a `MessageHeaders` contract
-  (`NoHeaders` or `WithHeaders<H>`), `#[derive(OutSlot)]` writes `OutSlot` plus the
-  `ContainsMessage` memberships, `#[derive(OutMessages)]` writes `OutMessages` over an enum's
-  variants, `#[derive(Deserialized)]` writes the payload construction plus the `Input` spelling
-  that puts a type on the codec-free lane, `#[derive(Serialized)]` writes `fn bytes(&self)` plus
-  the wire spellings that send the value byte-for-byte (`MessageWire` for a typed publish,
-  `ReplyShape` for the reply position), and `#[derive(FromRef)]` writes one `FromRef`
-  impl per field.
+  right: `#[derive(Outgoing)]` writes `OutgoingDestination` (the `Form` plus the `DESTINATION`
+  constant a declared name fills) with a `MessageHeaders` contract (`NoHeaders` or
+  `WithHeaders<H>`) and the type's `OutMessages` entry, `#[derive(OutSlot)]` writes `OutSlot` (its
+  `NAME`, its `Destination` offer and its dictionary) plus a `PublishedThrough` membership per
+  listed type, `#[derive(OutMessages)]` writes `OutMessages` over an enum's variants,
+  `#[derive(Deserialized)]` writes `from_payload` plus the `Input` spelling that puts a type on the
+  codec-free lane, `#[derive(Serialized)]` writes `wire_bytes` plus the wire spellings that send
+  the value byte-for-byte (`MessageWire` for a typed publish, `ReplyShape` for the reply position),
+  and `#[derive(FromRef)]` writes one `FromRef` impl per field.
 - The one thing genuinely lost with the feature off is the attribute surface itself: nothing reads
   a clause for you, so what the attribute would have declared you write as a trait impl.
 - `use ruststream::prelude::*;` still works: the glob's macro re-exports are themselves
@@ -70,14 +61,19 @@ alwaysApply: false
   reply traits `Serialized` / `ReplyShape`, the injections arena `Outs` / `Slot` and the publisher
   capability traits a slot bound names (`Publisher`, `TransactionalPublisher`, `OwnedTransactions`,
   `RequestReply`), plus `FailurePolicies` / `FailurePolicy`, `Workers`, `Unnamed`, `Out`,
-  `DefaultSlot`, `RouterDef` and `nonzero!`), and so do the spellings the hand-written impls
-  name: `Input` / `SoloDeserialized`, `MessageWire` / `SerializedWire`, `SerializedReply`,
-  `OutgoingDestination` with `CallerName` / `FixedName` / `NameTemplate`, `MessageHeaders` with
-  `NoHeaders` / `WithHeaders`, `PublishedThrough`, `OutMessages` / `OutgoingMessageMetadata`,
-  and `FromContext`. A service without the feature imports nothing beyond the glob.
-- Mount with `b.include(subscriber(source, body).build())` (the portable form: the source resolves
-  at startup), or `b.handle(subscriber, handler, metadata)` when you already hold an open
-  subscriber. Routers have the same `include` method, so grouping still works.
+  `DefaultSlot`, `Reply`, `Router` / `RouterDef` and `nonzero!`), and so do the spellings the
+  hand-written impls name: `Input` / `SoloDeserialized`, `MessageWire` / `SerializedWire`,
+  `ReplyShape` / `SerializedReply`, `BytesMut` (a `Serialized` impl names it), `OutEntry` (the
+  bound a body declares its arena with), `OutgoingDestination` with `CallerName` / `FixedName` /
+  `NameTemplate`, `MessageHeaders` with `NoHeaders` / `WithHeaders`, `PublishedThrough`,
+  `OutMessages` / `OutgoingMessageMetadata`, the transform vocabulary (`PublishTransform`,
+  `ContextKind`, `ForReply` / `ForSlot`, `Reads` / `Names`) and `FromContext`. A service without
+  the feature imports nothing beyond the glob.
+- Mount with `b.include(subscriber(source, body).build())`; the source resolves at startup.
+  Routers have the same `include` method, so grouping still works. `Router::handle` and
+  `BrokerScope::handle` take an already-open subscriber and a fully wired handler: they are the
+  runtime's own machinery, they read no scope codec and no settings, and a service does not write
+  them.
 - Write `main` yourself: `#[tokio::main]` plus `app.run().await`. The attribute's CLI (`run`,
   `asyncapi gen`) is what you give up; `run_until(..)` and `start()` are plain methods.
 - State is reached through `ctx.state()`, headers through `ctx.headers()`, and publishing through a
@@ -88,6 +84,7 @@ alwaysApply: false
 
 ```rust
 use std::error::Error;
+use std::future::{Future, ready};
 
 use ruststream::memory::prelude::*;
 use serde::Deserialize;
@@ -102,14 +99,14 @@ struct Order {
 struct Receive;
 
 impl Handle<Order> for Receive {
-    async fn handle(
+    fn handle(
         &self,
         order: &Order,
         _outs: &(),
         _ctx: &mut Context<'_>,
-    ) -> Result<(), HandlerOutcome> {
+    ) -> impl Future<Output = Result<(), HandlerOutcome>> {
         tracing::info!(order.id, "processing order");
-        Ok(())
+        ready(Ok(()))
     }
 }
 
@@ -135,7 +132,8 @@ The body's two unused parameters are not ceremony: `_outs` is the injections are
 declared none, and `_ctx` is the per-delivery context that is always in reach. **Keep anything that
 can panic inside the future**: the dispatcher calls `handler.handle(..)` and only then wraps the
 result in `catch_unwind`, so a panic raised before the first `await` escapes the guard and kills
-the task instead of settling by `on_failure(panic = ..)`.
+the task instead of settling by `on_failure(panic = ..)`. Writing the body as `async fn handle`
+is equally legal, and the right shape as soon as it awaits anything.
 
 `run()` runs until `SIGINT` / `SIGTERM`; `run_until(future)` drives shutdown from a future you own
 (a test signal, a timeout), and `start()` hands back a `RunningApp` for hosting the service beside
@@ -146,9 +144,7 @@ another foreground server.
 The constructor resolves the decode codec off the mount surface, the same ladder the attribute path
 uses: the scope's (`with_broker_codec`), the router chain's (`Router::with_codec`), else
 `DefaultCodec`. `.codec(..)` overrides it for one registration, and `.on_failure(..)` carries the
-decode-failure policy. (`typed(codec, handler)` is the wrapper underneath - it decodes the delivery
-and calls the inner handler with `&T` - and the one you build yourself for the `handle` SPI below,
-which reads no scope codec.)
+decode-failure policy.
 
 ```rust
 use ruststream::codec::CborCodec;
@@ -196,14 +192,14 @@ impl Input for Frame<'_> {
 struct Ingest;
 
 impl<'p> Handle<Frame<'p>> for Ingest {
-    async fn handle(
+    fn handle(
         &self,
         frame: &Frame<'p>,
         _outs: &(),
         _ctx: &mut Context<'_>,
-    ) -> Result<(), HandlerOutcome> {
+    ) -> impl Future<Output = Result<(), HandlerOutcome>> {
         parse(frame.0);
-        Ok(())
+        ready(Ok(()))
     }
 }
 
@@ -214,26 +210,31 @@ A constructor that validates (a flatbuffers root, a length check) returns `Err` 
 settles by the subscriber's `on_failure(decode = ..)` policy - the same rung a codec decode
 failure lands on, so that policy is accepted on this lane.
 
-Use `b.handle(subscriber, handler, meta)` instead when the broker hands you an open subscriber
-before registration (how you obtain one is broker-specific; the in-memory broker's `subscribe` is
-a plain synchronous call):
+A generated message (Protobuf, Cap'n Proto, FlatBuffers) rides the same lanes with the format's own
+functions in the impls, which is all `#[wire(prost)]` and `#[wire(encode = .., decode = ..)]` fill
+in. The outgoing half is three impls: `Serialized::wire_bytes` takes the publish path's own
+`BytesMut` and lends back what it wrote, so the message is encoded once and nothing intermediate is
+allocated, and the two wire spellings say where the value may be used.
 
 ```rust
-use ruststream::memory::MemoryMessage;
-use ruststream::runtime::HandlerMetadata;
+impl Serialized for Order {
+    type Error = prost::EncodeError;
 
-// The SPI takes a handler over the broker's own message, not over `[u8]`.
-struct Frames;
-
-impl Handler<MemoryMessage> for Frames {
-    async fn handle(&self, msg: &MemoryMessage, _ctx: &mut Context<'_>) -> HandlerOutcome {
-        parse(msg.payload());
-        HandlerOutcome::ack()
+    fn wire_bytes<'a>(&'a self, buf: &'a mut BytesMut) -> Result<&'a [u8], Self::Error> {
+        prost::Message::encode(self, &mut *buf)?;
+        Ok(&buf[..])
     }
 }
 
-let subscriber = b.broker().subscribe("orders");
-b.handle(subscriber, Frames, HandlerMetadata::raw("orders"));
+impl MessageWire for Order {
+    type Wire = SerializedWire;
+}
+
+impl ReplyShape for Order {
+    type Body = Self;
+    type Headers = ();
+    type Wire = SerializedReply;
+}
 ```
 
 ## Dependencies and state
@@ -330,7 +331,11 @@ short ones, and then the value publishes like any declared message:
 
 ```rust
 impl OutgoingDestination for Receipt {
-    type Form = CallerName; // FixedName / NameTemplate for a declared destination
+    // FixedName or NameTemplate for a declared destination, and then the name itself:
+    //   type Form = FixedName;
+    //   const DESTINATION: &'static str = "receipts";
+    // NameTemplate adds PARAMETERS and a TemplateAddress builder, one setter per placeholder.
+    type Form = CallerName;
 }
 
 impl MessageHeaders for Receipt {
@@ -339,16 +344,19 @@ impl MessageHeaders for Receipt {
 
 impl<M: OutSlot> OutMessages<M> for Receipt {
     fn outgoing() -> Vec<OutgoingMessageMetadata> {
-        Vec::new()
+        Vec::new() // a declared type reports one entry here; the document reads it
     }
 }
 
 publisher.message(&Receipt { order_id: 7 }).to("receipts").publish().await?;
 ```
 
-A payload that already is bytes implements `Serialized` the same way - `fn bytes(&self) -> &[u8]`
-plus the wire spellings (`MessageWire`, `ReplyShape`), exactly what `#[derive(Serialized)]`
-writes - and rides the same `message(..)` entry with no codec on the path.
+A slot marker is the same kind of declaration: `impl OutSlot` names the marker's `NAME`, its
+`Destination` offer (`Reads` unless the slot may name a destination) and the dictionary its
+`outgoing()` reports, and one `impl PublishedThrough<Marker> for Msg` per listed type is the
+membership the typed publish checks. A payload that already is bytes adds the `Serialized` and
+wire impls from [Raw bytes](#raw-bytes) and rides the same `message(..)` entry with no codec on
+the path.
 
 The mount chain, `after_startup`, publish transforms and `publish_layer` are all runtime API
 and work unchanged. The reply clause becomes the body's `R` axis plus the one `.reply()` on the
@@ -360,25 +368,24 @@ after it. A `serde::Serialize`
 an `R` implementing `Serialized` (the impls above; `ReplyShape` with `type Wire = SerializedReply`
 covers the reply position) leaves byte-for-byte, so those steps do not compile on it. There is one
 `.reply()` and one `.out(Reply, ..)` for both wires. A batch reply always publishes through the
-reply codec; the `Serialized` wire covers single replies. The `Out` slot parameter becomes the `O` axis:
-`Outs<(Slot<Marker, W, Enc, Pipe>,)>`, where `W` is the wired live value, `Enc` the include site's
-encode codec and `Pipe` the publish path it gave the slot (its `.transform(..)` steps over the
-app's own middleware), with the broker capability the body needs stated as a mandatory bound on
-that wired value, one entry per marker. Leaving `Pipe` generic under `OutPipeline` is what lets
-one body mount under any of them; spelled without it the entry pins the plain path
-(`PublishIdentity`: no slot transform, no app-wide `publish_layer`).
+reply codec; the `Serialized` wire covers single replies. A reply type that declares its own
+destination takes the bare `.reply()`, exactly as the attribute's bare `publish` clause does.
+
+The `Out` slot parameter becomes the `O` axis: `Outs<(E,)>` with one type parameter per marker,
+each bounded `E: OutEntry<Marker, Wire: Capability>`. The body states the marker and the broker
+capability it needs of the wired value, and nothing else: the codec the include site gave the slot
+and the publish path it composed (its `.transform(..)` steps over the app's own `publish_layer`)
+stay behind the bound, which is what lets one body mount under any of them.
 
 ```rust
-impl<W, Enc, Pipe> Handle<Order, (), Outs<(Slot<Primary, W, Enc, Pipe>,)>> for Mirror
+impl<M> Handle<Order, (), Outs<(M,)>> for Mirror
 where
-    W: Publisher,
-    Enc: Codec + Send + Sync,
-    Pipe: OutPipeline,
+    M: OutEntry<Primary, Wire: Publisher>,
 {
     async fn handle(
         &self,
         order: &Order,
-        outs: &Outs<(Slot<Primary, W, Enc, Pipe>,)>,
+        outs: &Outs<(M,)>,
         _ctx: &mut Context<'_>,
     ) -> Result<(), HandlerOutcome> {
         outs.get(Primary)
@@ -400,10 +407,11 @@ b.include(subscriber("mirror", Mirror).build())
 
 The markers come from the impl, so a missing, duplicate or extra `.out(..)` is a compile error
 naming the slot, and a single unnamed slot binds through the implicit `DefaultSlot`
-(`.out(DefaultSlot, policy).build()`). `outs.get(Marker)` hands back the entry itself: it keeps the `.message(..)`
-builder and is a transparent `Deref` onto the wired live value, so a broker-defined
-capability is called straight on it - a body that needs one pins the concrete live type
-(`Slot<Lanes, LaneRouter, Enc, Pipe>`) or bounds `W` with the broker's own trait.
+(`.out(DefaultSlot, policy).build()`). `outs.get(Marker)` hands back the entry itself: it keeps the
+`.message(..)` builder and is a transparent `Deref` onto the wired live value, so a broker-defined
+capability is called straight on it. A trait bound does not travel through that `Deref`, so a
+helper generic over such a capability works only where the broker crate grafted a blanket impl onto
+`Slot<M, W, E, Pipe, Body>`.
 
 ## Middleware
 
@@ -431,90 +439,30 @@ where
 }
 ```
 
-## Reaching the rest: write the definition out
+## What the chain reaches, and what it does not
 
-`b.handle` registers with the default failure policies and no settings, because it takes a handler,
-not a definition. It also never reads the scope codec, so `with_broker_codec` and
-`Router::with_codec` are inert on a `handle` registration - the codec is the one you named at
-`typed(..)`.
+Every form is reachable through the one constructor. The application state, the typed broker
+context and the injections are axes of the body's own `impl Handle`; the reply and document steps
+ride the chain (`.reply()` / `.to(..)`, `.describe(..)`, `.undocumented()`) next to the declarative
+settings the attribute path shares, the mandatory batch size `.batch(n)` among them. Registrations
+are documented by default under `asyncapi`, which is why message types need `schemars::JsonSchema`
+and `.undocumented()` is the per-registration exit.
 
-A `Router` reaches a little further without a definition: `Router::workers(Workers::pool(n))` /
-`Workers::keyed(n)` is the functional counterpart of the `workers(..)` clause (`BrokerScope` has no
-worker control at all). The batch shapes need nothing extra - `[T]` and `[Frame<'_>]` are input
-spellings of the one constructor, and the decoded one resolves the chain's codec.
+What used to be a second route is closed. The definition traits the retired expansion targeted are
+crate-internal now, so a definition type of your own is not something a service writes: a computed
+source is a value handed to `subscriber(..)`, computed settings are calls on the chain, and a
+description is `.describe(..)`. The settings state rides in the builder's type (`Open` per setting
+still free, `Fixed` per setting already named), which is what makes naming one twice a compile
+error rather than a silent override.
 
-Every form is reachable through that one constructor, so none is locked behind the definition
-traits: the application state, the typed broker context and the injections are all axes read off
-the body's own `impl Handle`, and the reply and document steps ride the chain
-(`.reply()` / `.to(..)`, `.describe(..)`, `.undocumented()`) next to the
-declarative settings the attribute path shares, the mandatory batch size `.batch(n)` among them.
-Registrations are documented by default under `asyncapi`, which is why the
-message types need `schemars::JsonSchema` and `.undocumented()` is the per-registration exit.
-What is left for the definition traits is being the attribute's own expansion target, and a fully
-custom definition - one whose source, metadata or settings are computed rather than named - so
-implement one and the whole mount surface opens up on your own type.
+A `Router` adds two steps of its own, each applying to the registration just included:
+`.workers(Workers::pool(n))` / `Workers::keyed(n)` is the functional counterpart of the
+`workers(..)` clause, and `.layer(..)` wraps that one registration outside its decode step.
+`Router::with_codec` sets the decode codec of everything included after it.
 
-```rust
-use ruststream::runtime::{
-    Declared, FailurePolicies, FailurePolicy, Fixed, Open, SubscriberBuilder, SubscriberDef,
-    SubscriberSettings, forms,
-};
-
-// This exact case is shorter as `subscriber("orders", Receive).on_failure(..).build()`; the
-// shape below is what a definition carrying its own declaration looks like. The SPI takes the
-// dispatch trait `Handler`, not the manual path's `Handle`.
-impl SubscriberDef for Receive {
-    type Input = /* the decode kind */;
-    type Context = ();
-    type Handler = Self;
-    type Source = Name;
-
-    fn source(&self) -> Self::Source { Name::new("orders") }
-    fn into_handler(self) -> Self { self }
-}
-
-// `Declared` is where the settings live, and its `Settings` has to be a builder. This is
-// verbatim what the expansion emits: `SubscriberBuilder::new(self, source)` plus the chain the
-// attribute's clauses parsed into.
-impl Declared for Receive {
-    type Form = forms::Subscribing;
-    // (workers, failure policies, start position, batch supply)
-    type Settings = SubscriberBuilder<Self, Name, (Open, Fixed, Open, Open)>;
-
-    fn declare(self) -> Self::Settings {
-        SubscriberBuilder::new(self, Name::new("orders"))
-            .on_failure(FailurePolicies::default().with_decode(FailurePolicy::Retry))
-    }
-}
-
-b.include(Receive);
-```
-
-The two routes are mutually exclusive: a direct `impl Declared` conflicts with the blanket
-`impl<T: IncludeDef> Declared for T`, so pick one per definition. The builder route is the one that
-scales - `SubscriberBuilder` forwards `SubscriberDef`, `InjectDef`/`InjectCall`,
-`PublishingDef`/`PublishingCall`, `BatchPublishingDef`/`BatchPublishingCall` and
-`HasSlots`/`BindSlots`, so the same shape carries every handler form, injected slots included.
-It does mean the source is written twice, in `declare()` and in the def's own `source()`, which is
-what the attribute writes too.
-
-The settings state rides in the `Settings` type (`AllOpen` when the declaration fixed none,
-`Fixed` in the slot for each one it did), which is what makes naming the same setting again at the
-mount site a compile error rather than a silent override. Put a setting in `declare` to keep it
-next to the handler, or leave the state open and let the mount site name it - the same choice the
-attribute gives you between a clause and a builder call.
-
-Read the expansion in `crates/ruststream-macros/src/expand.rs` before writing one of these: it
-names the exact `Input` kind, `Context` and form marker per handler shape, and it is the only place
-the whole mapping is written down. A definition that wants the attribute's own settings surface
-instead of the blanket can implement `Declared` directly and return
-`SubscriberBuilder::new(self, source)` with the chain applied, which is literally what the macro
-emits.
-
-The same holds for the derives: implement `OutgoingDestination` + `MessageHeaders` for a declared
-message, `OutSlot` + `ContainsMessage` for a slot marker, `OutMessages` for a set, `FromRef` per
-state field. The schema hooks on `SubscriberDef` are what feed the generated AsyncAPI document, so
-a hand-written definition contributes the same schemas.
+Read the expansion in `crates/ruststream-macros/src/expand/unified.rs` when you need the exact
+mapping from a handler shape to the axes and the form marker: it is the only place the whole table
+is written down.
 
 Enabling `macros` remains the shorter road, and the two styles compose in one application: a
 macro-free registration and an `include(def)` sit in the same `with_broker` scope.

--- a/.cursor/rules/broker-authors.mdc
+++ b/.cursor/rules/broker-authors.mdc
@@ -23,35 +23,77 @@ alwaysApply: false
   and ship a `SubscriptionSource<Connected<B>>` descriptor for broker-specific options (even a
   parameter-less broker ships one). Give the descriptor a constructor and derive `Clone`; add
   `FromName` when a name alone is enough to build it.
+- Both answer `redelivery_address`: the name a publisher on your broker uses to reach this
+  subscription again (a NATS subject, a Kafka topic, a Redis stream key). That is where the
+  runtime publishes the deferred copy when `retry_after` has no native delayed redelivery to ride.
+  Both default to "cannot say", which is the right answer wherever a subscribe name is not a
+  publish destination: a Google Pub/Sub subscription is read by its own name and published to
+  through its topic, so the descriptor asks the API. A scope wired with `retry_via` over a source
+  that cannot say refuses to start, naming the subscription - so a silent broker loses no message,
+  it loses the fallback. `harness::lifecycle` holds the answer to its promise.
 - Publishers split into policy plus live form: ship a freely constructible policy type carrying the
   options, implement `PublishPolicy<Connected>` to pair it into the live publisher, and implement
   `DefaultPublish` on the connected form when the plain policy works as-is (so `b.include(def)`
   compiles with no `.out(Reply, ..)`). Make mode selection a policy type transition, not a runtime
   flag: only the transactional policy's live form implements `TransactionalPublisher`.
+- Per-message settings (a QoS, a priority, an ordering key, an expiration) are `Publisher::Options`,
+  a type you own with every field optional (`()` when you have none). The policy holds the defaults,
+  `publish(msg, options)` resolves the call's fields over them, and `options` is `None` on every
+  path with no call site - a reply, a deferred retry. `Transaction` names an `Options` of its own,
+  because a transaction may honour a different set than the publisher it was opened from. A value
+  you cannot honour is a publish error, never a silent fallback.
+- `DescribeServer` reports a coordinate, not the configuration: the host and port clients connect
+  to, never credentials - the generated document is published. A broker configured from a URL
+  builds its `ServerSpec` with `ServerSpec::from_url` (several addresses: `host_from_url` each);
+  trimming the scheme off the URL and passing the rest to `ServerSpec::new` keeps the userinfo, and
+  that bug shipped in more than one broker crate.
 - Implement capability traits (`BatchSubscriber`, `TransactionalPublisher`, `OwnedTransactions`,
   `RequestReply`, `Partitioned`, `Seekable`/`Seeker`, `Positioned`, `DescribeServer`) only for what
-  the broker natively supports - never emulate.
+  the broker natively supports - never emulate. `BatchSubscriber` is the exception worth stretching
+  for: a transport that delivers one message at a time still offers it, assembled on the client
+  with the core's `BufferedSubscriber`, whose `batches` honours the size the mount named. The size
+  is the framework's word and not yours; the deadline that closes a partial batch is yours, so put
+  it on your descriptor (`.max_wait(..)`) - the 10 ms default is sized for an in-process bus, and
+  the shipping broker crates settle between 10 and 50 ms. Put the capability on
+  `Subscribe::Subscriber` too, or a `&[T]` body on `#[subscriber("topic")]` fails to compile.
+  Declining it is still right where batching breaks a guarantee the transport carries (a ZeroMQ
+  `ROUTER` answers each peer at its own address, and a batch's replies share one context); say so
+  in your crate's docs.
 - Expose the per-delivery context as a `#[non_exhaustive]` typed struct plus `ContextField` key
   types (unit structs with an associated `Context` and owned `Value`), so handlers can take
   `Ctx<Partition>`-style parameters. No type-map, no heap on the delivery path. A position that is
   not `Copy` borrows on the read side (`Field::Value<'a>` is generic over the source's lifetime);
   only the `ContextField::Value` behind `Ctx<K>` has to be owned and `'static`, so that key clones.
-- Your prelude has four layers in this order: `pub use ruststream::prelude::*;`, the crate surface
-  your examples name, your publish policies aliased to the uniform mount-site names
+- Your prelude has three layers in this order: `pub use ruststream::prelude::*;`, the crate surface
+  a service names (the broker, its subscription source, its `Config`, its error, the `ContextField`
+  keys a body reads), and your publish policies aliased to the uniform mount-site names
   (`NatsPublish as Publish`, `KafkaTransactionalPublish as TransactionalPublish`,
-  `LapinRequest as Request`), and the capability manifest (the core capability traits you actually
-  implement). A handler body imports only the core prelude and bounds a slot with the broker
-  capability trait (`Out<impl Publisher>`, `Out<impl TransactionalPublisher>`,
-  `Out<impl OwnedTransactions>`, `Out<impl RequestReply>`); a routes file imports yours. The core
-  exports no trait under the policy names, so the aliases collide with nothing - but your prelude
-  must never shadow a core name with anything of yours, because an explicit re-export beats the
-  core glob silently and the error lands in the service's file. Pin both halves behind your own
-  glob: `fn _p<T: Publisher>() {}` and `let _: Publish = Publish::default();`.
-- `ack` consumes `self`; for transports without acks return `AckError::Unsupported`. A handle that
-  carries an argument for a run of messages (a tenant, a partition hint, a delivery option your
-  broker expresses as a header) returns it from `base_headers` rather than writing it inside
-  `publish`; the builder writes the call site's headers over that base key by key. Errors and logs
-  are self-explanatory: name the subscription and the type involved, not just the raw error.
+  `LapinRequest as Request`), with the consumer-side capability traits you implement added next to
+  them as a manifest. A handler body imports only the core prelude and bounds a slot with the
+  broker capability trait (`Out<impl Publisher>`, `Out<impl TransactionalPublisher>`,
+  `Out<impl OwnedTransactions>`, `Out<impl RequestReply>`); a routes file imports yours. The one
+  exception is a body adjusting a per-message setting: it imports your prelude for the step and
+  names your options type in the bound, and its signature then says which broker it is tied to.
+  The core exports no trait under the policy names, so the aliases collide with nothing - but your
+  prelude must never shadow a core name with anything of yours, because an explicit re-export beats
+  the core glob silently and the error lands in the service's file. Leave out a trait whose method
+  collides with a defaulted core one (`Partitioned::partition_key` against
+  `IncomingMessage::partition_key`), and leave `BatchSubscriber` out of the manifest entirely: the
+  framework calls it and no body ever writes it as a bound. Pin both halves behind your own glob:
+  `fn _p<T: Publisher>() {}` and `let _: Publish = Publish::default();`.
+- `ack` consumes `self`; for transports without acks return `AckError::Unsupported`, at every
+  settling site. That answer is what lets the runtime tell a transport that honoured a delay from
+  one that cannot hold a message back, and the conformance suite passes on it. A handle that
+  carries a constant for a run of messages (a tenant, a producer name, a schema id) returns it from
+  `base_headers` rather than writing it inside `publish`; the builder writes the call site's
+  headers over that base key by key. A delivery setting is not one of those - it belongs to the
+  message, as a field of `Options`. Errors and logs are self-explanatory: name the subscription and
+  the type involved, not just the raw error.
+- Ship a `cargo generate` template per transport or topology (`templates/nats`, `templates/nats-js`)
+  and render plus `cargo check` it in your own CI, so an API change breaks your build rather than a
+  user's first one. Template blocks are additive only, and the package manifest is
+  `Cargo.toml.liquid`: cargo parses every `Cargo.toml` in a git source and a placeholder in the
+  package name breaks every dependent.
 - Integrations that need async I/O around encode/decode (schema registries, wire-format envelopes)
   are middleware on the async edges: transcode on the subscription's delivery path for consuming,
   and a core `PublishLayer` (`RustStream::publish_layer`) for publishing. Never a custom sync
@@ -60,11 +102,18 @@ alwaysApply: false
   one wrapper method per option. Auth (TLS, SASL) rides that passthrough; surface only the cargo
   features that build hermetically everywhere, and let users enable exotic client features by
   depending on the client crate directly (cargo features are additive).
-- Testing: implement `TestableBroker` for the broker's in-process transport and register it with
-  `register_testable_broker!` (under a `testing` feature), so `TestApp` and `run_suite` can drive
-  it. Verify with the conformance harness; run `lifecycle` against a real server (env-gated). No
-  simulation of broker-specific semantics (durable cursors, offsets, DLX) - those are tested only
-  against a server.
+- Testing: implement `TestableBroker` on the in-process transport's **connected** form and register
+  it with `register_testable_broker!` (under a `testing` feature), so `TestApp` and `run_suite` can
+  drive it. Run the contract suites against the stand-in as well as against a real server; run
+  `lifecycle` first, because it asks what a stand-in is never otherwise asked - does a publisher
+  made before the shutdown error afterwards. The stand-in answers acks the way the real transport
+  answers them, including `AckError::Unsupported`: one that claims a settlement its transport never
+  performs is how a handler's retry passes in a test and loses the message in production. Reproduce
+  what the client does (competing consumers, group distribution, correlation, buffering until
+  commit); do not fake what the broker does (fencing, cluster atomicity, broker-held timeouts,
+  durable cursors, offsets, DLX), and give every gap a comment naming the assertion it makes
+  unsound plus a test pinning it. Mount it with the production wiring: your own sources and
+  policies have to work against it unchanged.
 
 ## The lifecycle ladder
 
@@ -118,17 +167,30 @@ once, at startup.
 ```rust
 use ruststream::{DefaultPublish, OutgoingMessage, PairError, PublishPolicy, Publisher};
 
-/// The publish policy: builder options only, no connection, no publish surface.
+/// The broker's per-message settings: every field optional, so a call carries only what it
+/// adjusted. Derive `Debug` and `PartialEq` too, and a test asserts `with_options(&MyOptions { .. })`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MyOptions {
+    priority: Option<u8>,
+}
+
+/// The publish policy: builder options only, no connection, no publish surface. This is where the
+/// per-message defaults are configured, at the mount site.
 #[derive(Debug, Clone, Default)]
 pub struct MyPublish {
     exchange: Option<String>,
+    priority: u8,
 }
 
 impl PublishPolicy<ConnectedMyBroker> for MyPublish {
     type Live = MyPublisher;
 
     async fn pair(self, connected: &ConnectedMyBroker) -> Result<MyPublisher, PairError> {
-        Ok(MyPublisher { client: connected.client.clone(), exchange: self.exchange })
+        Ok(MyPublisher {
+            client: connected.client.clone(),
+            exchange: self.exchange,
+            default_priority: self.priority,
+        })
     }
 }
 
@@ -139,12 +201,60 @@ impl DefaultPublish for ConnectedMyBroker {
 
 impl Publisher for MyPublisher {
     type Error = MyError;
+    type Options = MyOptions;
 
-    async fn publish(&self, msg: OutgoingMessage<'_>) -> Result<(), MyError> {
-        self.client.send(msg.name(), msg.payload()).await.map_err(MyError::publish)
+    /// Resolving the call's fields over the policy's is the first thing publish does.
+    async fn publish(
+        &self,
+        msg: OutgoingMessage<'_>,
+        options: Option<&MyOptions>,
+    ) -> Result<(), MyError> {
+        let priority = options
+            .and_then(|options| options.priority)
+            .unwrap_or(self.default_priority);
+        self.client
+            .send(msg.name(), msg.payload(), priority)
+            .await
+            .map_err(MyError::publish)
     }
 }
 ```
+
+## Per-message settings on the publish builder
+
+A call site adjusts one field through a step you add to the publish builder. Nothing wraps the
+publisher, so the publish still goes through the mount site's own entry, with the codec and the
+transforms that entry named. The bound on the sink's options type is what keeps your steps off a
+builder over another broker's publisher. Ship the trait from your prelude, next to the policy
+aliases.
+
+```rust
+use ruststream::runtime::{PublishBuilder, PublishSink};
+
+pub trait MyPublishSteps {
+    /// Sends this one message at `priority`, whatever the mount site's default is.
+    #[must_use]
+    fn priority(self, priority: u8) -> Self;
+}
+
+impl<Sink, Body, Enc, Hdrs, Dest> MyPublishSteps for PublishBuilder<Sink, Body, Enc, Hdrs, Dest>
+where
+    Sink: PublishSink<Options = MyOptions>,
+{
+    fn priority(mut self, priority: u8) -> Self {
+        self.options_mut()
+            .get_or_insert_with(MyOptions::default)
+            .priority = Some(priority);
+        self
+    }
+}
+```
+
+A step is the only shape a per-message setting takes. Do not put the send in a trait of your own: a
+publish that leaves through a value of yours is one the test harness no longer attributes to the
+slot, and a setting like an ordering key is exactly what a test wants to assert on. Do not carry
+one as a header either - it is a protocol field, not bytes your `publish` parses back inside one
+process.
 
 ## Subscription source
 
@@ -152,12 +262,18 @@ impl Publisher for MyPublisher {
 options and resolves against the connected form at startup.
 
 ```rust
-use ruststream::{FromName, Subscribe, SubscriptionSource};
+use ruststream::{FromName, RedeliveryAddress, Subscribe, SubscriptionSource};
 
 impl Subscribe for ConnectedMyBroker {
     type Subscriber = MySubscriber;
     async fn subscribe(&self, name: &str) -> Result<MySubscriber, MyError> {
         self.open(MySubscribeOptions::new(name)).await
+    }
+
+    /// Where a publisher reaches this subscription again. Defaulted to `None`; answer with the
+    /// name itself wherever a publish under a subscribe name lands in that subscription.
+    fn redelivery_address(&self, name: &str) -> Option<RedeliveryAddress> {
+        Some(RedeliveryAddress::new(name.to_owned()))
     }
 }
 
@@ -168,6 +284,15 @@ impl SubscriptionSource<ConnectedMyBroker> for MySubscribeOptions {
     }
     async fn subscribe(self, connected: &ConnectedMyBroker) -> Result<MySubscriber, MyError> {
         connected.open(self).await
+    }
+
+    /// The same answer for the descriptor, asking the broker where only the live connection
+    /// knows (a Pub/Sub subscription's topic). The runtime asks once, at startup.
+    async fn redelivery_address(
+        &self,
+        _connected: &ConnectedMyBroker,
+    ) -> Result<Option<RedeliveryAddress>, MyError> {
+        Ok(Some(RedeliveryAddress::new(self.subject.clone())))
     }
 }
 
@@ -204,6 +329,13 @@ impl<Def: Declared, W, F, P, Pg, Codec> MySubscriber
 }
 ```
 
+One core setting changes the source type rather than a state slot: `start_at(..)` wraps your
+descriptor in `StartAt<MySubscribeOptions, Position>`, and your methods fall out of scope on every
+subscription that named a start position. Cover it with a second impl over the wrapped source,
+where the position slot reads `Fixed` by construction, so the two never overlap;
+`StartAt::map_inner` takes the descriptor out and hands the position back untouched, so each method
+stays one line.
+
 The publish side mirrors it. A mount site names a publish policy with `.out(marker, policy)` -
 `Reply` for what a `publish("dest")` handler returns, an `Out` slot's marker for a slot - and
 `MapPublisher` is the hook over the policy that position carries. Bind the extension trait to the
@@ -211,19 +343,47 @@ policy, not to the chain, so one impl covers the reply, every slot, a router and
 
 ```rust
 pub trait MyPublishSettings {
-    fn stream(self, name: impl Into<String>) -> Self;
+    fn ack_timeout(self, timeout: Duration) -> Self;
 }
 
 impl<T: MapPublisher<Policy = MyPublish>> MyPublishSettings for T {
-    fn stream(self, name: impl Into<String>) -> Self {
-        self.map_publisher(|policy| policy.stream(name))
+    fn ack_timeout(self, timeout: Duration) -> Self {
+        self.map_publisher(|policy| policy.ack_timeout(timeout))
     }
 }
 ```
 
+A policy setting is a property of the handle, never the destination: where a message goes is the
+message type's declaration or the call site's `.to(..)`, so a policy method that names a subject, a
+topic or a stream puts a second source of truth next to the one the document reports.
+
 `map_publisher` replaces the policy with one of the same type, which is what a publisher's own
 settings produce; a different policy type is a different publish mode and belongs in the
-`.out(marker, policy)` call itself.
+`.out(marker, policy)` call itself, where an already-configured value can be passed directly
+(`.out(Reply, Publish::default().ack_timeout(Duration::from_secs(5)))`).
+
+## Extending the `Out` slot vocabulary
+
+A body's `Out<impl X, Marker>` accepts any `X` the live value behind the slot implements, so a live
+value that is more than a publisher (a per-partition producer cache, a shard router) carries a
+capability trait of your own. What the body holds is not that value but the arena entry,
+`Slot<M, W, E, Pipe, Body>`, a transparent window onto it: autoderef carries a method call through,
+a trait bound does not. Graft one blanket impl next to your trait and helpers generic over the
+capability take the entry as it is:
+
+```rust
+impl<M, W: Lanes, E, Pipe, Body> Lanes for Slot<M, W, E, Pipe, Body> {
+    fn lane(&self, shard: u64) -> (&MyPublisher, &'static str) {
+        (**self).lane(shard)
+    }
+}
+```
+
+A capability that hands out a publisher and lets the body send through it publishes outside the
+slot view, so the harness attributes nothing to the slot and a test asserts on the broker's publish
+log instead. That is the price of handing out the inner publisher. A capability that only sets one
+per-message setting and ends in a single publish is not a capability trait at all - it is a field
+of `Publisher::Options` and a step on the builder.
 
 ## Typed context and `Ctx` keys
 
@@ -263,13 +423,16 @@ impl at all - `()` is the default.
 
 ## Conformance
 
-Routing runs against the broker's in-process transport (its **connected** form is the
-`TestableBroker`); the full lifecycle ladder runs against a real server behind an env gate.
+The suites are written against the traits, so they run unchanged against the in-process transport
+(its **connected** form is the `TestableBroker`) and against a real server behind an env gate. Run
+both: the stand-in is what a service's whole test suite rides on, and the server is what the
+release runs against. `run_suite` covers the routing contract - ordering, ack and nack, headers,
+the publish log; the `capabilities::*` suites are yours to call, one per capability you implement,
+and they are not part of `run_suite`.
 
 ```rust
 use ruststream::conformance::harness;
 
-// routing contract: ordering, ack/nack, headers, ... (testing feature)
 // sync Fn() -> B, where B: Broker and B::Connected: TestableBroker + Subscribe
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn routing_conformance() {
@@ -277,7 +440,9 @@ async fn routing_conformance() {
 }
 
 // the ladder: sync new -> connect(self) -> subscribe via SubscriptionSource -> publish ->
-// receive -> ack -> shutdown(self), then a publisher made before shutdown must error after it
+// receive -> ack (accepting AckError::Unsupported) -> shutdown(self), then a publisher made
+// before shutdown must error after it, and a publish to the address the subscription reported
+// must arrive at that subscription
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn lifecycle_conformance() {
     let Ok(url) = std::env::var("MY_BROKER_TEST_URL") else { return };
@@ -293,4 +458,5 @@ async fn lifecycle_conformance() {
 ```
 
 When changing anything on the broker contract, run the conformance suite against the real broker
-before releasing - an in-process pass is not enough.
+before releasing - an in-process pass is not enough. Every broker repo has a `just test-brokers`
+recipe that starts its docker-compose stand and runs the live suites.

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -12,7 +12,12 @@ alwaysApply: false
 - Library code uses `thiserror` (`anyhow` is bins/examples only); public error enums are
   `#[non_exhaustive]`. Never panic on user/network input - return `Result`.
 - Native `async fn in trait`; `+ Send` at the call site, not the trait. Destructors never panic or
-  block. Features are strictly additive, never mutually exclusive.
+  block. Features are strictly additive, never mutually exclusive: `json` (default), `msgpack`,
+  `cbor`, `memory`, `macros`, `asyncapi`, `metrics`, `logging`, `otel`, `conformance`, `cli`,
+  `testing`.
+- Settlement is honest: every site that settles a delivery accepts `AckError::Unsupported`. A
+  transport that cannot acknowledge is a supported broker, not a failure, and the conformance
+  suite passes on it - the redelivery scenario ends where the requeue reports itself unsupported.
 - Compile-time rejection is the default. The ladder for catching a MISUSE (not data - decode errors
   and broker faults are runtime by nature) is compile error > build-time assert > startup error >
   hot-path check, and the last rung is not an option. Prefer an enum over sibling `bool`/`Option`
@@ -22,9 +27,11 @@ alwaysApply: false
   external (the language, the domain); mark those with a "why" comment. Put
   `#[diagnostic::on_unimplemented]` guidance on bounds users will hit.
 - Gates: `just check` (`cargo fmt --check`, `clippy --all-targets --all-features -- -D warnings`,
-  `cargo check` all-features and `--no-default-features`) + `just test`. SemVer pre-1.0: minor =
-  breaking, patch = additive; `ruststream` and `ruststream-macros` versions are lockstep via
-  `[workspace.package].version`.
+  `cargo check` all-features, `--no-default-features` and the codec-free leg
+  `--no-default-features --features testing,memory,macros`, then `cargo doc` under
+  `RUSTDOCFLAGS="-D warnings"`), `just test` (all-features, the reduced-feature legs, doctests on
+  both feature edges), `just ci` for both. SemVer pre-1.0: minor = breaking, patch = additive;
+  `ruststream` and `ruststream-macros` versions are lockstep via `[workspace.package].version`.
 - English only, no emoji, no em-dashes. One logical unit per commit; no `Co-Authored-By`. Do not
   publish/tag/release - prepare branches/PRs; the maintainer releases.
 
@@ -48,7 +55,10 @@ pub enum PublishError {
 
 ## Trait with async methods
 
-Use RPITIT; keep `+ Send` on the returned future. Do not force object-safety in core.
+Use RPITIT; keep `+ Send` on the returned future. Do not force object-safety in core. A broker's
+per-message settings are an associated type of the publisher, so a setting never rides a header:
+`Options` is `()` for a broker that has none, and `None` on the paths with no call site to adjust
+them (a reply, a deferred retry).
 
 ```rust
 use std::future::Future;
@@ -56,7 +66,10 @@ use std::future::Future;
 pub trait Publisher: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Publishes `msg`.
+    /// The broker's per-message settings; every field optional.
+    type Options: Clone + Send + Sync + 'static;
+
+    /// Publishes `msg` with the settings the call site adjusted.
     ///
     /// # Errors
     ///
@@ -64,7 +77,13 @@ pub trait Publisher: Send + Sync {
     fn publish(
         &self,
         msg: OutgoingMessage<'_>,
+        options: Option<&Self::Options>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Headers this handle contributes under every message it sends.
+    fn base_headers(&self) -> Option<&HeaderMap> {
+        None
+    }
 }
 ```
 
@@ -107,9 +126,17 @@ pub type DefaultCodec = MsgpackCodec;
 
 ## Conformance self-test
 
-The reference `MemoryBroker` runs the harness in `tests/`.
+The reference `MemoryBroker` runs the harness in `tests/conformance_self.rs`. The routing suite
+reads the publish log back, so it takes the retaining form; the lifecycle ladder takes the plain
+one. The closures stay closures: their bounds are higher-ranked, so a bare method path would bind
+one concrete lifetime and fail to type-check.
 
 ```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_broker_passes_conformance_suite() {
+    harness::run_suite(|| MemoryBroker::retaining(Retention::Messages(nonzero!(64)))).await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn memory_broker_passes_lifecycle() {
     harness::lifecycle(

--- a/.cursor/rules/usage.mdc
+++ b/.cursor/rules/usage.mdc
@@ -9,7 +9,8 @@ alwaysApply: false
   `Headers`, `Out`), the mount-site settings, the publish builder (`PublishExt`), the publisher
   capability traits a slot bound names (`Publisher`, `TransactionalPublisher`, `OwnedTransactions`,
   `RequestReply`), and the attribute macros and derives. A body never names a publish policy, so it
-  never knows which broker runs it.
+  never knows which broker runs it. The one exception is a body that adjusts a per-message broker
+  setting: it imports that broker's prelude for the step and names its options type in the bound.
 - A mount site imports the BROKER's glob (`use ruststream_nats::prelude::*;`,
   `use ruststream::memory::prelude::*;`): it re-exports the core prelude, the broker, its
   subscription descriptor and its context keys, plus its publish policies under the uniform names
@@ -19,23 +20,34 @@ alwaysApply: false
   items they share resolve to the same types.
 - Only what a given service actually reaches for stays an explicit import: codecs
   (`ruststream::codec`) and the optional feature modules (`ruststream::testing`, `asyncapi`,
-  `metrics`, `logging`, `otel`). `RouterDef`, `DefaultSlot`, `FailurePolicies` / `FailurePolicy`,
-  `Workers`, `Unnamed`, `nonzero!` and the manual path's `Handle` / `subscriber` pair are all in
-  the prelude.
+  `metrics`, `logging`, `otel`). `Router` / `RouterDef`, `Reply`, `DefaultSlot`, `OutSlot`,
+  `FailurePolicies` / `FailurePolicy`, `Workers`, `Unnamed`, `nonzero!`, the transform vocabulary
+  (`PublishTransform`, `ForReply` / `ForSlot`, `Reads` / `Names`) and the manual path's `Handle` /
+  `subscriber` pair are all in the prelude.
 - A handler is an `async fn` annotated with `#[subscriber("subject")]`. Its first parameter is the
   payload, and its type alone picks the form: `&T` is one message and `&[T]` a batch, while the
   lane is the type's own business - `T: serde::Deserialize` decodes with the codec, a
   `#[derive(Deserialized)]` type builds itself from the raw bytes (`&Frame<'_>`, batch
   `&[Frame<'_>]`). No clause names any of this. Further parameters are extractors:
   `State<T>` injects a component of the application state, `Ctx<K>` one broker context field,
-  `Headers<T>` the delivery headers parsed into a typed contract, `Out<impl Publisher, ..>` a live
-  publisher. An explicit `ctx: &mut Context` parameter is optional and last; omit it unless you
+  `Headers<T>` the delivery headers parsed into a typed contract, and any type implementing
+  `FromContext` is one you wrote yourself (an auth guard, a request-scoped lookup); an extractor
+  that rejects settles the delivery and the body never runs. `Out<impl Publisher, ..>` is not an
+  extractor but an injection: a live publisher the mount site's policy built. An explicit
+  `ctx: &mut Context` parameter is optional and comes right after the payload; omit it unless you
   use it.
 - The return type drives acknowledgement: `HandlerOutcome`, `()` (always acks), `Result<_, E>` (an
-  `Err` nacks), `Result<HandlerOutcome, E>`, or `Vec<HandlerOutcome>` on a batch to settle entry by
-  entry. For a reply handler, add a `publish("subject")` clause and return the reply value, or
-  `Result<Reply, HandlerOutcome>` for explicit ack control (`Vec<Reply>` and
+  `Err` drops - a nack with no requeue), `Result<HandlerOutcome, E>`, or `Vec<HandlerOutcome>` on a
+  batch to settle entry by entry. For a reply handler, add a `publish` clause and return the reply
+  value, or `Result<Reply, HandlerOutcome>` for explicit ack control (`Vec<Reply>` and
   `Result<Vec<Reply>, HandlerOutcome>` are the batch counterparts).
+- Where a reply goes is a property of the reply type, not of the mount site. Every reply type
+  derives `Outgoing`, and a type without it is a compile error at the handler naming the derive.
+  `#[outgoing(name = "dest")]` on the type is the destination and the clause stays bare
+  (`publish`); a derive naming nothing takes the clause's name (`publish("dest")`). A name template
+  does not resolve on the reply path - nothing binds its placeholders there. The generated AsyncAPI
+  document reports the resolved destination, so a declaration cannot document one channel and
+  publish to another.
 - Build the service with `#[ruststream::app]` on a synchronous `fn app() -> RustStream` (or
   `impl App` when layers/state change the type). Do not write your own `main` or `#[tokio::main]`.
 - Application state is built once in `on_startup` (async closures: `async move |()| ...`) and
@@ -157,9 +169,8 @@ value carries a builder for the declarative settings, applied before `include` t
 ```rust
 use std::time::Duration;
 
-use ruststream::nonzero;
-use ruststream::prelude::*;
-use ruststream::runtime::{FailurePolicies, FailurePolicy};
+// FailurePolicies, FailurePolicy and nonzero! ride the prelude; no second import
+use ruststream::memory::prelude::*;
 
 #[subscriber]
 async fn bill(order: &Order) -> HandlerOutcome {
@@ -194,21 +205,44 @@ b.include(audit.name("orders").start_at(MemoryPosition::start()));
 
 `workers(n)`, `on_failure(..)` and `start_at(..)` can also be written as attribute clauses
 (`#[subscriber("orders", workers(16, by_key))]`, `#[subscriber("orders", on_failure(decode = retry))]`,
-`#[subscriber("audit", start_at(MemoryPosition::start()))]`). `start_at` forces the position on
+`#[subscriber("audit", start_at(MemoryPosition::start()))]`); those four (`publish` is the fourth)
+are the only clauses, and `batch(n)` is mount-site only. `start_at` forces the position on
 every startup and takes a value of the broker's own position type; without it the subscription
 opens at the broker's default. A conditional default (apply only when no stored cursor exists for
 the group) belongs on the broker's own subscription descriptor.
 
+Seeking needs a log to seek in. `MemoryBroker::new()` keeps nothing, so the two forms are different
+types: `MemoryBroker::retaining(Retention::Messages(nonzero!(64)))` is the one whose subscriptions
+are `Seekable`, and a `start_at(..)` or a `SeekHandle` read only compiles against it. A handler
+repositions its own subscription through the broker's context keys
+(`Ctx(seeker): Ctx<SeekHandle>`, then `seeker.seek(MemoryPosition::sequence(3))`); a position the
+retention bound already evicted reports `MemoryError::PositionEvicted`.
+
 ## Replying (request/response)
 
-Return the reply value and add `publish("subject")`. The reply publisher is the broker's default
-policy unless the mount names one with `.out(Reply, ..)`.
+Return the reply value and write `publish` on the subscriber. The reply type derives `Outgoing`,
+and its declaration decides where the answer goes: a type fixing its own name is published there
+and the clause names nothing, a type naming nothing takes the clause's name. The reply publisher is
+the broker's default policy unless the mount names one with `.out(Reply, ..)`.
 
 ```rust
 use ruststream::memory::prelude::*;
 use serde::Serialize;
 
-#[derive(Serialize)]
+// the destination on the type: the clause stays bare
+#[derive(Debug, Serialize, Outgoing)]
+#[outgoing(name = "receipts")]
+struct Receipt {
+    id: u64,
+}
+
+#[subscriber("receipt-requests", publish)]
+async fn issue_receipt(order: &Order) -> Receipt {
+    Receipt { id: order.id }
+}
+
+// the destination left open: the mount site says
+#[derive(Debug, Serialize, Outgoing)]
 struct Confirmation {
     id: u64,
     accepted: bool,
@@ -220,6 +254,7 @@ async fn confirm(order: &Order) -> Confirmation {
 }
 
 // in with_broker(broker, |b| { ... }):
+b.include(issue_receipt);                              // the type carries the destination
 b.include(confirm);                                    // broker's default publish policy
 b.include(confirm).out(Reply, Publish);                // an explicit one
 b.include(confirm).out(Reply, Publish).codec(CborCodec).transform(Envelope);  // the whole wiring
@@ -236,8 +271,9 @@ Return `Result<Reply, HandlerOutcome>` to control acknowledgement: `Ok(reply)` p
 `Result` out in the signature (a type alias is treated as a plain reply type). A failed reply
 publish nacks the incoming message with `requeue = true`.
 
-Note the `publish(..)` clause takes a string literal; runtime-computed destinations are not
-supported there.
+The `publish(..)` clause takes a string literal, and a name template does not resolve here.
+Answering somewhere else per delivery (a direct `reply-to`, a `ROUTER` peer identity) is a
+transform; see [naming a destination from a transform](#naming-a-destination-from-a-transform).
 
 ## Raw payloads
 
@@ -280,7 +316,7 @@ both compile. A `Vec<u8>` reply is not a byte reply - it encodes like any `Seria
 `Serialized` batch reply does not exist.
 
 ```rust
-#[derive(Serialized)]
+#[derive(Outgoing, Serialized)]
 struct Export(Vec<u8>);
 
 #[subscriber("relay-in", publish("relay-out"))]
@@ -293,8 +329,26 @@ A `Serialized` reply names its publish policy at the include site the same way a
 (`b.include(relay).out(Reply, Publish)`, or nothing for the broker's default); what it does not take
 is the wiring steps after it, since its bytes leave with no codec and no transform stack.
 
-For a custom serialization format you want *typed* handlers for, implement `Codec` instead and
-keep the typed path.
+A binary protocol (Protobuf, Cap'n Proto, FlatBuffers) is not a codec: the generated message *is*
+its encoding, so it rides the same lanes and the model type stays visible at the mount site, in a
+slot's dictionary and in the document. Three derives and one attribute put a whole schema there,
+and a generator writes them for you (`prost_build`'s `message_attribute`):
+
+```rust
+#[derive(Clone, PartialEq, prost::Message, Outgoing, Serialized, Deserialized)]
+#[outgoing(name = "orders")]
+#[wire(prost)]
+struct Order {
+    #[prost(uint64, tag = "1")]
+    id: u64,
+}
+```
+
+`#[wire(prost)]` is shorthand for one generator's pair of functions; the general form names them,
+`#[wire(encode = <path>, decode = <path>)]`, where `encode` is a `fn(&Self, &mut BytesMut)` and
+`decode` a `fn(&[u8]) -> Result<Self, E>`. Neither lane resolves a codec, so such a service
+compiles with no codec feature at all. For a custom serialization format you want *typed* handlers
+for, implement `Codec` instead and keep the typed path.
 
 ## Publishing from a handler (`Out`)
 
@@ -354,26 +408,25 @@ async fn route(
 
 b.include(route)
     .out(Audit, Publish)
-    .transform(OutboxEnvelope)  // an OutTransform on the slot the .out(..) before it bound
+    .transform(OutboxEnvelope)  // rides the slot the .out(..) before it bound
     .out(Orders, Publish)
     .build();
 ```
 
-`.transform(..)` composes an `OutTransform` (`apply(&mut Outgoing<'_>)`, no publish context: the
-body issues a slot publish itself) onto the slot named right before it, and onto that one only.
-Before any `.out(..)` the step does not exist. On a registration that also has a reply,
-`.transform(..)` after `.out(Reply, ..)` grows the reply's `PublishTransform` stack and after
-`.out(marker, ..)` the slot's.
+`.transform(..)` composes a `PublishTransform` onto the position named right before it, and onto
+that one only; before any `.out(..)` the step has no position to ride. The step repeats, and the
+transforms run in the order the chain writes them. On a registration that also replies,
+`.transform(..)` after `.out(Reply, ..)` grows the reply's stack and after `.out(marker, ..)` the
+slot's.
 
 The capability in the bound can be refined - `Out<impl OwnedTransactions, Ledger>` compiles only
 against a policy whose live publisher supports owned transactions, checked at the include site.
 The bound names a broker capability trait (`Publisher`, `TransactionalPublisher`,
 `OwnedTransactions`, `RequestReply`, or one a broker crate defines), never a broker type; on the
-manual path the same bound sits on the entry's wired value, `where W: OwnedTransactions, E: Codec
-+ Send + Sync, Pipe: OutPipeline` (the third parameter is the slot's publish path, left generic so
-one body mounts under any transform or app-wide layer). Under it the entry offers that
-capability's typed form - `message(..)`, `begin()`, `transaction()` - over the include site's
-codec and the marker's list.
+manual path the same bound sits on the entry's wired value,
+`where L: OutEntry<Ledger, Wire: OwnedTransactions>`. Under it the entry offers that capability's
+typed form - `message(..)`, `begin()`, `transaction()` - over the include site's codec and the
+marker's list.
 
 ### Narrowing one path to a set of types
 
@@ -446,7 +499,115 @@ out.message(&Export(bytes)).to("egress").publish().await?;
 A message declaring `headers = Meta` publishes only with `.with_headers(&meta)` - forgetting it,
 or passing another type, does not compile. `with_headers` also takes an already-built `HeaderMap`
 by value. A `Serialize` type owned by another crate cannot derive `Outgoing`: wrap it in a newtype
-that does.
+that does. The publisher may add a base of its own (`base_headers`, a tenant or a producer name);
+the builder lays that base down first and writes the call site's headers over it, key by key.
+
+## Publish transforms
+
+A published message passes two levels. A `PublishTransform` sits on one position, chained with
+`.transform(..)` after the `.out(..)` that named it; a `PublishLayer` sits on the application,
+added with `.publish_layer(..)` before `with_broker`, and wraps every publish a handler makes,
+replies and slots alike. A position's transforms run first, then the app-wide layers, then the
+send. A router's slots run their own transforms and not the app-wide chain, because its routes are
+typed before the app that mounts them.
+
+Every impl of `PublishTransform<K>` declares two things. What it **reads** is the position's kind:
+`ForReply<C>` hands it `PublishContext<'_, C>` (the delivery being answered - its channel, the
+incoming headers, the broker's typed per-delivery fields), `ForSlot` hands it `SlotContext<'_>`
+(the slot's own name and nothing else, because the body issued that publish and has already read
+its own `Context`). A transform reading nothing writes one impl over every kind and mounts
+anywhere. What it **may do** is `type Destination`: `Reads` leaves the destination alone, `Names`
+sets it. Stable Rust has no associated-type default, so every impl writes the line; almost every
+one writes `Reads`.
+
+```rust
+use ruststream::runtime::{
+    ContextKind, ForReply, Names, Outgoing, PublishContext, PublishTransform, Reads,
+};
+
+/// Reads nothing, so one impl serves a reply and a slot alike.
+struct EnvelopeTransform;
+
+impl<K: ContextKind> PublishTransform<K> for EnvelopeTransform {
+    type Destination = Reads;
+
+    fn apply(&self, out: &mut Outgoing<'_>, _cx: &K::View<'_>) {
+        out.headers_mut().insert("x-envelope", b"1".to_vec());
+    }
+}
+```
+
+### Naming a destination from a transform
+
+Some answers have no destination to declare: an AMQP request carries the queue to answer on in its
+`reply-to` header, a ZeroMQ `ROUTER` addresses each answer to the peer that asked. A transform
+declaring `Destination = Names` sets the name per delivery, and it mounts with the ordinary
+`.transform(..)` step - there is no second verb.
+
+```rust
+struct ReplyTo;
+
+impl<C> PublishTransform<ForReply<C>> for ReplyTo {
+    type Destination = Names;
+
+    fn apply(&self, out: &mut Outgoing<'_>, cx: &PublishContext<'_, C>) {
+        if let Some(to) = cx.headers().get("reply-to")
+            && let Ok(to) = std::str::from_utf8(to)
+        {
+            out.set_name(to.to_owned());
+        }
+    }
+}
+
+// `Response` leaves its destination open, so this position offers the naming right;
+// "answers" is the declared fallback and what the document reports
+b.include(answer).out(Reply, Publish).transform(ReplyTo);
+```
+
+A position offers that right only where nothing declared the destination, and elsewhere the
+`.transform(..)` call does not compile, naming the type that already declared one. A reply type
+carrying `#[outgoing(name = ..)]` offers nothing, a batch's replies never do (they answer many
+deliveries at once), and a position offers it once. A slot offers it only when every type in its
+marker's `#[publishes(..)]` dictionary leaves its destination open, which means a marker with no
+dictionary - `DefaultSlot` included - never does. A slot that gave the right away offers plain
+sending only: a transaction and a request / reply round trip do not compile on it.
+
+## Broker settings per message
+
+A QoS, a priority, an ordering key, an expiration are the broker's own per-message settings, not
+headers. They reach a publish from two places. The publish policy carries the defaults, named at
+the mount site, and every message through that position is sent with them:
+
+```rust
+b.include(record).out(Ledger, Publish::default().qos(1)).build();
+b.include(acknowledge).out(Reply, Publish::default().qos(1));  // a reply has no call site
+```
+
+The call adjusts one setting for one message, through a step the broker adds to the publish
+builder. A setting no step names keeps the policy's default, and the rest of the publish is still
+the mount site's: the entry's codec, its transforms, the slot the test harness records it against.
+
+```rust
+// the body imports the broker's prelude for the step, and names its options type in the bound -
+// the one place a handler body imports more than the framework prelude
+use ruststream_rumqttc::prelude::*;
+
+#[subscriber("telemetry.in")]
+async fn record(
+    reading: &Reading,
+    Out(audit): Out<impl Publisher<Options = MqttOptions>, Telemetry>,
+) -> HandlerOutcome {
+    if audit.message(reading).to("telemetry.out").retain(true).publish().await.is_err() {
+        return HandlerOutcome::retry();
+    }
+    HandlerOutcome::ack()
+}
+```
+
+The steps are on the builder, so they work on every publish surface: an `Out` slot, a transaction
+opened on one, a bare publisher from the state or a startup hook. Which steps exist is the broker's
+documentation to answer. A setting never rides a header and never wraps the publisher (an adapter
+would lose the mount site's codec).
 
 ## State injection (dependency injection)
 
@@ -533,15 +694,11 @@ commit, or a publish after settling do not compile:
 ```rust
 use std::error::Error;
 
-use ruststream::TransactionalPublisher;
-use ruststream::codec::JsonCodec;
-use ruststream::runtime::Transactional;
+use ruststream::prelude::*;
 
 // The bound names the capability the seeding needs, not the broker's publisher; the same
 // capability unlocks `begin()` on an `Out` slot (`Out<impl TransactionalPublisher, Journal>`).
-async fn seed_events<P>(
-    seeder: Transactional<P, JsonCodec>,
-) -> Result<(), Box<dyn Error + Send + Sync>>
+async fn seed_events<P>(seeder: P) -> Result<(), Box<dyn Error + Send + Sync>>
 where
     P: TransactionalPublisher,
 {
@@ -553,8 +710,9 @@ where
 }
 ```
 
-The same policy-plus-wrapper choice applies wherever a publisher is attached, and the verb is the
-same on both: `.out(Reply, ..)` for a reply handler, `.out(marker, ..)` for a slot.
+A policy is named the same way wherever a publisher is attached, and the verb is one:
+`.out(Reply, ..)` for a reply handler, `.out(marker, ..)` for a slot, `after_startup(policy, hook)`
+for the first publish.
 
 ## Broker context fields (`Ctx<K>`)
 
@@ -592,15 +750,19 @@ async fn convert(chunk: &Chunk, Headers(meta): Headers<ChunkMeta>) -> HandlerOut
 
 ## Context (optional explicit parameter)
 
-When you need the raw delivery objects, take `ctx: &mut Context<'_, C, S>` as the last parameter
-(`C` = broker context type, `S` = application state):
+When you need the raw delivery objects, take `ctx: &mut Context<'_, C, S>` as the second parameter,
+right after the payload (`C` = broker context type, `S` = application state):
 
 - `ctx.name()` - the subject/channel the message arrived on.
 - `ctx.headers()` / `ctx.headers_mut()` - the working copy of the message headers (`HeaderMap`).
 - `ctx.state()` - the shared application state built by `on_startup`.
+- `ctx.context(KEY)` - one broker field by compile-time key, the `Ctx<K>` extractor's other half.
+- `ctx.set(KEY, value)` - a per-delivery scratch value, for middleware.
+- `ctx.after(outcome).then(fut)`, `ctx.after_ack(fut)`, `ctx.after_settle(fut)` - a post-settle
+  hook selected by how the delivery settles.
 
 There is no `ctx.get::<T>()` and no named-publisher registry; state is typed (`State<T>` /
-`ctx.state()`), and publishing goes through `publish(..)` replies or an `Out` parameter.
+`ctx.state()`), and publishing goes through a `publish` reply or an `Out` parameter.
 
 On a batch handler `C` is the broker's *subscription-scoped* context, not its per-delivery one:
 name it (`ctx: &mut Context<'_, MemoryBatchContext>`) to read what the whole subscription shares -
@@ -640,8 +802,7 @@ makes, replies and `Out` slots alike, except in a router (its routes are typed b
 that mounts them, so a router's slots carry their own `.transform(..)` steps only).
 
 ```rust
-use ruststream::memory::prelude::*;
-use ruststream::runtime::RouterDef; // the only router item outside the prelude
+use ruststream::memory::prelude::*; // Router and RouterDef ride the prelude
 
 fn orders() -> Router<MemoryBroker, impl RouterDef<MemoryBroker>> {
     Router::new().include(accept)
@@ -654,6 +815,10 @@ fn shipping() -> Router<MemoryBroker, impl RouterDef<MemoryBroker>> {
 // in with_broker(broker, |b| { ... }):
 b.include_router(orders().merge(shipping()));
 ```
+
+On a router every registration that carries an attachment (a reply publisher, an `Out` slot) ends
+with an explicit `.build()`: a chain without it never becomes a router, so it does not compile.
+With no `.out(Reply, ..)` named, `.build()` takes the broker's own default publish policy.
 
 ## Broker-specific subscriptions
 
@@ -706,7 +871,8 @@ use ruststream::testing::TestApp;
 
 let tb = TestApp::start(service()).await?;
 
-// the publish drives the handler to a standstill before returning
+// the publish drives the handler to a standstill before returning; in a single-broker app
+// `tb.message(..)` says the same without naming the broker
 tb.broker::<MemoryBroker>()
     .message(&Order { id: 42 })
     .to("orders")
@@ -723,6 +889,21 @@ tb.broker::<MemoryBroker>()
     .published::<Receipt>("receipts")
     .assert_called_once()
     .with(&Receipt { order_id: 42 });
+```
+
+`tb.out::<Marker>()` is the other view: exactly what left through one injected publisher, across
+every broker. It takes the same assertions as `published` (`assert_called_once`, `with_raw`,
+`messages`; chain `.decoded_as::<T>()` for the typed `with`), and it is the only place a test reads
+back the per-message broker settings a publish carried - `with_options(&expected)` compares them,
+`assert_options_default()` states that no step touched one. The broker's publish log has already
+resolved the settings into the protocol, so asking it for options panics.
+
+```rust
+// every field of an options type is optional, so the expectation is a struct literal
+tb.out::<Telemetry>()
+    .assert_called_once()
+    .with_options(&MqttOptions { retain: Some(true), ..MqttOptions::default() });
+tb.out::<Notes>().assert_called_once().assert_options_default();
 ```
 
 Broker crates ship their own in-process test broker under their `testing` feature; `TestApp` drives


### PR DESCRIPTION
# Description

The four Cursor rule files under `.cursor/rules/` date from the 0.7 surface of 2026-09-04 and missed everything since: the reply destination declared on the reply type (#311), publish transforms declaring what they read and whether they may name a destination (#324), per-message settings as typed options and their harness assertions (#327, #331), the redelivery address a broker reports (#321), the server description built from a URL (#318), the memory broker's retention forms (#319) and the settlement contract (#308). Each rule was checked section by section against the rewritten guides and the code; `OutTransform` is gone, the manual-path rule shows the one supported way (`Handle` plus `subscriber(..)`) instead of the internal definition traits, and every name the rules use was swept against the crate.

Found on the way: the rustdoc of the reply resolution and the `on_unimplemented` note of a declared reply still tell the user to drop a `.redirect(..)` step that does not exist (the chain uses `.transform(..)`); fixed separately.

Stacked on #330 (base `feat/publish-options`); retarget to `main` once it lands.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)