### PR TITLE
fix: stop telling the user to drop a redirect step that does not exist

### DIFF
--- a/src/runtime/handle/outs.rs
+++ b/src/runtime/handle/outs.rs
@@ -74,8 +74,8 @@
 //! entry's transparent `Deref`. Everything is monomorphized: the arena is built once at startup,
 //! and a delivery only ever passes a reference to it.
 //!
-//! A mount site that hands the slot's destination to a transform with `.redirect(..)` leaves the
-//! first row of that table and nothing else: the rows below it reach the broker without the slot's
+//! A mount site that hands the slot's destination to a transform (a `.transform(..)` step whose
+//! transform declares `Destination = Names`) leaves the first row of that table and nothing else: the rows below it reach the broker without the slot's
 //! publish path, so their messages would go where that transform never looked, and a body asking
 //! for one of them fails to mount.
 

--- a/src/runtime/handle/reply.rs
+++ b/src/runtime/handle/reply.rs
@@ -192,9 +192,10 @@ where
 /// commits.
 ///
 /// A definition names its reply type the moment it exists - the handler's return type does not
-/// depend on the policies a chain is still binding - so a step that has to know the reply, like
-/// `.redirect(..)`, reads it here. Implemented by `#[subscriber]` next to the definition and by
-/// the value path's sealed reply definition; you never name it.
+/// depend on the policies a chain is still binding - so a step that has to know the reply, like a
+/// `.transform(..)` mounting a transform that names the destination, reads it here. Implemented by
+/// `#[subscriber]` next to the definition and by the value path's sealed reply definition; you
+/// never name it.
 #[doc(hidden)]
 pub trait DeclaresReply {
     /// The reply type, as [`ReplyShape`] sees it.
@@ -215,17 +216,19 @@ impl<A, R, O, C, H, Doc, Dest> DeclaresReply
 /// A reply whose destination a mount chain may name per delivery.
 ///
 /// A reply type that declares its own channel (`#[outgoing(name = "..")]`) is published there, and
-/// the generated document says so; letting a redirect move it would put the two back out of step,
-/// which is the whole reason the destination lives on the type. So `.redirect(..)` applies to a
-/// reply type that leaves the destination open - the mount site's `publish("dest")` name is then
-/// the declared fallback, and the redirect names where each answer actually goes.
+/// the generated document says so; letting a transform move it would put the two back out of
+/// step, which is the whole reason the destination lives on the type. So a transform that
+/// declares `Destination = Names` mounts only on a reply type that leaves the destination open -
+/// the mount site's `publish("dest")` name is then the declared fallback, and the transform names
+/// where each answer actually goes.
 #[doc(hidden)]
 #[diagnostic::on_unimplemented(
-    message = "`{Self}` declares where it is published, so it cannot be redirected",
+    message = "`{Self}` declares where it is published, so a transform cannot name its destination",
     label = "this reply's destination is its type's own",
     note = "drop `#[outgoing(name = \"..\")]` from the reply type and name the fallback at the \
             mount site (`publish(\"dest\")` on the attribute, `.to(\"dest\")` on the chain), or \
-            publish the reply where its declaration says and drop the `.redirect(..)` step"
+            publish the reply where its declaration says and mount a transform that declares \
+            `Destination = Reads`"
 )]
 pub trait RedirectableReply {}
 

--- a/src/runtime/router/form_out.rs
+++ b/src/runtime/router/form_out.rs
@@ -90,13 +90,13 @@ slot_form! {
 // name the definition's `BindSlots` outputs so the bounds read flat instead of through
 // `<Def::Bound as ..>` projections.
 
-/// The pipeline one slot's `.transform(..)` steps lower onto, before its redirect (if any) takes
-/// the head of it.
+/// The pipeline one slot's `.transform(..)` steps lower onto, before its naming transform (if any)
+/// takes the head of it.
 type SlotPipeline<Layers, Pipe> = <Layers as LowerOutTransforms<Pipe>>::Out;
 
 /// The bound-source tuple element of one slot: the policy the runtime pairs (narrowed where the
-/// chain named a redirect), the codec the slot encodes with (its own when the chain named one,
-/// else the surface's) and the pipeline it publishes through.
+/// chain mounted a naming transform), the codec the slot encodes with (its own when the chain
+/// named one, else the surface's) and the pipeline it publishes through.
 macro_rules! slot_source {
     ($attach:ident, $layers:ident, $enc:ident, $surface:ty, $pipe:ty) => {
         (


### PR DESCRIPTION
# Description

The rustdoc of the reply resolution and the `on_unimplemented` note a declared reply raises still spoke of a `.redirect(..)` step. No such step exists: a transform that names the destination is mounted with the ordinary `.transform(..)` step and declares `Destination = Names`. The compile error therefore told the user to drop a step they could not have written. The rustdoc and the diagnostic now name the step and the declaration that exist. No snapshot under `tests/ui` exercises that note, so none changed.

Found while refreshing the Cursor rules (#333).

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code follows the project's style guidelines (`just check` passes: rustfmt, clippy, and
      `cargo check` with all features and with `--no-default-features`)
- [x] I have performed a self-review of my own code
- [x] I have made the necessary changes to the documentation (rustdoc and/or the docs site)
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
- [x] New and existing tests pass locally (`just test`)