### PR TITLE
chore: bump the version to 0.7.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "ruststream-macros"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/ruststream-macros"]
 exclude = ["templates"]
 
 [workspace.package]
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.4"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -481,7 +481,7 @@ tracing = "0.1.29"
 # Exact pin: the two crates release in lockstep and the proc-macro surface tracks the library
 # release for release (a loose range let a partial `cargo update` pair a new core with an old
 # macros crate and fail to compile). Bumped by the same edit as [workspace.package].version.
-ruststream-macros = { version = "=0.7.0-rc.3", path = "crates/ruststream-macros", optional = true }
+ruststream-macros = { version = "=0.7.0-rc.4", path = "crates/ruststream-macros", optional = true }
 # 0.3.22 is the real floor, not 0.3: `tracing-opentelemetry` 0.33 requires `^0.3.22`, so the
 # `otel` feature never resolved anything lower, and the declared bound claimed years of releases
 # that were never built against.


### PR DESCRIPTION
# Description

Bumps the workspace version to `0.7.0-rc.4` for the fourth release candidate of the 0.7 line, so
that the maintainer can cut the release once #339 (the retry position as an ordinary out slot with
`out_reply` / `out_retry`, transforms that set a broker's per-message options, the broker-author
documentation fixes) is merged. Both crates move together, as the lockstep rule requires; nothing
else changes.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (clippy runs with `-D warnings`)
